### PR TITLE
Metadata interface{} field added to MessageToSend

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -153,6 +153,7 @@ const (
 type MessageToSend struct {
 	Topic      string
 	Key, Value Encoder
+	Metadata   interface{}
 
 	// these are filled in by the producer as the message is processed
 	offset    int64

--- a/producer.go
+++ b/producer.go
@@ -154,7 +154,7 @@ type MessageToSend struct {
 	Topic    string      // The Kafka topic for this message
 	Key      Encoder     // The partitioning key for this message. It must implement the Encoder interface. Pre-existing Encoders include StringEncoder and ByteEncoder
 	Value    Encoder     // The actual message to store in Kafka. It must implement the Encoder interface. Pre-existing Encoders include StringEncoder and ByteEncoder
-	Metadata interface{} // This field is used to hold arbitrary data you wish to include so it will be available when recieving on the Succcesses and Errors channels
+	Metadata interface{} // This field is used to hold arbitrary data you wish to include so it will be available when recieving on the Successes and Errors channels.  Sarma completely ignores this field and is only to be used for pass-through data.
 
 	// these are filled in by the producer as the message is processed
 	offset    int64

--- a/producer.go
+++ b/producer.go
@@ -154,7 +154,7 @@ type MessageToSend struct {
 	Topic    string      // The Kafka topic for this message
 	Key      Encoder     // The partitioning key for this message. It must implement the Encoder interface. Pre-existing Encoders include StringEncoder and ByteEncoder
 	Value    Encoder     // The actual message to store in Kafka. It must implement the Encoder interface. Pre-existing Encoders include StringEncoder and ByteEncoder
-	Metadata interface{} // This field is used to hold arbitrary data you wish to include so it will be available when recieving on the Successes and Errors channels.  Sarma completely ignores this field and is only to be used for pass-through data.
+	Metadata interface{} // This field is used to hold arbitrary data you wish to include so it will be available when receiving on the Successes and Errors channels.  Sarama completely ignores this field and is only to be used for pass-through data.
 
 	// these are filled in by the producer as the message is processed
 	offset    int64

--- a/producer.go
+++ b/producer.go
@@ -151,9 +151,10 @@ const (
 
 // MessageToSend is the collection of elements passed to the Producer in order to send a message.
 type MessageToSend struct {
-	Topic      string
-	Key, Value Encoder
-	Metadata   interface{}
+	Topic    string      // The Kafka topic for this message
+	Key      Encoder     // The partitioning key for this message. It must implement the Encoder interface. Pre-existing Encoders include StringEncoder and ByteEncoder
+	Value    Encoder     // The actual message to store in Kafka. It must implement the Encoder interface. Pre-existing Encoders include StringEncoder and ByteEncoder
+	Metadata interface{} // This field is used to hold arbitrary data you wish to include so it will be available when recieving on the Succcesses and Errors channels
 
 	// these are filled in by the producer as the message is processed
 	offset    int64


### PR DESCRIPTION
This simple change adds an additional interface{} field to the MessageToSend struct
named Metadata.  It is the intention of this field to allow clients to
attach arbitrary data of their choosing to the MessaageToSend so they
can retrieve that data in the Successes and Errors channels and not have
to do any sort of bookkeeping themselves.