### PR TITLE
Fix flaky SimpleProducer test

### DIFF
--- a/producer_test.go
+++ b/producer_test.go
@@ -65,14 +65,15 @@ func TestConcurrentSimpleProducer(t *testing.T) {
 	response2 := new(ProduceResponse)
 	response2.AddTopicPartition("my_topic", 0, NoError)
 	broker2.Returns(response2)
-	broker2.Returns(response2)
 
 	client, err := NewClient("client_id", []string{broker1.Addr()}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	producer, err := NewSimpleProducer(client, nil)
+	config := NewProducerConfig()
+	config.FlushMsgCount = 100
+	producer, err := NewSimpleProducer(client, config)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This test failed randomly in an unrelated PR:
https://travis-ci.org/Shopify/sarama/jobs/50586636

Turns out we were relying on the go scheduler to end up batching 100 messages
into exactly two requests, which isn't guaranteed at all. Now that we can pass a
full config into the SimpleProducer, just set the FlushMsgCount and expect a
single request.

cc @wvanbergen @drdee @yagnik 