### PR TITLE
make it possible to configure inner Producer in SimpleProducer

### DIFF
--- a/simple_producer.go
+++ b/simple_producer.go
@@ -14,15 +14,17 @@ type spExpect struct {
 	result chan error
 }
 
-// NewSimpleProducer creates a new SimpleProducer using the given client, topic and partitioner. If the
-// partitioner is nil, messages are partitioned by the hash of the key
-// (or randomly if there is no key).
-func NewSimpleProducer(client *Client, topic string, partitioner PartitionerConstructor) (*SimpleProducer, error) {
+// NewSimpleProducerWithConfig is the same as NewSimpleProducer, except it
+// includes the option to set certain configuration parameters on the
+// underlying producer
+func NewSimpleProducerWithConfig(client *Client, topic string, partitioner PartitionerConstructor, config *ProducerConfig) (*SimpleProducer, error) {
 	if topic == "" {
 		return nil, ConfigurationError("Empty topic")
 	}
 
-	config := NewProducerConfig()
+	if config == nil {
+		config = NewProducerConfig()
+	}
 	config.AckSuccesses = true
 	if partitioner != nil {
 		config.Partitioner = partitioner
@@ -43,6 +45,14 @@ func NewSimpleProducer(client *Client, topic string, partitioner PartitionerCons
 	go withRecover(sp.matchResponses)
 
 	return sp, nil
+
+}
+
+// NewSimpleProducer creates a new SimpleProducer using the given client, topic and partitioner. If the
+// partitioner is nil, messages are partitioned by the hash of the key
+// (or randomly if there is no key).
+func NewSimpleProducer(client *Client, topic string, partitioner PartitionerConstructor) (*SimpleProducer, error) {
+	return NewSimpleProducerWithConfig(client, topic, partitioner, nil)
 }
 
 // SendMessage produces a message with the given key and value. To send strings as either key or value, see the StringEncoder type.

--- a/simple_producer.go
+++ b/simple_producer.go
@@ -17,7 +17,7 @@ type spExpect struct {
 // NewSimpleProducerWithConfig is the same as NewSimpleProducer, except it
 // includes the option to set certain configuration parameters on the
 // underlying producer
-func NewSimpleProducerWithConfig(client *Client, topic string, partitioner PartitionerConstructor, config *ProducerConfig) (*SimpleProducer, error) {
+func NewSimpleProducerWithConfig(client *Client, topic string, config *ProducerConfig) (*SimpleProducer, error) {
 	if topic == "" {
 		return nil, ConfigurationError("Empty topic")
 	}
@@ -26,9 +26,6 @@ func NewSimpleProducerWithConfig(client *Client, topic string, partitioner Parti
 		config = NewProducerConfig()
 	}
 	config.AckSuccesses = true
-	if partitioner != nil {
-		config.Partitioner = partitioner
-	}
 
 	prod, err := NewProducer(client, config)
 
@@ -45,14 +42,18 @@ func NewSimpleProducerWithConfig(client *Client, topic string, partitioner Parti
 	go withRecover(sp.matchResponses)
 
 	return sp, nil
-
 }
 
 // NewSimpleProducer creates a new SimpleProducer using the given client, topic and partitioner. If the
 // partitioner is nil, messages are partitioned by the hash of the key
 // (or randomly if there is no key).
 func NewSimpleProducer(client *Client, topic string, partitioner PartitionerConstructor) (*SimpleProducer, error) {
-	return NewSimpleProducerWithConfig(client, topic, partitioner, nil)
+	config := NewProducerConfig()
+	if partitioner != nil {
+		config.Partitioner = partitioner
+	}
+
+	return NewSimpleProducerWithConfig(client, topic, config)
 }
 
 // SendMessage produces a message with the given key and value. To send strings as either key or value, see the StringEncoder type.


### PR DESCRIPTION
This is a fairly simple PR. The underlying motivation is that we occasionally have larger messages, so we need to be able to configure `ProducerConfig.MaxMessageBytes`

The pre-existing behavior is preserved exactly as is, so this is fully backwards compatible.