### PR TITLE
Handle ReplicaNotAvailable like LeaderNotAvailable when initializing a client

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,7 +70,7 @@ func NewClient(id string, addrs []string, config *ClientConfig) (*Client, error)
 	switch err {
 	case nil:
 		break
-	case LeaderNotAvailable:
+	case LeaderNotAvailable, ReplicaNotAvailable:
 		// indicates that maybe part of the cluster is down, but is not fatal to creating the client
 		Logger.Println(err)
 	default:


### PR DESCRIPTION
According to the logs, this was the cause of the kafka_sysv_mq_producer was not restarting during our testing. Apparently we already found that this caused issues when using LeaderNotAvailable (#144), and apparently ReplicaNotAvailable can happen to. We should handle them similarly

@Shopify/kafka 