### PR TITLE
Replace successes channel with individual promises

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -85,7 +85,6 @@ func TestFuncMultiPartitionProduce(t *testing.T) {
 	config.FlushFrequency = 50 * time.Millisecond
 	config.FlushMsgCount = 200
 	config.ChannelBufferSize = 20
-	config.AckSuccesses = true
 	producer, err := NewProducer(client, config)
 	if err != nil {
 		t.Fatal(err)
@@ -98,12 +97,16 @@ func TestFuncMultiPartitionProduce(t *testing.T) {
 
 		go func(i int, w *sync.WaitGroup) {
 			defer w.Done()
-			msg := &MessageToSend{Topic: "multi_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("hur %d", i))}
+			promise := make(chan error)
+			msg := &MessageToSend{Topic: "multi_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("hur %d", i)), Promise: promise}
 			producer.Input() <- msg
 			select {
 			case ret := <-producer.Errors():
 				t.Fatal(ret.Err)
-			case <-producer.Successes():
+			case err := <-promise:
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 		}(i, &wg)
 	}
@@ -132,30 +135,38 @@ func testProducingMessages(t *testing.T, config *ProducerConfig) {
 	}
 	defer safeClose(t, consumer)
 
-	config.AckSuccesses = true
 	producer, err := NewProducer(client, config)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expectedResponses := TestBatchSize
+	promise := make(chan error)
 	for i := 1; i <= TestBatchSize; {
-		msg := &MessageToSend{Topic: "single_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("testing %d", i))}
+		msg := &MessageToSend{Topic: "single_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("testing %d", i)), Promise: promise}
 		select {
 		case producer.Input() <- msg:
 			i++
 		case ret := <-producer.Errors():
 			t.Fatal(ret.Err)
-		case <-producer.Successes():
-			expectedResponses--
+		case err := <-promise:
+			if err != nil {
+				t.Fatal(err)
+			} else {
+				expectedResponses--
+			}
 		}
 	}
 	for expectedResponses > 0 {
 		select {
 		case ret := <-producer.Errors():
 			t.Fatal(ret.Err)
-		case <-producer.Successes():
-			expectedResponses--
+		case err := <-promise:
+			if err != nil {
+				t.Fatal(err)
+			} else {
+				expectedResponses--
+			}
 		}
 	}
 	err = producer.Close()

--- a/simple_producer.go
+++ b/simple_producer.go
@@ -1,14 +1,11 @@
 package sarama
 
-import "sync"
-
 // SimpleProducer publishes Kafka messages. It routes messages to the correct broker, refreshing metadata as appropriate,
 // and parses responses for errors. You must call Close() on a producer to avoid leaks, it may not be garbage-collected automatically when
 // it passes out of scope (this is in addition to calling Close on the underlying client, which is still necessary).
 type SimpleProducer struct {
 	producer *Producer
 	topic    string
-	m        sync.Mutex
 }
 
 // NewSimpleProducer creates a new SimpleProducer using the given client, topic and partitioner. If the
@@ -20,7 +17,6 @@ func NewSimpleProducer(client *Client, topic string, partitioner PartitionerCons
 	}
 
 	config := NewProducerConfig()
-	config.AckSuccesses = true
 	if partitioner != nil {
 		config.Partitioner = partitioner
 	}
@@ -36,18 +32,10 @@ func NewSimpleProducer(client *Client, topic string, partitioner PartitionerCons
 
 // SendMessage produces a message with the given key and value. To send strings as either key or value, see the StringEncoder type.
 func (sp *SimpleProducer) SendMessage(key, value Encoder) error {
-	sp.m.Lock()
-	defer sp.m.Unlock()
+	promise := make(chan error)
+	sp.producer.Input() <- &MessageToSend{Topic: sp.topic, Key: key, Value: value, Promise: promise}
 
-	sp.producer.Input() <- &MessageToSend{Topic: sp.topic, Key: key, Value: value}
-
-	// we always get one or the other because AckSuccesses is true
-	select {
-	case err := <-sp.producer.Errors():
-		return err.Err
-	case <-sp.producer.Successes():
-		return nil
-	}
+	return <-promise
 }
 
 // Close shuts down the producer and flushes any messages it may have buffered. You must call this function before


### PR DESCRIPTION
Makes tracking success of individual messages much simpler and friendly to
order-dependent things. Also provides a more efficient solution to the first
half of #187 (it lets us get rid of the mutex in SimpleProducer).

@pjvds @wvanbergen

this is not quite ready as-is:
- [ ] godoc needs updating
- [x] `retryMessages` needs to respect `Msg.Promise`
- [ ] replace `AckSuccesses` with `OnlyPromiseErrors` for users who don't care about nils on success
- [ ] needs a test where multiple distinct promise channels are used (verifying that the right successes/errors are sent on the right channels)
- [ ] needs a test where promise channels _aren't_ used

but those are easy if we can agree that this makes sense as a solution?
