### PR TITLE
Expose some client methods.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -76,7 +76,14 @@ func TestClientMetadata(t *testing.T) {
 	}
 	defer client.Close()
 
-	parts, err := client.partitions("my_topic")
+	topics, err := client.Topics()
+	if err != nil {
+		t.Error(err)
+	} else if len(topics) != 1 || topics[0] != "my_topic" {
+		t.Error("Client returned incorrect topics:", topics)
+	}
+
+	parts, err := client.Partitions("my_topic")
 	if err != nil {
 		t.Error(err)
 	} else if len(parts) != 1 || parts[0] != 0 {
@@ -137,7 +144,7 @@ func TestClientRefreshBehaviour(t *testing.T) {
 	}
 	defer client.Close()
 
-	parts, err := client.partitions("my_topic")
+	parts, err := client.Partitions("my_topic")
 	if err != nil {
 		t.Error(err)
 	} else if len(parts) != 1 || parts[0] != 0xb {

--- a/consumer.go
+++ b/consumer.go
@@ -215,7 +215,7 @@ func (c *Consumer) fetchMessages() {
 		case NO_ERROR:
 			break
 		case UNKNOWN_TOPIC_OR_PARTITION, NOT_LEADER_FOR_PARTITION, LEADER_NOT_AVAILABLE:
-			err = c.client.refreshTopic(c.topic)
+			err = c.client.RefreshTopicMetadata(c.topic)
 			if c.sendError(err) {
 				for c.broker = nil; err != nil; c.broker, err = c.client.leader(c.topic, c.partition) {
 					if !c.sendError(err) {
@@ -317,7 +317,7 @@ func (c *Consumer) getOffset(where OffsetTime, retry bool) (int64, error) {
 		if !retry {
 			return -1, block.Err
 		}
-		err = c.client.refreshTopic(c.topic)
+		err = c.client.RefreshTopicMetadata(c.topic)
 		if err != nil {
 			return -1, err
 		}

--- a/producer.go
+++ b/producer.go
@@ -59,7 +59,7 @@ func (p *Producer) SendMessage(key, value Encoder) error {
 }
 
 func (p *Producer) choosePartition(key Encoder) (int32, error) {
-	partitions, err := p.client.partitions(p.topic)
+	partitions, err := p.client.Partitions(p.topic)
 	if err != nil {
 		return -1, err
 	}
@@ -133,7 +133,7 @@ func (p *Producer) safeSendMessage(key, value Encoder, retry bool) error {
 		if !retry {
 			return block.Err
 		}
-		err = p.client.refreshTopic(p.topic)
+		err = p.client.RefreshTopicMetadata(p.topic)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The producer and consumer still make use of some private methods, but those are
harder to expose consistently. This is at least a good start towards #23.

Flo, this should make your map app a lot simpler.

@fw42 @burke @Sirupsen 
