### PR TITLE
fix connErr panic while NewClient fail

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -101,6 +101,7 @@ func (b *Broker) Open(conf *BrokerConfig) error {
 
 		b.conn, b.connErr = net.DialTimeout("tcp", b.addr, conf.DialTimeout)
 		if b.connErr != nil {
+			b.conn = nil
 			Logger.Printf("Failed to connect to broker %s\n", b.addr)
 			Logger.Println(b.connErr)
 			return


### PR DESCRIPTION
I use the driver and write a simple example like this:

```
package main

import (
    "fmt"
    kafka "github.com/yqylovy/sarama"
)

func main() {
    // kafka.NewClient("my_client1", []string{"192.168.10.28:9092"}, nil)
    _, err := kafka.NewClient("my_client1", []string{"192.168.10.28:9092"}, nil)
    if err != nil {
        fmt.Println("A ERROR:" + err.Error())
        return
    } else {
        fmt.Println("> connected")
        // defer client.Close()
    }
}
```

however,it panic while I run it 

```
panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x18 pc=0x439e53]

    goroutine 1 [running]:
    runtime.panic(0x535640, 0x6e0b68)
        /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
    github.com/Shopify/sarama.(*Broker).send(0xc210059120, 0x56d5b0, 0xa, 0x7f6b1bdf02b8, 0xc21004d180, ...)
        /usr/share/go/src/github.com/Shopify/sarama/broker.go:275 +0x243
    github.com/Shopify/sarama.(*Broker).sendAndReceive(0xc210059120, 0x56d5b0, 0xa, 0x7f6b1bdf02b8, 0xc21004d180, ...)
        /usr/share/go/src/github.com/Shopify/sarama/broker.go:297 +0x7a
    github.com/Shopify/sarama.(*Broker).GetMetadata(0xc210059120, 0x56d5b0, 0xa, 0xc21004d180, 0x1, ...)
        /usr/share/go/src/github.com/Shopify/sarama/broker.go:171 +0xa2
    github.com/Shopify/sarama.(*Client).refreshMetadata(0xc21005c000, 0x6ed000, 0x0, 0x0, 0x3, ...)
        /usr/share/go/src/github.com/Shopify/sarama/client.go:279 +0x21b
    github.com/Shopify/sarama.(*Client).RefreshAllMetadata(0xc21005c000, 0x0, 0x0)
        /usr/share/go/src/github.com/Shopify/sarama/client.go:192 +0x65
    github.com/Shopify/sarama.NewClient(0x56d5b0, 0xa, 0xc21000a3f0, 0x1, 0x1, ...)
        /usr/share/go/src/github.com/Shopify/sarama/client.go:67 +0x39d
    main.main()
        /root/workspace/src/test/test_kafka2.go:11 +0xaf
```

So I modify the connErr judgement to make it avoid panic and output  `kafka: Client has run out of available brokers to talk to. Is your cluster reachable?`
