### PR TITLE
Check more errors

### DIFF
--- a/partitioner.go
+++ b/partitioner.go
@@ -74,7 +74,10 @@ func (p *HashPartitioner) Partition(key Encoder, numPartitions int32) int32 {
 		return p.random.Partition(key, numPartitions)
 	}
 	p.hasher.Reset()
-	p.hasher.Write(bytes)
+	_, err = p.hasher.Write(bytes)
+	if err != nil {
+		return p.random.Partition(key, numPartitions)
+	}
 	hash := int32(p.hasher.Sum32())
 	if hash < 0 {
 		hash = -hash

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "io"
+
 // make []int32 sortable so we can sort partition numbers
 type int32Slice []int32
 
@@ -25,6 +27,15 @@ func withRecover(fn func()) {
 	}()
 
 	fn()
+}
+
+func safeAsyncClose(c io.Closer) {
+	tmp := c // local var prevents clobbering in goroutine
+	go withRecover(func() {
+		if err := tmp.Close(); err != nil {
+			Logger.Println("Error closing", tmp, ":", err)
+		}
+	})
 }
 
 // Encoder is a simple interface for any type that can be encoded as an array of bytes


### PR DESCRIPTION
Caught by errcheck. All remaining errcheck warnings have been audited and are
harmless (mostly because Broker.Open returns such a limited set of errors).

@wvanbergen 
