### PR TITLE
Add an option for a connect timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ type ClientConfig struct {
 	MetadataRetries      int           // How many times to retry a metadata request when a partition is in the middle of leader election.
 	WaitForElection      time.Duration // How long to wait for leader election to finish between retries.
 	ConcurrencyPerBroker int           // How many outstanding requests each broker is allowed to have.
+	ConnectTimeout       time.Duration // How long to wait for an initial client connection
 }
 
 // Client is a generic Kafka client. It manages connections to one or more Kafka brokers.
@@ -60,6 +61,8 @@ func NewClient(id string, addrs []string, config *ClientConfig) (*Client, error)
 		brokers:          make(map[int32]*Broker),
 		leaders:          make(map[string]map[int32]int32),
 	}
+
+	client.extraBroker.connectTimeout = config.ConnectTimeout
 	client.extraBroker.Open(config.ConcurrencyPerBroker)
 
 	// do an initial fetch of all cluster metadata by specifing an empty list of topics


### PR DESCRIPTION
This is a proposal to include a connect timeout to NewClient().  

It's motivated by a problem encountered by a developer with an unhealthy Kafka cluster that would accept connections, but never read/write from the socket.  This would cause the NewClient() call to block indefinitely waiting on a response. The Java command-line tools eventually timed out out and reported an error which seems friendlier.

I've added a unit test to simulate this situation.

Summary of changes:
- Add a new `ConnectTimeout` field to the `ClientConfig` struct
- Add a new `connectTimeout` field to the `Broker` struct
- Pass the timeout from the ClientConfig to the Broker in `NewClient()`
- The timeout value is applied to the first message processed by `responseReceiver()` and is removed immediately after the first message is received.  Any errors encountered setting / clearing timeout values are percolated through the regular error reporting mechanism.  

@fw42 / @burke please take a look.
/cc @wvanbergen 
