### PR TITLE
Fixed Producer and Consumer examples.

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -121,7 +121,7 @@ func ExampleConsumer() {
 	}
 	defer client.Close()
 
-	consumer, err := NewConsumer(client, "my_topic", 0, "my_consumer_group", nil)
+	consumer, err := NewConsumer(client, "my_topic", 0, "my_consumer_group", &ConsumerConfig{MaxWaitTime: 200})
 	if err != nil {
 		panic(err)
 	} else {

--- a/producer_test.go
+++ b/producer_test.go
@@ -313,7 +313,7 @@ func ExampleProducer() {
 	}
 	defer client.Close()
 
-	producer, err := NewProducer(client, &ProducerConfig{RequiredAcks: WaitForLocal})
+	producer, err := NewProducer(client, &ProducerConfig{RequiredAcks: WaitForLocal, MaxBufferedBytes: 1024, MaxBufferTime: 1000})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Because NewProducer now requires non-default values for MaxBufferedBytes and MaxBufferTime, and because NewConsumer now require non-default values for MaxWaitTime. I included these parameters into the Producer and Consumer examples. They should work now.

... I'm just starting to learn my way around sarama. The API looks clean and straightforward. I'm looking forward to working with your library.
