### PR TITLE
Warn if Consumer is naively configured in a way that will cause busy-looping

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -26,8 +26,8 @@ type ConsumerConfig struct {
 	// treated as no limit.
 	MaxMessageSize int32
 	// The maximum amount of time (in ms) the broker will wait for MinFetchSize bytes to become available before it
-	// returns fewer than that anyways. The default of 0 causes Kafka to return immediately when there are no pending events.
-	// This is rarely desirable behaviour. 500 is a reasonable setting for most use-cases.
+	// returns fewer than that anyways. The default of 0 causes Kafka to return immediately, which is rarely desirable
+	// as it causes the Consumer to spin when no events are available. 100-500ms is a reasonable range for most cases.
 	MaxWaitTime int32
 
 	// The method used to determine at which offset to begin consuming messages.
@@ -92,7 +92,7 @@ func NewConsumer(client *Client, topic string, partition int32, group string, co
 	if config.MaxWaitTime < 0 {
 		return nil, ConfigurationError("Invalid MaxWaitTime")
 	} else if config.MaxWaitTime < 100 {
-		Logger.Println("ConsumerConfig{MaxWaitTime} is very low. This can cause high CPU and network usage. Consider increasing this value.")
+		Logger.Println("ConsumerConfig.MaxWaitTime is very low, which can cause high CPU and network usage. See documentation for details.")
 	}
 
 	if config.EventBufferSize < 0 {


### PR DESCRIPTION
@sirupsen @wvanbergen @eapache.

I don't want to actually modify any of these values, since any being 0 does have a theoretically-valid meaning.

However, three different people here have run into this busy-looping problem, and this log message will solve that. Thoughts?
