### PR TITLE
Address some golint suggestions

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -463,7 +463,7 @@ func (w *brokerConsumer) subscriptionConsumer() {
 			return
 		}
 
-		for child, _ := range w.subscriptions {
+		for child := range w.subscriptions {
 			block := response.GetBlock(child.topic, child.partition)
 			if block == nil {
 				child.sendError(IncompleteResponse)
@@ -483,7 +483,7 @@ func (w *brokerConsumer) updateSubscriptionCache(newSubscriptions []*PartitionCo
 		w.subscriptions[child] = none{}
 	}
 
-	for child, _ := range w.subscriptions {
+	for child := range w.subscriptions {
 		select {
 		case <-child.dying:
 			close(child.trigger)
@@ -497,7 +497,7 @@ func (w *brokerConsumer) abort(err error) {
 	_ = w.broker.Close() // we don't care about the error this might return, we already have one
 	w.consumer.client.disconnectBroker(w.broker)
 
-	for child, _ := range w.subscriptions {
+	for child := range w.subscriptions {
 		child.sendError(err)
 		child.trigger <- none{}
 	}
@@ -516,7 +516,7 @@ func (w *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 		MaxWaitTime: int32(w.consumer.config.MaxWaitTime / time.Millisecond),
 	}
 
-	for child, _ := range w.subscriptions {
+	for child := range w.subscriptions {
 		request.AddBlock(child.topic, child.partition, child.offset, child.fetchSize)
 	}
 

--- a/consumer_metadata_response.go
+++ b/consumer_metadata_response.go
@@ -2,7 +2,7 @@ package sarama
 
 type ConsumerMetadataResponse struct {
 	Err             KError
-	CoordinatorId   int32
+	CoordinatorID   int32
 	CoordinatorHost string
 	CoordinatorPort int32
 }
@@ -14,7 +14,7 @@ func (r *ConsumerMetadataResponse) decode(pd packetDecoder) (err error) {
 	}
 	r.Err = KError(tmp)
 
-	r.CoordinatorId, err = pd.getInt32()
+	r.CoordinatorID, err = pd.getInt32()
 	if err != nil {
 		return err
 	}

--- a/consumer_metadata_response_test.go
+++ b/consumer_metadata_response_test.go
@@ -25,7 +25,7 @@ func TestConsumerMetadataResponseError(t *testing.T) {
 		t.Error("Decoding produced incorrect error value.")
 	}
 
-	if response.CoordinatorId != 0 {
+	if response.CoordinatorID != 0 {
 		t.Error("Decoding produced incorrect ID.")
 	}
 
@@ -47,7 +47,7 @@ func TestConsumerMetadataResponseSuccess(t *testing.T) {
 		t.Error("Decoding produced error value where there was none.")
 	}
 
-	if response.CoordinatorId != 0xAB {
+	if response.CoordinatorID != 0xAB {
 		t.Error("Decoding produced incorrect coordinator ID.")
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -10,15 +10,15 @@ import (
 var OutOfBrokers = errors.New("kafka: Client has run out of available brokers to talk to. Is your cluster reachable?")
 
 // ClosedClient is the error returned when a method is called on a client that has been closed.
-var ClosedClient = errors.New("kafka: Tried to use a client that was closed.")
+var ClosedClient = errors.New("kafka: Tried to use a client that was closed")
 
 // IncompleteResponse is the error returned when the server returns a syntactically valid response, but it does
 // not contain the expected information.
-var IncompleteResponse = errors.New("kafka: Response did not contain all the expected topic/partition blocks.")
+var IncompleteResponse = errors.New("kafka: Response did not contain all the expected topic/partition blocks")
 
 // InvalidPartition is the error returned when a partitioner returns an invalid partition index
 // (meaning one outside of the range [0...numPartitions-1]).
-var InvalidPartition = errors.New("kafka: Partitioner returned an invalid partition index.")
+var InvalidPartition = errors.New("kafka: Partitioner returned an invalid partition index")
 
 // AlreadyConnected is the error returned when calling Open() on a Broker that is already connected.
 var AlreadyConnected = errors.New("kafka: broker: already connected")
@@ -28,15 +28,15 @@ var NotConnected = errors.New("kafka: broker: not connected")
 
 // EncodingError is returned from a failure while encoding a Kafka packet. This can happen, for example,
 // if you try to encode a string over 2^15 characters in length, since Kafka's encoding rules do not permit that.
-var EncodingError = errors.New("kafka: Error while encoding packet.")
+var EncodingError = errors.New("kafka: Error while encoding packet")
 
 // InsufficientData is returned when decoding and the packet is truncated. This can be expected
 // when requesting messages, since as an optimization the server is allowed to return a partial message at the end
 // of the message set.
-var InsufficientData = errors.New("kafka: Insufficient data to decode packet, more bytes expected.")
+var InsufficientData = errors.New("kafka: Insufficient data to decode packet, more bytes expected")
 
 // ShuttingDown is returned when a producer receives a message during shutdown.
-var ShuttingDown = errors.New("kafka: Message received by producer in process of shutting down.")
+var ShuttingDown = errors.New("kafka: Message received by producer in process of shutting down")
 
 // DecodingError is returned when there was an error (other than truncated data) decoding the Kafka broker's response.
 // This can be a bad CRC or length field, or any other invalid value.

--- a/snappy.go
+++ b/snappy.go
@@ -16,9 +16,11 @@ func snappyEncode(src []byte) ([]byte, error) {
 // SnappyDecode decodes snappy data
 func snappyDecode(src []byte) ([]byte, error) {
 	if bytes.Equal(src[:8], snappyMagic) {
-		pos := uint32(16)
-		max := uint32(len(src))
-		dst := make([]byte, 0)
+		var (
+			pos = uint32(16)
+			max = uint32(len(src))
+			dst []byte
+		)
 		for pos < max {
 			size := binary.BigEndian.Uint32(src[pos : pos+4])
 			pos = pos + 4


### PR DESCRIPTION
- Error strings should not end with a dot.
- No need for `else` when if clause has return statement.
- Exported constants should be documented.
- Some minor changes about variables.

The following glint suggestions have not been implemented.
- Document all methods, or do not export them.
- Error variables should start with Err.

@eapache 