### PR TITLE
Don't fail to create the client on LeaderNotAvailable

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,7 +63,13 @@ func NewClient(id string, addrs []string, config *ClientConfig) (*Client, error)
 
 	// do an initial fetch of all cluster metadata by specifing an empty list of topics
 	err := client.RefreshAllMetadata()
-	if err != nil {
+	switch err {
+	case nil:
+		break
+	case LeaderNotAvailable:
+		// indicates that maybe part of the cluster is down, but is not fatal to creating the client
+		Logger.Println(err)
+	default:
 		client.Close()
 		return nil, err
 	}


### PR DESCRIPTION
It indicates that part of the cluster is probably down, but it shouldn't be
fatal.

@wvanbergen this was reported to me via private email, I've asked them to file a real ticket but if I understood correctly this is the right fix. A lot of people are on vacation - who else should I ping for a review?
