### PR TITLE
Drop pretense of support for Go 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Sarama is an MIT-licensed Go client library for Apache Kafka 0.8 (and later).
 
 Documentation is available via godoc at http://godoc.org/github.com/Shopify/sarama
 
-It is compatible with Go 1.0 and 1.1 (which means `go vet` on 1.1 will return
-some suggestions that we are ignoring for the sake of compatibility with 1.0).
+It is compatible with Go 1.1 and 1.2 (which means `go vet` on 1.2 may return
+some suggestions that we are ignoring for the sake of compatibility with 1.1).
 
 A word of warning: the API is not 100% stable yet. It won't change much (in particular the low-level
 Broker and Request/Response objects could *probably* be considered frozen) but there may be the occasional

--- a/broker.go
+++ b/broker.go
@@ -248,9 +248,6 @@ func (b *Broker) sendAndReceive(clientID string, req requestEncoder, res decoder
 	case err = <-promise.errors:
 		return err
 	}
-
-	// For backward compatibility with go1.0
-	return nil
 }
 
 func (b *Broker) decode(pd packetDecoder) (err error) {

--- a/client.go
+++ b/client.go
@@ -265,7 +265,7 @@ func (client *Client) resurrectDeadBrokers() {
 
 	client.deadBrokerAddrs = []string{}
 	client.extraBrokerAddrs = []string{}
-	for addr, _ := range brokers {
+	for addr := range brokers {
 		client.extraBrokerAddrs = append(client.extraBrokerAddrs, addr)
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -175,9 +175,6 @@ func (c *Consumer) sendError(err error) bool {
 	case c.events <- &ConsumerEvent{Err: err}:
 		return true
 	}
-
-	// For backward compatibility with go1.0
-	return true
 }
 
 func (c *Consumer) fetchMessages() {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -137,7 +137,7 @@ consumerLoop:
 			if event.Err != nil {
 				panic(event.Err)
 			}
-			msgCount += 1
+			msgCount++
 		case <-time.After(5 * time.Second):
 			fmt.Println("> timed out")
 			break consumerLoop

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -124,7 +124,7 @@ func (b *MockBroker) serverError(err error, conn net.Conn) bool {
 	return false
 }
 
-// New launches a fake Kafka broker. It takes a TestState (e.g. *testing.T) as provided by the
+// NewMockBroker launches a fake Kafka broker. It takes a TestState (e.g. *testing.T) as provided by the
 // test framework and a channel of responses to use.  If an error occurs it is
 // simply logged to the TestState and the broker exits.
 func NewMockBroker(t TestState, brokerID int) *MockBroker {


### PR DESCRIPTION
Our travis config was already only 1.1/1.2. Remove a few 1.0-specific bits, and
clean up a few lint errors found in the process.

@wvanbergen
