### PR TITLE
Update API Keys per latest version of the spec

### DIFF
--- a/offset_commit_request.go
+++ b/offset_commit_request.go
@@ -45,7 +45,7 @@ func (r *OffsetCommitRequest) encode(pe packetEncoder) error {
 }
 
 func (r *OffsetCommitRequest) key() int16 {
-	return 6
+	return 8
 }
 
 func (r *OffsetCommitRequest) version() int16 {

--- a/offset_fetch_request.go
+++ b/offset_fetch_request.go
@@ -25,7 +25,7 @@ func (r *OffsetFetchRequest) encode(pe packetEncoder) error {
 }
 
 func (r *OffsetFetchRequest) key() int16 {
-	return 7
+	return 9
 }
 
 func (r *OffsetFetchRequest) version() int16 {


### PR DESCRIPTION
The spec page on the wiki was updated with new key values on March 19:
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol

@wvanbergen
