### PR TITLE
Add a test to make sure connection to a cluster that is completely down will return an error

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -43,6 +43,16 @@ func checkKafkaAvailability(t *testing.T) {
 	}
 }
 
+func TestFuncConnectionFailure(t *testing.T) {
+	config := NewClientConfig()
+	config.MetadataRetries = 1
+
+	_, err := NewClient("test", []string{"localhost:9000"}, config)
+	if err != OutOfBrokers {
+		t.Fatal("Expected returned error to be OutOfBrokers, but was: ", err)
+	}
+}
+
 func TestFuncProducing(t *testing.T) {
 	config := NewProducerConfig()
 	testProducingMessages(t, config)


### PR DESCRIPTION
@Shopify/kafka