### PR TITLE
Make withRecover raceless for real

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -19,9 +19,10 @@ func (slice int32Slice) Swap(i, j int) {
 
 func withRecover(fn func()) {
 	defer func() {
-		if PanicHandler != nil {
+		handler := PanicHandler
+		if handler != nil {
 			if err := recover(); err != nil {
-				PanicHandler(err)
+				handler(err)
 			}
 		}
 	}()


### PR DESCRIPTION
Properly fixes #52 this time.

Almost exactly a year ago (+ 3 days) when Flo added the withRecover function we
discussed how if the user set/unset the PanicHandler in time with an actual
panic they could cause secondary panics and weirdness. We decided putting a
mutex in was overkill and closed the issue.

It just occurred to me that there is a 1000x better fix, which is to just cache
the handler value locally so we know we're calling the same value we do our
nil-check on. Duh. I'm not sure why neither of us thought of this at the time...

@fw42 @wvanbergen 
