### PR TITLE
Fix race in bufferedBytes access

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -269,7 +269,10 @@ func (bp *brokerProducer) addMessage(msg *produceMessage, maxBufferBytes uint32)
 }
 
 func (bp *brokerProducer) flushIfOverCapacity(maxBufferBytes uint32) {
-	if bp.bufferedBytes > maxBufferBytes {
+	bp.mapM.Lock()
+	over := bp.bufferedBytes > maxBufferBytes
+	bp.mapM.Unlock()
+	if over {
 		select {
 		case bp.flushNow <- true:
 		default:


### PR DESCRIPTION
Without the fix was getting following race warning on go1.3rc1

```
WARNING: DATA RACE
Write by goroutine 41:
  github.com/Shopify/sarama.(*brokerProducer).flush()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:309 +0x491
  github.com/Shopify/sarama.(*brokerProducer).flushIfAnyMessages()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:287 +0xc8
  github.com/Shopify/sarama.func·008()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:230 +0x3af

Previous read by goroutine 68:
  github.com/Shopify/sarama.(*brokerProducer).flushIfOverCapacity()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:272 +0x3a
  github.com/Shopify/sarama.(*brokerProducer).addMessage()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:268 +0x430
  github.com/Shopify/sarama.(*Producer).addMessage()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:178 +0xf1
  github.com/Shopify/sarama.(*produceMessage).enqueue()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/produce_message.go:19 +0x87
  github.com/Shopify/sarama.(*Producer).genericSendMessage()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:170 +0x303
  github.com/Shopify/sarama.(*Producer).QueueMessage()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:124 +0x9e
  bitbucket.org/blah/project/event/tracker.(*StandardTracker).QueueEvent()
      /home/evgeniy/g/src/bitbucket.org/blah/project/event/tracker/tracker.go:139 +0x160
  bitbucket.org/blah/project/event/tracker.(*StandardTracker).Auction()
      /home/evgeniy/g/src/bitbucket.org/blah/project/event/tracker/tracker.go:94 +0x7b
  bitbucket.org/blah/project.(*Mux).Auction()
      /home/evgeniy/g/src/bitbucket.org/blah/project/mux.go:161 +0x12da
  bitbucket.org/blah/project.func·006()
      /home/evgeniy/g/src/bitbucket.org/blah/project/mux.go:842 +0x8c
  net/http.HandlerFunc.ServeHTTP()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1235 +0x4d
  bitbucket.org/blah/project/utils.func·002()
      /home/evgeniy/g/src/bitbucket.org/blah/project/utils/timeout.go:27 +0xff

Goroutine 41 (running) created at:
  github.com/Shopify/sarama.(*Producer).newBrokerProducer()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:245 +0x31a
  github.com/Shopify/sarama.(*Producer).brokerProducerFor()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:195 +0x24b
  github.com/Shopify/sarama.(*produceMessage).enqueue()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/produce_message.go:23 +0x180
  github.com/Shopify/sarama.(*Producer).genericSendMessage()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:170 +0x303
  github.com/Shopify/sarama.(*Producer).SendMessage()
      /home/evgeniy/g/src/bitbucket.org/blah/project/Godeps/_workspace/src/github.com/Shopify/sarama/producer.go:139 +0x9e
  bitbucket.org/blah/project/event/tracker.(*StandardTracker).Ping()
      /home/evgeniy/g/src/bitbucket.org/blah/project/event/tracker/tracker.go:134 +0x18a
  bitbucket.org/blah/project.(*Heartbeat).checkConnections()
      /home/evgeniy/g/src/bitbucket.org/blah/project/heartbeat.go:74 +0xfd2
  bitbucket.org/blah/project.NewHeartbeat()
      /home/evgeniy/g/src/bitbucket.org/blah/project/heartbeat.go:24 +0x8f
  bitbucket.org/blah/project.(*Mux).Heartbeat()
      /home/evgeniy/g/src/bitbucket.org/blah/project/mux.go:532 +0x97
  bitbucket.org/blah/project.*Mux.Heartbeat·fm()
      /home/evgeniy/g/src/bitbucket.org/blah/project/mux.go:72 +0x51
  net/http.HandlerFunc.ServeHTTP()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1235 +0x4d
  net/http.(*ServeMux).ServeHTTP()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1511 +0x21c
  bitbucket.org/blah/project.(*Mux).ServeHTTP()
      <autogenerated>:1 +0x67
  net/http.serverHandler.ServeHTTP()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1673 +0x1fc
  net/http.(*conn).serve()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1174 +0xf9e

Goroutine 68 (finished) created at:
  bitbucket.org/blah/project/utils.(*timeoutHandler).ServeHTTP()
      /home/evgeniy/g/src/bitbucket.org/blah/project/utils/timeout.go:29 +0x1e4
  net/http.(*ServeMux).ServeHTTP()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1511 +0x21c
  bitbucket.org/blah/project.(*Mux).ServeHTTP()
      <autogenerated>:1 +0x67
  net/http.serverHandler.ServeHTTP()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1673 +0x1fc
  net/http.(*conn).serve()
      /home/evgeniy/.gvm/gos/go1.3rc1/src/pkg/net/http/server.go:1174 +0xf9e
```
