### PR TITLE
Preparatory steps for the new consumer

### DIFF
--- a/fetch_response.go
+++ b/fetch_response.go
@@ -128,6 +128,23 @@ func (fr *FetchResponse) GetBlock(topic string, partition int32) *FetchResponseB
 	return fr.Blocks[topic][partition]
 }
 
+func (fr *FetchResponse) AddError(topic string, partition int32, err KError) {
+	if fr.Blocks == nil {
+		fr.Blocks = make(map[string]map[int32]*FetchResponseBlock)
+	}
+	partitions, ok := fr.Blocks[topic]
+	if !ok {
+		partitions = make(map[int32]*FetchResponseBlock)
+		fr.Blocks[topic] = partitions
+	}
+	frb, ok := partitions[partition]
+	if !ok {
+		frb = new(FetchResponseBlock)
+		partitions[partition] = frb
+	}
+	frb.Err = err
+}
+
 func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value Encoder, offset int64) {
 	if fr.Blocks == nil {
 		fr.Blocks = make(map[string]map[int32]*FetchResponseBlock)

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 )
 
+type none struct{}
+
 // make []int32 sortable so we can sort partition numbers
 type int32Slice []int32
 


### PR DESCRIPTION
Some miscellaneous changes I found necessary while developing it, that have been
separated out so they can land first:
- define `type none struct{}` for convenience
- implement `FetchResponse.AddError()`
- prefer the seedBroker when fetching metadata, it makes client behaviour much
  more deterministic and easier to test in multi-broker setups

@wvanbergen @graemej @mkobetic @marc-barry 
