### PR TITLE
Concurrent metadata refresh

### DIFF
--- a/client.go
+++ b/client.go
@@ -311,16 +311,14 @@ func (client *Client) refreshMetadata(topics []string, retries int) error {
 		return err
 	default:
 		// means all brokers are timedout... At what level should we disconnect a broker?
-
-	}
-
-	if retries > 0 {
-		Logger.Printf("Out of available brokers. Resurrecting dead brokers after %dms... (%d retries remaining)\n", client.config.WaitForElection/time.Millisecond, retries)
-		time.Sleep(client.config.WaitForElection)
-		client.resurrectDeadBrokers()
-		return client.refreshMetadata(topics, retries-1)
-	} else {
-		Logger.Printf("Out of available brokers.\n")
+		if retries > 0 {
+			Logger.Printf("Out of available brokers. Resurrecting dead brokers after %dms... (%d retries remaining)\n", client.config.WaitForElection/time.Millisecond, retries)
+			time.Sleep(client.config.WaitForElection)
+			client.resurrectDeadBrokers()
+			return client.refreshMetadata(topics, retries-1)
+		} else {
+			Logger.Printf("Out of available brokers.\n")
+		}
 	}
 
 	return OutOfBrokers

--- a/client.go
+++ b/client.go
@@ -348,17 +348,6 @@ func (client *Client) resurrectDeadBrokers() {
 	client.seedBroker.Open(client.config.DefaultBrokerConf)
 }
 
