### PR TITLE
Simplify travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: go
-go: 
+go:
   - 1.1
   - 1.2
-
-script:
-  - go test -v


### PR DESCRIPTION
Per http://docs.travis-ci.com/user/languages/go/ "go test -v" is the default
action, so there's no need to explicitly specify it. Also remove some trailing
whitespace.

@wvanbergen
