### PR TITLE
Old kafka URL is dead, replace with new one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ go:
 
 before_install:
 - sudo apt-get install zookeeper 2>&1
-- wget http://apache.mirror.nexicom.net/kafka/0.8.1/kafka_2.10-0.8.1.tgz -O kafka.tgz
+- wget http://apache.mirror.nexicom.net/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz -O kafka.tgz
 - mkdir -p kafka && tar xzf kafka.tgz -C kafka --strip-components 1
 - nohup bash -c "cd kafka && bin/kafka-server-start.sh config/server.properties &"


### PR DESCRIPTION
for upstream 0.8.1.1 release

we should find a way to make this not break on each new upstream release

@wvanbergen
