### PR TITLE
Remove limit on length field in ResponseHeader.

### DIFF
--- a/response_header.go
+++ b/response_header.go
@@ -1,7 +1,5 @@
 package sarama
 
-import "math"
-
 type responseHeader struct {
 	length        int32
 	correlationID int32
@@ -12,7 +10,7 @@ func (r *responseHeader) decode(pd packetDecoder) (err error) {
 	if err != nil {
 		return err
 	}
-	if r.length <= 4 || r.length > 2*math.MaxUint16 {
+	if r.length <= 4 {
 		return DecodingError
 	}
 


### PR DESCRIPTION
I can't find anything in the protocol spec that indicates this is actually required, and we're getting a larger value than this returned from kafka in some cases. This caused Sarama to continuously disconnect/reconnect brokers, effectively stalling for these high-volume topic-partitions.
