### PR TITLE
Don't fully trust kafka metadata errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -431,10 +431,11 @@ func (client *Client) cachedLeader(topic string, partitionID int32) (*Broker, er
 	if partitions != nil {
 		metadata, ok := partitions[partitionID]
 		if ok {
-			if metadata.Err == LeaderNotAvailable {
-				return nil, metadata.Err
+			b := client.brokers[metadata.Leader]
+			if b == nil {
+				return nil, LeaderNotAvailable
 			}
-			return client.brokers[metadata.Leader], nil
+			return b, nil
 		}
 	}
 


### PR DESCRIPTION
Verify that we really got a leader back, even in the case where the error is not
LeaderNotAvailable. Might solve #245.

@nsd20463 does this fix your bug? If so I will merge it, but I would also suggest filing a ticket upstream that Kafka should really return `LeaderNotAvailable` if it's not going to send us a broker.