### PR TITLE
Disconnect the broker when it returns us certain errors

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -339,6 +339,7 @@ func (bp *brokerProducer) flushRequest(p *Producer, prb produceRequestBuilder, e
 		errorCb(err)
 		return false
 	default:
+		p.client.disconnectBroker(bp.broker)
 		overlimit := 0
 		prb.reverseEach(func(msg *produceMessage) {
 			if err := msg.reenqueue(p); err != nil {


### PR DESCRIPTION
Specifically, in the cases that indicate it is probably unreachable or
something. Otherwise we never reconnect, even if it comes back up.

Fixes #133

@burke @graemej @Sirupsen
