### PR TITLE
Add a check to make debugging easier when the client has been closed previously

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,9 +21,6 @@ type Client struct {
 	id     string
 	config ClientConfig
 
-	// True if this client was closed, for error tracking
-	closed bool
-
 	// the broker addresses given to us through the constructor are not guaranteed to be returned in
 	// the cluster metadata (I *think* it only returns brokers who are currently leading partitions?)
 	// so we store them separately
@@ -79,6 +76,14 @@ func NewClient(id string, addrs []string, config *ClientConfig) (*Client, error)
 // a client object passes out of scope, as it will otherwise leak memory. You must close any Producers or Consumers
 // using a client before you close the client.
 func (client *Client) Close() error {
+	// Check to see whether the client is closed
+	if client.Closed() {
+		// Chances are this is being called from a defer() and the error will go unobserved
+		// so we go ahead and log the event in this case.
+		Logger.Printf("Close() called on already closed client")
+		return ClosedClient
+	}
+
 	client.lock.Lock()
 	defer client.lock.Unlock()
 
@@ -87,7 +92,6 @@ func (client *Client) Close() error {
 	}
 	client.brokers = nil
 	client.leaders = nil
-	client.closed = true
 
 	if client.extraBroker != nil {
 		go client.extraBroker.Close()
@@ -98,6 +102,11 @@ func (client *Client) Close() error {
 
 // Partitions returns the sorted list of available partition IDs for the given topic.
 func (client *Client) Partitions(topic string) ([]int32, error) {
+	// Check to see whether the client is closed
+	if client.Closed() {
+		return nil, ClosedClient
+	}
+
 	partitions := client.cachedPartitions(topic)
 
 	if partitions == nil {
@@ -117,6 +126,11 @@ func (client *Client) Partitions(topic string) ([]int32, error) {
 
 // Topics returns the set of available topics as retrieved from the cluster metadata.
 func (client *Client) Topics() ([]string, error) {
+	// Check to see whether the client is closed
+	if client.Closed() {
+		return nil, ClosedClient
+	}
+
 	client.lock.RLock()
 	defer client.lock.RUnlock()
 
@@ -187,20 +201,19 @@ func (client *Client) disconnectBroker(broker *Broker) {
 	go broker.Close()
 }
 
-func (client *Client) CheckUsable() error {
-     	if client.closed {
-		return ClosedClient
+func (client *Client) Closed() bool {
+	if client.brokers == nil {
+		return true
 	}
-	return nil
+	return false
 }
-
 
 func (client *Client) refreshMetadata(topics []string, retries int) error {
 	// This function is a sort of central point for most functions that create new
 	// resources.  Check to see if we're dealing with a closed Client and error
 	// out immediately if so.
-	if err := client.CheckUsable(); err != nil {
-		return err
+	if client.Closed() {
+		return ClosedClient
 	}
 
 	// Kafka will throw exceptions on an empty topic and not return a proper

--- a/consumer.go
+++ b/consumer.go
@@ -69,6 +69,12 @@ type Consumer struct {
 // NewConsumer creates a new consumer attached to the given client. It will read messages from the given topic and partition, as
 // part of the named consumer group.
 func NewConsumer(client *Client, topic string, partition int32, group string, config *ConsumerConfig) (*Consumer, error) {
+	// Check that we are not dealing with a closed Client before processing
+	// any other arguments
+	if client.Closed() {
+		return nil, ClosedClient
+	}
+
 	if config == nil {
 		config = new(ConsumerConfig)
 	}

--- a/errors.go
+++ b/errors.go
@@ -9,8 +9,8 @@ import (
 // or otherwise failed to respond.
 var OutOfBrokers = errors.New("kafka: Client has run out of available brokers to talk to. Is your cluster reachable?")
 
-// ClosedClient is the error returned when the client was previously closed but used subsequently.
-var ClosedClient = errors.New("kafka: Use of a client that was previously closed")
+// ClosedClient is the error returned when a method is called on a client that has been closed.
+var ClosedClient = errors.New("kafka: Tried to use a client that was closed.")
 
 // NoSuchTopic is the error returned when the supplied topic is rejected by the Kafka servers.
 var NoSuchTopic = errors.New("kafka: Topic not recognized by brokers.")

--- a/producer.go
+++ b/producer.go
@@ -19,6 +19,12 @@ type Producer struct {
 
 // NewProducer creates a new Producer using the given client. The resulting producer will publish messages on the given topic.
 func NewProducer(client *Client, topic string, config *ProducerConfig) (*Producer, error) {
+	// Check that we are not dealing with a closed Client before processing
+	// any other arguments
+	if client.Closed() {
+		return nil, ClosedClient
+	}
+
 	if config == nil {
 		config = new(ProducerConfig)
 	}
@@ -37,10 +43,6 @@ func NewProducer(client *Client, topic string, config *ProducerConfig) (*Produce
 
 	if topic == "" {
 		return nil, ConfigurationError("Empty topic")
-	}
-
-	if err := client.CheckUsable(); err != nil {
-		return nil, err
 	}
 
 	p := new(Producer)


### PR DESCRIPTION
Add a check to make debugging easier when the client has been closed previously.  This has a tendency to happen when a misplaced defer() to clean up the client has fired.
