### PR TITLE
Make mockbroker's ID an int32 to avoid a boatload of casts

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -31,7 +31,7 @@ func TestClientExtraBrokers(t *testing.T) {
 	mb2 := NewMockBroker(t, 2)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mb1.Returns(mdr)
 
 	client, err := NewClient("client_id", []string{mb1.Addr()}, nil)
@@ -49,8 +49,8 @@ func TestClientMetadata(t *testing.T) {
 	mb5 := NewMockBroker(t, 5)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb5.Addr(), int32(mb5.BrokerID()))
-	mdr.AddTopicPartition("my_topic", 0, int32(mb5.BrokerID()))
+	mdr.AddBroker(mb5.Addr(), mb5.BrokerID())
+	mdr.AddTopicPartition("my_topic", 0, mb5.BrokerID())
 	mb1.Returns(mdr)
 
 	client, err := NewClient("client_id", []string{mb1.Addr()}, nil)
@@ -88,11 +88,11 @@ func TestClientRefreshBehaviour(t *testing.T) {
 	mb5 := NewMockBroker(t, 5)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb5.Addr(), int32(mb5.BrokerID()))
+	mdr.AddBroker(mb5.Addr(), mb5.BrokerID())
 	mb1.Returns(mdr)
 
 	mdr2 := new(MetadataResponse)
-	mdr2.AddTopicPartition("my_topic", 0xb, int32(mb5.BrokerID()))
+	mdr2.AddTopicPartition("my_topic", 0xb, mb5.BrokerID())
 	mb5.Returns(mdr2)
 
 	client, err := NewClient("clientID", []string{mb1.Addr()}, nil)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -18,7 +18,7 @@ func TestSimpleConsumer(t *testing.T) {
 	mb2 := NewMockBroker(t, 2)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mdr.AddTopicPartition("my_topic", 0, 2)
 	mb1.Returns(mdr)
 
@@ -61,7 +61,7 @@ func TestConsumerRawOffset(t *testing.T) {
 	mb2 := NewMockBroker(t, 2)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mdr.AddTopicPartition("my_topic", 0, 2)
 	mb1.Returns(mdr)
 
@@ -94,7 +94,7 @@ func TestConsumerLatestOffset(t *testing.T) {
 	mb2 := NewMockBroker(t, 2)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mdr.AddTopicPartition("my_topic", 0, 2)
 	mb1.Returns(mdr)
 

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -26,7 +26,7 @@ type TestState interface {
 // It is not necessary to prefix message length or correlation ID to your response bytes, the server does that
 // automatically as a convenience.
 type MockBroker struct {
-	brokerID     int
+	brokerID     int32
 	port         int32
 	stopper      chan bool
 	expectations chan encoder
@@ -35,7 +35,7 @@ type MockBroker struct {
 	expecting    encoder
 }
 
-func (b *MockBroker) BrokerID() int {
+func (b *MockBroker) BrokerID() int32 {
 	return b.brokerID
 }
 
@@ -127,7 +127,7 @@ func (b *MockBroker) serverError(err error, conn net.Conn) bool {
 // NewMockBroker launches a fake Kafka broker. It takes a TestState (e.g. *testing.T) as provided by the
 // test framework and a channel of responses to use.  If an error occurs it is
 // simply logged to the TestState and the broker exits.
-func NewMockBroker(t TestState, brokerID int) *MockBroker {
+func NewMockBroker(t TestState, brokerID int32) *MockBroker {
 	var err error
 
 	broker := &MockBroker{

--- a/producer_test.go
+++ b/producer_test.go
@@ -30,7 +30,7 @@ func TestSimpleProducer(t *testing.T) {
 	defer mb2.Close()
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mdr.AddTopicPartition("my_topic", 0, 2)
 	mb1.Returns(mdr)
 
@@ -64,7 +64,7 @@ func TestSimpleSyncProducer(t *testing.T) {
 	defer mb2.Close()
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mdr.AddTopicPartition("my_topic", 1, 2)
 	mb1.Returns(mdr)
 
@@ -99,7 +99,7 @@ func TestMultipleFlushes(t *testing.T) {
 	defer mb2.Close()
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
 	mdr.AddTopicPartition("my_topic", 0, 2)
 	mb1.Returns(mdr)
 
@@ -139,8 +139,8 @@ func TestMultipleProducer(t *testing.T) {
 	defer mb3.Close()
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
-	mdr.AddBroker(mb3.Addr(), int32(mb3.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
+	mdr.AddBroker(mb3.Addr(), mb3.BrokerID())
 	mdr.AddTopicPartition("topic_a", 0, 2)
 	mdr.AddTopicPartition("topic_b", 0, 3)
 	mdr.AddTopicPartition("topic_c", 0, 3)
@@ -197,8 +197,8 @@ func TestFailureRetry(t *testing.T) {
 	mb3 := NewMockBroker(t, 3)
 
 	mdr := new(MetadataResponse)
-	mdr.AddBroker(mb2.Addr(), int32(mb2.BrokerID()))
-	mdr.AddBroker(mb3.Addr(), int32(mb3.BrokerID()))
+	mdr.AddBroker(mb2.Addr(), mb2.BrokerID())
+	mdr.AddBroker(mb3.Addr(), mb3.BrokerID())
 	mdr.AddTopicPartition("topic_a", 0, 2)
 	mdr.AddTopicPartition("topic_b", 0, 3)
 	mdr.AddTopicPartition("topic_c", 0, 3)
@@ -225,7 +225,7 @@ func TestFailureRetry(t *testing.T) {
 	// isn't quite as random as claimed, though, it seems. Maybe because
 	// the same random seed is used each time?
 	mdr2 := new(MetadataResponse)
-	mdr2.AddBroker(mb3.Addr(), int32(mb3.BrokerID()))
+	mdr2.AddBroker(mb3.Addr(), mb3.BrokerID())
 	mdr2.AddTopicPartition("topic_b", 0, 3)
 	mb2.Returns(mdr2)
 


### PR DESCRIPTION
@wvanbergen 
