### PR TITLE
producer: add warning about RequiredAcks>1

### DIFF
--- a/produce_request.go
+++ b/produce_request.go
@@ -1,7 +1,10 @@
 package sarama
 
 // RequiredAcks is used in Produce Requests to tell the broker how many replica acknowledgements
-// it must see before responding. Any positive int16 value is valid, or the constants defined here.
+// it must see before responding. Any of the constants defined here are valid. On broker versions
+// prior to 0.8.2.0 any other positive int16 is also valid (the broker will wait for that many
+// acknowledgements) but in 0.8.2.0 and later this will raise an exception (it has been replaced
+// by setting the `min.isr` value in the brokers configuration).
 type RequiredAcks int16
 
 const (

--- a/producer.go
+++ b/producer.go
@@ -43,6 +43,8 @@ func NewProducerConfig() *ProducerConfig {
 func (config *ProducerConfig) Validate() error {
 	if config.RequiredAcks < -1 {
 		return ConfigurationError("Invalid RequiredAcks")
+	} else if config.RequiredAcks > 1 {
+		Logger.Println("ProducerConfig.RequiredAcks > 1 is deprecated and will raise an exception with kafka >= 0.8.2.0.")
 	}
 
 	if config.Timeout < 0 {


### PR DESCRIPTION
Per https://groups.google.com/d/msg/kafka-clients/4dR2FeN9GKE/_I3WRMoF8AsJ

Setting it to a value > 1 will raise an exception in 0.8.2.0 and later, so
update the godoc and log a warning when validating such a configuration.

@wvanbergen @snormore @drdee 

cc @mkobetic @yagnik 