### PR TITLE
Only compress a message once

### DIFF
--- a/message.go
+++ b/message.go
@@ -40,25 +40,25 @@ func (m *Message) encode(pe packetEncoder) error {
 		return err
 	}
 
-	var body []byte
 	switch m.Codec {
-	case COMPRESSION_NONE:
-		body = m.Value
 	case COMPRESSION_GZIP:
 		if m.Value != nil {
 			var buf bytes.Buffer
 			writer := gzip.NewWriter(&buf)
 			writer.Write(m.Value)
 			writer.Close()
-			body = buf.Bytes()
+			m.Value = buf.Bytes()
+			m.Codec = COMPRESSION_NONE
 		}
 	case COMPRESSION_SNAPPY:
-		body, err = snappy.Encode(nil, m.Value)
+		tmp, err := snappy.Encode(nil, m.Value)
 		if err != nil {
 			return err
 		}
+		m.Value = tmp
+		m.Codec = COMPRESSION_NONE
 	}
-	err = pe.putBytes(body)
+	err = pe.putBytes(m.Value)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@burke @fw42 

It occurred to me recently that due to the two-pass nature of message encoding, compressed messages were getting compressed twice when encoded, which was rather inefficient.

This is the simple, obvious fix for that issue - when encoding a compressed message, just store the compressed version back in the message body and set the Codec to COMPRESSION_NONE so we don't try and compress it again.
