### PR TITLE
Require a non-zero timeout when WaitForAll

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -53,6 +53,10 @@ func (config *ProducerConfig) Validate() error {
 		Logger.Println("ProducerConfig.Timeout only supports millisecond resolution; nanoseconds will be truncated.")
 	}
 
+	if config.RequiredAcks == WaitForAll && config.Timeout == 0 {
+		return ConfigurationError("If you WaitForAll you must specify a non-zero timeout to wait.")
+	}
+
 	if config.FlushMsgCount < 0 {
 		return ConfigurationError("Invalid FlushMsgCount")
 	}


### PR DESCRIPTION
Otherwise requests are almost bound to fail - there's no good reason for this
config.

@wvanbergen @drdee 