### PR TITLE
hard limit on max size of any request sent by producer

### DIFF
--- a/encoder_decoder.go
+++ b/encoder_decoder.go
@@ -20,6 +20,10 @@ func encode(in encoder) ([]byte, error) {
 		return nil, err
 	}
 
+	if prepEnc.length < 0 || uint32(prepEnc.length) > MaxRequestSize {
+		return nil, EncodingError
+	}
+
 	realEnc.raw = make([]byte, prepEnc.length)
 	err = in.encode(&realEnc)
 	if err != nil {

--- a/sarama.go
+++ b/sarama.go
@@ -19,3 +19,9 @@ var Logger = log.New(ioutil.Discard, "[Sarama] ", log.LstdFlags)
 // PanicHandler is called for recovering from panics spawned internally to the library (and thus
 // not recoverable by the caller's goroutine). Defaults to nil, which means panics are not recovered.
 var PanicHandler func(interface{})
+
+// MaxRequestSize is the maximum size (in bytes) of any request that Sarama will attempt to send. Trying
+// to send a request larger than this will result in an EncodingError. The default of 100 MiB is aligned
+// with Kafka's default `socket.request.max.bytes`, which is the largest request the broker will attempt
+// to process.
+var MaxRequestSize uint32 = 100 * 1024 * 1024


### PR DESCRIPTION
See discussion on:
https://github.com/tylertreat/mq-benchmarking/pull/2

This probably needs to be configurable and possibly thought through (does it belong somewhere else in the flush path instead/as well?), but it seems to work for now to make the benchmark run.

@wvanbergen @Sirupsen @graemej @burke 
