### PR TITLE
client: recognize full-topic leader election

### DIFF
--- a/client.go
+++ b/client.go
@@ -528,7 +528,13 @@ func (client *Client) update(data *MetadataResponse) ([]string, error) {
 
 	var err error
 	for _, topic := range data.Topics {
-		if topic.Err != NoError {
+		switch topic.Err {
+		case NoError:
+			break
+		case LeaderNotAvailable:
+			toRetry[topic.Name] = true
+			continue
+		default:
 			err = topic.Err
 			continue
 		}


### PR DESCRIPTION
Apparently my assumption in 1b465e78c274a76c0a522272cac25e39ddaa0d07 was false,
and `LeaderNotAvailable` can also appear at the topic level (not just the
partition level).