### PR TITLE
consumer: silently skip messages already consumed

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -263,8 +263,8 @@ func (c *Consumer) fetchMessages() {
 			fetchSize = c.config.DefaultFetchSize
 		}
 
+		atLeastOne := false
 		for _, msgBlock := range block.MsgSet.Messages {
-			atLeastOne := false
 			prelude := true
 
 			for _, msg := range msgBlock.Messages() {
@@ -293,14 +293,15 @@ func (c *Consumer) fetchMessages() {
 				}
 			}
 
-			if !atLeastOne {
-				select {
-				case <-c.stopper:
-					close(c.events)
-					close(c.done)
-					return
-				case c.events <- &ConsumerEvent{Topic: c.topic, Partition: c.partition, Err: IncompleteResponse}:
-				}
+		}
+
+		if !atLeastOne {
+			select {
+			case <-c.stopper:
+				close(c.events)
+				close(c.done)
+				return
+			case c.events <- &ConsumerEvent{Topic: c.topic, Partition: c.partition, Err: IncompleteResponse}:
 			}
 		}
 	}

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -137,8 +137,11 @@ func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value En
 		partitions = make(map[int32]*FetchResponseBlock)
 		fr.Blocks[topic] = partitions
 	}
-	frb := new(FetchResponseBlock)
-	partitions[partition] = frb
+	frb, ok := partitions[partition]
+	if !ok {
+		frb = new(FetchResponseBlock)
+		partitions[partition] = frb
+	}
 	var kb []byte
 	var vb []byte
 	if key != nil {
@@ -147,9 +150,7 @@ func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value En
 	if value != nil {
 		vb, _ = value.Encode()
 	}
-	var msgSet MessageSet
 	msg := &Message{Key: kb, Value: vb}
 	msgBlock := &MessageBlock{Msg: msg, Offset: offset}
-	msgSet.Messages = append(msgSet.Messages, msgBlock)
-	frb.MsgSet = msgSet
+	frb.MsgSet.Messages = append(frb.MsgSet.Messages, msgBlock)
 }


### PR DESCRIPTION
It seems that sometimes the broker can return us messages we've already seen,
and that this is legitimate, so we shouldn't produce errors, just quietly ignore
them.

Possibly fixes #166 pending confirmation from upstream
(https://issues.apache.org/jira/browse/KAFKA-1744).

@Melraidin @wvanbergen 
