### PR TITLE
Fix two minor bugs in producer.go

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -242,7 +242,6 @@ func (p *Producer) newBrokerProducer(broker *Broker) *brokerProducer {
 				if shutdownRequired = bp.flush(p); shutdownRequired {
 					goto shutdown
 				}
-				bp.flush(p)
 			case <-timer.C:
 				if shutdownRequired = bp.flushIfAnyMessages(p); shutdownRequired {
 					goto shutdown
@@ -314,9 +313,9 @@ func (bp *brokerProducer) flush(p *Producer) (shutdownRequired bool) {
 	bp.mapM.Lock()
 	for tp, messages := range bp.messages {
 		if len(messages) > 0 && p.tryAcquireDeliveryLock(tp) {
-			defer p.releaseDeliveryLock(tp)
 			prb = append(prb, messages...)
 			delete(bp.messages, tp)
+			p.releaseDeliveryLock(tp)
 		}
 	}
 	bp.mapM.Unlock()


### PR DESCRIPTION
- Remove a second superfluous call to bp.flush when bp.flushNow is
  triggered.
- Release delivery lock after use instead of deferring until end of
  function.

Regarding the second: a deferred call is deferred until the end of the function, not the end of the scope, and it appears the delivery lock can be released after the delete instead of later at the end of the function.
