### PR TITLE
Default configuration value fixes

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,13 @@ import (
 	"testing"
 )
 
+func TestDefaultClientConfigValidates(t *testing.T) {
+	config := NewClientConfig()
+	if err := config.Validate(); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestSimpleClient(t *testing.T) {
 
 	mb := NewMockBroker(t, 1)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+func TestDefaultConsumerConfigValidates(t *testing.T) {
+	config := NewConsumerConfig()
+	if err := config.Validate(); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestSimpleConsumer(t *testing.T) {
 	mb1 := NewMockBroker(t, 1)
 	mb2 := NewMockBroker(t, 2)

--- a/produce_message.go
+++ b/produce_message.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "log"
+import (
+	"log"
+	"time"
+)
 
 type produceMessage struct {
 	tp         topicPartition
@@ -45,7 +48,7 @@ func (msg *produceMessage) hasTopicPartition(topic string, partition int32) bool
 }
 
 func (b produceRequestBuilder) toRequest(config *ProducerConfig) *ProduceRequest {
-	req := &ProduceRequest{RequiredAcks: config.RequiredAcks, Timeout: config.Timeout}
+	req := &ProduceRequest{RequiredAcks: config.RequiredAcks, Timeout: int32(config.Timeout / time.Millisecond)}
 
 	// If compression is enabled, we need to group messages by topic-partition and
 	// wrap them in MessageSets. We already discarded that grouping, so we

--- a/produce_request_test.go
+++ b/produce_request_test.go
@@ -1,6 +1,8 @@
 package sarama
 
-import "testing"
+import (
+	"testing"
+)
 
 var (
 	produceRequestEmpty = []byte{

--- a/producer_test.go
+++ b/producer_test.go
@@ -10,9 +10,16 @@ const TestMessage = "ABC THE MESSAGE"
 
 func defaultProducerConfig() *ProducerConfig {
 	config := NewProducerConfig()
-	config.MaxBufferTime = 1000000                                // don't flush based on time
+	config.MaxBufferTime = 1000000 * time.Millisecond             // don't flush based on time
 	config.MaxBufferedBytes = uint32((len(TestMessage) * 10) - 1) // flush after 10 messages
 	return config
+}
+
+func TestDefaultProducerConfigValidates(t *testing.T) {
+	config := NewProducerConfig()
+	if err := config.Validate(); err != nil {
+		t.Error(err)
+	}
 }
 
 func TestSimpleProducer(t *testing.T) {


### PR DESCRIPTION
- Use time.Duration values instead of raw integers
- Add tests to verify that the default configuration objects created by `New***Config()` validate.
- Fix some comments

@eapache 
