### PR TITLE
Add default replication to vagrant setup

### DIFF
--- a/vagrant/server.properties
+++ b/vagrant/server.properties
@@ -62,6 +62,10 @@ log.dirs=KAFKA_DATADIR
 # the brokers.
 num.partitions=2
 
+# Create new topics with a replication factor of 2 so failover can be tested
+# more easily.
+default.replication.factor=2
+
 ############################# Log Flush Policy #############################
 
 # Messages are immediately written to the filesystem but by default we only fsync() to sync


### PR DESCRIPTION
@wvanbergen @mkobetic doesn't solve anything, just makes it easier for our test setup to check failover-y things.
