### PR TITLE
Added two examles, changing the API to be friendlier along the way

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -28,11 +28,11 @@ type responsePromise struct {
 
 // NewBroker creates and returns a Broker targetting the given host:port address.
 // This does not attempt to actually connect, you have to call Connect() for that.
-func NewBroker(host string, port int32) *Broker {
+func NewBroker(host string, port int) *Broker {
 	b := new(Broker)
 	b.id = -1 // don't know it yet
 	b.host = host
-	b.port = port
+	b.port = int32(port)
 	return b
 }
 

--- a/client.go
+++ b/client.go
@@ -20,7 +20,7 @@ type Client struct {
 // NewClient creates a new Client with the given client ID. It connects to the broker at the given
 // host:port address, and uses that broker to automatically fetch metadata on the rest of the kafka cluster.
 // If metadata cannot be retrieved (even if the connection otherwise succeeds) then the client is not created.
-func NewClient(id string, host string, port int32) (client *Client, err error) {
+func NewClient(id string, host string, port int) (client *Client, err error) {
 	tmp := NewBroker(host, port)
 	err = tmp.Connect()
 	if err != nil {
@@ -195,7 +195,7 @@ func (client *Client) cachedPartitions(topic string) []int32 {
 	}
 
 	ret := make([]int32, 0, len(partitions))
-	for id, _ := range partitions {
+	for id := range partitions {
 		ret = append(ret, id)
 	}
 
@@ -265,7 +265,7 @@ func (client *Client) update(data *MetadataResponse) ([]string, error) {
 	}
 
 	ret := make([]string, 0, len(toRetry))
-	for topic, _ := range toRetry {
+	for topic := range toRetry {
 		ret = append(ret, topic)
 	}
 	return ret, nil

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -77,11 +77,12 @@ func TestSimpleConsumer(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		select {
 		case msg := <-consumer.Messages():
+			if msg.Err != nil {
+				t.Error(msg.Err)
+			}
 			if msg.Offset != int64(i) {
 				t.Error("Incorrect message offset!")
 			}
-		case err := <-consumer.Errors():
-			t.Error(err)
 		}
 	}
 
@@ -108,9 +109,10 @@ consumerLoop:
 	for {
 		select {
 		case msg := <-consumer.Messages():
+			if msg.Err != nil {
+				panic(msg.Err)
+			}
 			fmt.Println(msg)
-		case err := <-consumer.Errors():
-			panic(err)
 		case <-time.After(5 * time.Second):
 			fmt.Println("> timed out")
 			break consumerLoop

--- a/examples/consumer/consumer.go
+++ b/examples/consumer/consumer.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"github.com/shopify/sarama"
+)
+
+func main() {
+
+	id := "example-client"
+	host := "127.0.0.1"
+	port := 9092
+
+	client, err := sarama.NewClient(id, host, port)
+	if err != nil {
+		panic(err)
+	}
+
+	topic := "test"
+	partition := 0
+	group := "example-consumer-group"
+
+	consumer, err := sarama.NewConsumer(client, topic, partition, group)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Listening on topic:", topic, "partition:", partition)
+	for msgOrErr := range consumer.Messages() {
+		if err := msgOrErr.Err; err != nil {
+			fmt.Println(err)
+			continue
+		}
+		msg := msgOrErr.Msg
+		fmt.Println("Got message with key:", string(msg.Key), "value:", string(msg.Value), "offset:", msgOrErr.Offset)
+	}
+
+}

--- a/examples/producer/producer.go
+++ b/examples/producer/producer.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"github.com/shopify/sarama"
+	"time"
+)
+
+func main() {
+
+	id := "example-client"
+	host := "127.0.0.1"
+	port := 9092
+
+	client, err := sarama.NewClient(id, host, port)
+	if err != nil {
+		panic(err)
+	}
+
+	topic := "test"
+
+	producer := sarama.NewProducer(client, topic, sarama.RandomPartitioner{})
+
+	ticker := time.Tick(1 * time.Second)
+	remaining := 5
+	for {
+		select {
+		case <-ticker:
+
+			if remaining == 0 {
+				return
+			}
+			remaining--
+
+			key := fmt.Sprintf("foo%d", remaining)
+			value := fmt.Sprintf("bar%d", remaining)
+			fmt.Println("Sending message with key:", key, "value:", value)
+			err = producer.SendMessageString(key, value)
+			if err != nil {
+				panic(err)
+			}
+
+		}
+	}
+}

--- a/producer.go
+++ b/producer.go
@@ -25,6 +25,18 @@ func (p *Producer) SendMessage(key, value Encoder) error {
 	return p.safeSendMessage(key, value, true)
 }
 
+func (p *Producer) SendMessageString(key, value string) error {
+	keyEnc := StringEncoder(key)
+	valueEnc := StringEncoder(value)
+	return p.safeSendMessage(keyEnc, valueEnc, true)
+}
+
+func (p *Producer) SendMessageBytes(key, value []byte) error {
+	keyEnc := ByteEncoder(key)
+	valueEnc := ByteEncoder(value)
+	return p.safeSendMessage(keyEnc, valueEnc, true)
+}
+
 func (p *Producer) choosePartition(key Encoder) (int32, error) {
 	partitions, err := p.client.partitions(p.topic)
 	if err != nil {


### PR DESCRIPTION
I'm open to discussion on any of these changes. 

@eapache

Summary of changes:
#### Int types

Several methods take parameters as `int` rather than the internally-required `int32`:
- `NewClient`'s `port`
- `NewBrokers`'s `port`
- `NewConsumer`'s `partition`
#### Message channels

I also unified `Consumer`'s `Messages` and `Errors` into a single channel that returns a struct:

```
struct MessageOrError {
  MessageBlock
  Err error
}
```

This allows calling code to range over a single channel rather than having to select on two and worry about closing logic.
#### Encoder Convenience

I added `SendMessageString` and `SendMessageBytes` as very simple convenience methods. Knowing about `StringEncoder` sounded ok in theory but it ended up feeling like a weird burden at the callsite.
