### PR TITLE
Return better error when server returns no offsets

### DIFF
--- a/client.go
+++ b/client.go
@@ -207,7 +207,7 @@ func (client *Client) GetOffset(topic string, partitionID int32, where OffsetTim
 		return -1, block.Err
 	}
 	if len(block.Offsets) != 1 {
-		return -1, IncompleteResponse
+		return -1, OffsetOutOfRange
 	}
 
 	return block.Offsets[0], nil


### PR DESCRIPTION
Return OffsetOutOfRange instead of IncompleteResponse. Apparently when the
offset is out of range for an offset request, it doesn't return an error, just a
blank array, so translate that appropriately.

Fixes #123 

@wvanbergen @manygrams 
