### PR TITLE
Process partition metadata in event of topic-level error

### DIFF
--- a/client.go
+++ b/client.go
@@ -537,10 +537,8 @@ func (client *Client) update(data *MetadataResponse) ([]string, error) {
 			break
 		case LeaderNotAvailable:
 			toRetry[topic.Name] = true
-			continue
 		default:
 			err = topic.Err
-			continue
 		}
 
 		client.metadata[topic.Name] = make(map[int32]*PartitionMetadata, len(topic.Partitions))


### PR DESCRIPTION
As per 1b465e78c274a76c0a522272cac25e39ddaa0d07, "I can't think of a case where
the stale data from the last "complete" update is somehow more useful than the
up-to-date partial data."

@wvanbergen 