### PR TITLE
Remove Broker.Equals()

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -107,18 +107,6 @@ func (b *Broker) Addr() string {
 	return b.addr
 }
 
-// Equals compares two brokers. Two brokers are considered equal if they have the same address and id,
-// or if they are both nil.
-func (b *Broker) Equals(a *Broker) bool {
-	switch {
-	case a == nil && b == nil:
-		return true
-	case (a == nil && b != nil) || (a != nil && b == nil):
-		return false
-	}
-	return a.id == b.id && a.addr == b.addr
-}
-
 func (b *Broker) GetMetadata(clientID string, request *MetadataRequest) (*MetadataResponse, error) {
 	response := new(MetadataResponse)
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -161,42 +161,6 @@ func ExampleBroker() error {
 	return nil
 }
 
-func TestBrokerEquals(t *testing.T) {
-	var b1, b2 *Broker
-
-	b1 = nil
-	b2 = nil
-
-	if !b1.Equals(b2) {
-		t.Error("Two nil brokers didn't compare equal.")
-	}
-
-	b1 = NewBroker("abc:123")
-
-	if b1.Equals(b2) {
-		t.Error("Non-nil and nil brokers compared equal.")
-	}
-	if b2.Equals(b1) {
-		t.Error("Nil and non-nil brokers compared equal.")
-	}
-
-	b2 = NewBroker("abc:1234")
-	if b1.Equals(b2) || b2.Equals(b1) {
-		t.Error("Brokers with different addrs compared equal.")
-	}
-
-	b2 = NewBroker("abc:123")
-	b2.id = -2
-	if b1.Equals(b2) || b2.Equals(b1) {
-		t.Error("Brokers with different ids compared equal.")
-	}
-
-	b2.id = -1
-	if !b1.Equals(b2) || !b2.Equals(b1) {
-		t.Error("Similar brokers did not compare equal.")
-	}
-}
-
 func TestBrokerAccessors(t *testing.T) {
 
 	broker := NewBroker("abc:123")


### PR DESCRIPTION
Also simplify the client code that used to use it. Now that we expose `Broker.Addr()` as an accessor, the `Equals` method is unneeded and the client code can be simplified rather substantially.

@fw42 @burke @Sirupsen 
