### PR TITLE
Fix nil-pointer panic in consumer.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -156,6 +156,7 @@ func (c *Consumer) fetchMessages() {
 					return
 				}
 			}
+			continue
 		}
 
 		block := response.GetBlock(c.topic, c.partition)


### PR DESCRIPTION
As was revealed during real-world use, if the broker we start with errors (and
returns a nil response) but we successfully find a new broker to talk to, we
have to start the loop again to get an actual response from the new broker.
Proceeding with the nil response just causes it to panic immediately.

Add the missing `continue` statement.

CC @burke @fw42 
