### PR TITLE
Compression codec is only two bits, not three.

### DIFF
--- a/message.go
+++ b/message.go
@@ -10,8 +10,8 @@ import (
 // CompressionCodec represents the various compression codecs recognized by Kafka in messages.
 type CompressionCodec int8
 
-// only the last three bits are really used
-const compressionCodecMask int8 = 0x07
+// only the last two bits are really used
+const compressionCodecMask int8 = 0x03
 
 const (
 	CompressionNone   CompressionCodec = 0


### PR DESCRIPTION
As per discussion on https://issues.apache.org/jira/browse/KAFKA-1110

@burke @fw42 @Sirupsen @joestein
