### PR TITLE
prod: drain successes on close just like errors

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -208,15 +208,15 @@ func (p *Producer) Input() chan<- *MessageToSend {
 // it may otherwise leak memory. You must call this before calling Close on the
 // underlying client.
 func (p *Producer) Close() error {
-	go func() {
+	go withRecover(func() {
 		p.input <- &MessageToSend{flags: shutdown}
-	}()
+	})
 
 	if p.config.AckSuccesses {
-		go func() {
+		go withRecover(func() {
 			for _ = range p.successes {
 			}
-		}()
+		})
 	}
 
 	var errors ProduceErrors


### PR DESCRIPTION
We kindly drain the errors channel on close so that users who stop reading from
it when calling close (e.g. in a defer) don't hang. We should do the same thing
for the successes channel when AckSuccesses is defined.

May or may not fix the bug reported tangentially at the bottom of
https://github.com/Shopify/sarama/issues/180#issuecomment-63127314
where shutting down with AckSuccesses could be very slow.

@wvanbergen 
