### PR TITLE
Make maximum-parsable response size configurable

### DIFF
--- a/response_header.go
+++ b/response_header.go
@@ -7,14 +7,12 @@ type responseHeader struct {
 	correlationID int32
 }
 
-const maxMessageSize = 32 * 1024 * 1024 // 32MB
-
 func (r *responseHeader) decode(pd packetDecoder) (err error) {
 	r.length, err = pd.getInt32()
 	if err != nil {
 		return err
 	}
-	if r.length <= 4 || r.length > maxMessageSize {
+	if r.length <= 4 || r.length > MaxResponseSize {
 		return DecodingError{Info: fmt.Sprintf("Message too large or too small. Got %d", r.length)}
 	}
 

--- a/sarama.go
+++ b/sarama.go
@@ -32,3 +32,9 @@ var PanicHandler func(interface{})
 // with Kafka's default `socket.request.max.bytes`, which is the largest request the broker will attempt
 // to process.
 var MaxRequestSize uint32 = 100 * 1024 * 1024
+
+// MaxResponseSize is the maximum size (in bytes) of any response that Sarama will attempt to parse. If
+// a broker returns a response message larger than this value, Sarama will return a DecodingError. The
+// default of 100 MiB is aligned with Kafka's default `socket.request.max.bytes`, which is the largest
+// request the broker will attempt to process.
+var MaxResponseSize int32 = 100 * 1024 * 1024


### PR DESCRIPTION
Replace hard-coded maxMessageSize with a configurable MaxResponseSize to match
the already-configurable MaxRequestSize.

Fixes #216.

@wvanbergen @graemej 
