### PR TITLE
Fix HashPartitioner returning negative partitions.

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -64,9 +64,11 @@ func (p *Producer) choosePartition(key Encoder) (int32, error) {
 		return -1, err
 	}
 
-	choice := p.config.Partitioner.Partition(key, len(partitions))
+	numPartitions := int32(len(partitions))
 
-	if choice >= len(partitions) {
+	choice := p.config.Partitioner.Partition(key, numPartitions)
+
+	if choice < 0 || choice >= numPartitions {
 		return -1, InvalidPartition
 	}
 


### PR DESCRIPTION
@burke @fw42 
CC @wvanbergen @honkfestival @tobi 

TL;DR: casting a uint32 (the fnv hash) to an int32 can produce negative values, which are not valid array indices.

There are _so_ many levels of stupid involved in this:
- Go 1.0 (on the app servers) is LP64, where-as Go 1.1 (my dev machine) is ILP64. I personally consider this a breaking API change, so I'm not sure why they allowed it in a point release.
- I used `int` instead of `int32` for the `Partitioner` interface because I didn't care to make the interface properly strict (anyone who recalls the discussion around explicitly sized types? This is why all types should be explicitly sized.)
- In the producer I tested for too-large indices, but not negative indices.

So: the tests weren't failing on my machine because on my machine ints are 64-bits, so casting a uint32 always produces positive values. The producer wasn't catching the error because I forgot to add that check. The interface wasn't forced to 32-bit in the first place because I forgot.

Three changes:
- force the partitioner interface to 32-bit so that the tests started failing on Go1.1 dev boxes
- catch negative indices in the producer so that the panic becomes just an error
- stop returning negative indices from the HashProducer in the first place
