### PR TITLE
Add two new optional channels to the ProducerConfig for handling failures and acks

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -409,7 +409,7 @@ func (bp *brokerProducer) flushRequest(p *Producer, prb produceRequestBuilder, e
 				if overlimit > 0 {
 					errorCb(DroppedMessagesError{overlimit, err})
 				} else {
-					errorCb(DroppedMessagesError{overlimit, block.Err})
+					errorCb(nil)
 				}
 			default:
 				errorCb(DroppedMessagesError{len(prb), block.Err})


### PR DESCRIPTION
FailedChannel, when provided will have all messages that are not acked sent as type *ConsumerEvent. The application using this package is responsible for reading from the failed channel or it will eventually block.

AckingChannel, when provided will provide counts per partition, per topic of acked messages after each flush. The application using this package is responsible for reading from the acking channel or is will eventually block.

This commit also includes a change for the error sent in the DroppedMessagesError struct to the errorCb to be the block error instead of the error returned from Produce.