-func (client *Client) any() *Broker {
-	client.lock.RLock()
-	defer client.lock.RUnlock()
-
-	for _, broker := range client.brokers {
-		return broker
-	}
-
-	return client.seedBroker
-}
-
 func (client *Client) cachedLeader(topic string, partitionID int32) *Broker {
 	client.lock.RLock()
 	defer client.lock.RUnlock()

--- a/client_test.go
+++ b/client_test.go
@@ -1,8 +1,6 @@
 package sarama
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestDefaultClientConfigValidates(t *testing.T) {
 	config := NewClientConfig()
@@ -12,7 +10,6 @@ func TestDefaultClientConfigValidates(t *testing.T) {
 }
 
 func TestSimpleClient(t *testing.T) {
-
 	mb := NewMockBroker(t, 1)
 
 	mb.Returns(new(MetadataResponse))

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -52,7 +52,6 @@ func TestSimpleConsumer(t *testing.T) {
 			t.Error("Incorrect message offset!")
 		}
 	}
-
 }
 
 func TestConsumerRawOffset(t *testing.T) {

--- a/metadata_fanout.go
+++ b/metadata_fanout.go
@@ -1,0 +1,84 @@
+package sarama
+
+import "sync"
+
+type metadataFanout struct {
+	wg             sync.WaitGroup
+	cleanupWaiting sync.Once
+	initClose      sync.Once
+	resultChan     chan *fanoutResult
+	closeChan      chan struct{}
+	// Public channels
+	Get chan *fanoutResult
+	// optional channel to notify outside when clean up is complete
+	Done chan struct{}
+}
+
+type fanoutResult struct {
+	err      error
+	response *MetadataResponse
+}
+
+func newMetadataFanout() *metadataFanout {
+	f := &Fetcher{
+		wg:             sync.WaitGroup{},
+		cleanupWaiting: sync.Once{},
+		initClose:      sync.Once{},
+		closeChan:      make(chan struct{}),
+		resultChan:     make(chan *fanoutResult, 1),
+
+		Get:  make(chan *fanoutResult),
+		Done: make(chan struct{}),
+	}
+	go f.Listen()
+	return f
+}
+
+// Fetch is called by the thread initiating the fanout.
+// It "forks" and starts up the described worker.
+//
+// The Worker should implement its own timeout functionality
+//
+// TODO what should be the Format for the worker func?
+func (f *metadataFanout) Fetch(broker *Broker, clientId string, request *MetadataRequest) {
+	f.wg.Add(1)
+	f.cleanupWaiting.Do(func() { go f.waitAndCleanup(f.Done) })
+	go func(worker func() (string, error)) {
+		r, e := broker.GetMetadata(clientId, request)
+		select {
+		case <-f.closeChan:
+			f.wg.Done()
+		case f.resultChan <- &fanoutResult{
+			err:      e,
+			response: r,
+		}:
+		}
+	}(worker)
+}
+
+func (f *metadataFanout) waitAndCleanup(doneChan chan struct{}) {
+	// Wait until all workers have returned or a successful result has come
+	// and workers can shutdown
+	f.wg.Wait()
+	// then tell the listen loop to close
+	close(f.resultChan)
+	// and tell the outside we are cleaned up.
+	close(doneChan)
+}
+
+// Listen validates the results and initiates shutdown if there is a valid result.
+// If no valid result is found it emits the last failing result.
+func (f *metadataFanout) Listen() {
+	var lastResult *fanoutResult
+	for r := range f.resultChan {
+		f.wg.Done()
+		lastResult = r
+		if r.err == nil {
+			f.initClose.Do(func() {
+				close(f.closeChan)
+				f.Get <- r
+			})
+		}
+	}
+	f.Get <- lastResult
+}

--- a/metadata_fanout.go
+++ b/metadata_fanout.go
@@ -20,7 +20,7 @@ type fanoutResult struct {
 }
 
 func newMetadataFanout() *metadataFanout {
-	f := &Fetcher{
+	f := &metadataFanout{
 		wg:             sync.WaitGroup{},
 		cleanupWaiting: sync.Once{},
 		initClose:      sync.Once{},
@@ -43,7 +43,7 @@ func newMetadataFanout() *metadataFanout {
 func (f *metadataFanout) Fetch(broker *Broker, clientId string, request *MetadataRequest) {
 	f.wg.Add(1)
 	f.cleanupWaiting.Do(func() { go f.waitAndCleanup(f.Done) })
-	go func(worker func() (string, error)) {
+	go func(worker *Broker) {
 		r, e := broker.GetMetadata(clientId, request)
 		select {
 		case <-f.closeChan:
@@ -53,7 +53,7 @@ func (f *metadataFanout) Fetch(broker *Broker, clientId string, request *Metadat
 			response: r,
 		}:
 		}
-	}(worker)
+	}(broker)
 }
 
 func (f *metadataFanout) waitAndCleanup(doneChan chan struct{}) {

--- a/metadata_fanout_test.go
+++ b/metadata_fanout_test.go
@@ -86,10 +86,9 @@ func TestMetadataFanout(t *testing.T) {
 		},
 	}
 	for _, fetch := range fetchers {
-		func(ff metadataFetcher) {
-			f.Fetch(ff, "id1", &MetadataRequest{Topics: []string{"topics"}})
-		}(fetch)
+		f.Fetch(fetch, "id1", &MetadataRequest{Topics: []string{"topics"}})
 	}
+	go f.WaitAndCleanup()
 	result := <-f.GetResult
 	if result.err == expected.err && metadataResponseIdsEqual(result.response, expected.response) {
 		t.Errorf("expected %+v but got %+v\n", expected, result)
@@ -130,10 +129,9 @@ func TestMetadataFanoutAllErrored(t *testing.T) {
 		},
 	}
 	for _, fetch := range fetchers {
-		func(ff metadataFetcher) {
-			f.Fetch(ff, "id1", &MetadataRequest{Topics: []string{"topics"}})
-		}(fetch)
+		f.Fetch(fetch, "id1", &MetadataRequest{Topics: []string{"topics"}})
 	}
+	go f.WaitAndCleanup()
 	result := <-f.GetResult
 	if result.err == expected.err && metadataResponseIdsEqual(result.response, expected.response) {
 		t.Errorf("expected %+v but got %+v\n", expected, result)
@@ -173,10 +171,9 @@ func TestMetadataFanoutSingleConnection(t *testing.T) {
 		},
 	}
 	for _, fetch := range fetchers {
-		func(ff metadataFetcher) {
-			f.Fetch(ff, "id1", &MetadataRequest{Topics: []string{"topics"}})
-		}(fetch)
+		f.Fetch(fetch, "id1", &MetadataRequest{Topics: []string{"topics"}})
 	}
+	go f.WaitAndCleanup()
 	result := <-f.GetResult
 	if result.err == expected.err && metadataResponseIdsEqual(result.response, expected.response) {
 		t.Errorf("expected %+v but got %+v\n", expected, result)

--- a/metadata_fanout_test.go
+++ b/metadata_fanout_test.go
@@ -117,7 +117,7 @@ func TestMetadataFanoutAllErrored(t *testing.T) {
 	}
 	result := <-f.Get
 	if result.err == expected.err && metadataResponseIdsEqual(result.response, expected.response) {
-		t.Errorf("expected %+v but got %+v\n", expected.response.Brokers[0], result.response.Brokers[0])
+		t.Errorf("expected %+v but got %+v\n", expected, result)
 	}
 	<-f.Done
 }

--- a/metadata_fanout_test.go
+++ b/metadata_fanout_test.go
@@ -1,0 +1,123 @@
+package sarama
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+type mockMetadataFetcher struct {
+	e  error
+	id int32
+	t  time.Duration
+}
+
+func (m *mockMetadataFetcher) GetMetadata(clientId string, request *MetadataRequest) (*MetadataResponse, error) {
+	time.Sleep(m.t)
+	if m.e != nil {
+		return &MetadataResponse{
+			Brokers: []*Broker{
+				&Broker{
+					id: m.id,
+				},
+			},
+		}, m.e
+	}
+	return &MetadataResponse{
+		Brokers: []*Broker{
+			&Broker{
+				id: m.id,
+			},
+		},
+	}, nil
+}
+
+func metadataResponseIdsEqual(r1 *MetadataResponse, r2 *MetadataResponse) bool {
+	if len(r1.Brokers) != len(r2.Brokers) {
+		return false
+	}
+	if len(r1.Brokers) < 1 {
+		return true
+	}
+	for idx, i := range r1.Brokers {
+		if i != r2.Brokers[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMetadataFanout(t *testing.T) {
+	f := newMetadataFanout()
+	expected := fanoutResult{
+		response: &MetadataResponse{
+			Brokers: []*Broker{
+				&Broker{
+					id: 1,
+				},
+			},
+		},
+	}
+	for _, fetch := range []mockMetadataFetcher{
+		mockMetadataFetcher{
+			id: 1,
+			t:  10 * time.Millisecond,
+		},
+		mockMetadataFetcher{
+			id: 2,
+			e:  errors.New("timeed out"),
+			t:  5 * time.Millisecond,
+		},
+		mockMetadataFetcher{
+			id: 3,
+			t:  15 * time.Millisecond,
+		},
+	} {
+		ff := fetch
+		f.Fetch(&ff, "id1", &MetadataRequest{Topics: []string{"topics"}})
+	}
+	result := <-f.Get
+	if result.err == expected.err && metadataResponseIdsEqual(result.response, expected.response) {
+		t.Errorf("expected %+v but got %+v\n", expected, result)
+	}
+	<-f.Done
+}
+
+func TestMetadataFanoutAllErrored(t *testing.T) {
+	f := newMetadataFanout()
+	expected := fanoutResult{
+		err: errors.New("timeed out"),
+		response: &MetadataResponse{
+			Brokers: []*Broker{
+				&Broker{
+					id: 3,
+				},
+			},
+		},
+	}
+	for _, fetch := range []mockMetadataFetcher{
+		mockMetadataFetcher{
+			id: 1,
+			e:  errors.New("timeed out"),
+			t:  10 * time.Millisecond,
+		},
+		mockMetadataFetcher{
+			id: 2,
+			e:  errors.New("timeed out"),
+			t:  5 * time.Millisecond,
+		},
+		mockMetadataFetcher{
+			e:  errors.New("timeed out"),
+			id: 3,
+			t:  15 * time.Millisecond,
+		},
+	} {
+		ff := fetch
+		f.Fetch(&ff, "id1", &MetadataRequest{Topics: []string{"topics"}})
+	}
+	result := <-f.Get
+	if result.err == expected.err && metadataResponseIdsEqual(result.response, expected.response) {
+		t.Errorf("expected %+v but got %+v\n", expected.response.Brokers[0], result.response.Brokers[0])
+	}
+	<-f.Done
+}

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"runtime"
 	"strconv"
 )
 
@@ -104,6 +105,7 @@ func (b *MockBroker) serverLoop() (ok bool) {
 		if _, err = conn.Write(response); err != nil {
 			return b.serverError(err, conn)
 		}
+
 	}
 	if err = conn.Close(); err != nil {
 		return b.serverError(err, nil)
@@ -116,6 +118,9 @@ func (b *MockBroker) serverLoop() (ok bool) {
 }
 
 func (b *MockBroker) serverError(err error, conn net.Conn) bool {
+	buf := make([]byte, 1024)
+	n := runtime.Stack(buf, false)
+	Logger.Println(buf[:n])
 	b.t.Error(err)
 	if conn != nil {
 		conn.Close()


### PR DESCRIPTION
Changes broker metadata to refresh concurrently rather than sequentially. If all brokers error out the last call to `Broker.GetMetadata(...)` that returned an error is exposed and the client enters the resurrection retry loop.

This also make users of `sarama.Client` (e.g. consumer/producer) be solely responsible for disconnecting brokers who timeout or misbehave. 


Related to https://github.com/Shopify/sarama/issues/15