### PR TITLE
[WIP] Unite MessageToSend and ConsumerEvent

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -32,7 +32,7 @@ func TestConsumerOffsetManual(t *testing.T) {
 
 	for i := 0; i <= 10; i++ {
 		fr := new(FetchResponse)
-		fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(i+1234))
+		fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(i+1234))
 		mb2.Returns(fr)
 	}
 
@@ -85,7 +85,7 @@ func TestConsumerLatestOffset(t *testing.T) {
 	mb2.Returns(or)
 
 	fr := new(FetchResponse)
-	fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), 0x010101)
+	fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, 0x010101)
 	mb2.Returns(fr)
 
 	client, err := NewClient("client_id", []string{mb1.Addr()}, nil)
@@ -129,12 +129,12 @@ func TestConsumerFunnyOffsets(t *testing.T) {
 	mb1.Returns(mdr)
 
 	fr := new(FetchResponse)
-	fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(1))
-	fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(3))
+	fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(1))
+	fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(3))
 	mb2.Returns(fr)
 
 	fr = new(FetchResponse)
-	fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(5))
+	fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(5))
 	mb2.Returns(fr)
 
 	client, err := NewClient("client_id", []string{mb1.Addr()}, nil)
@@ -222,7 +222,7 @@ func TestConsumerRebalancingMultiplePartitions(t *testing.T) {
 	// generate broker responses
 	fr := new(FetchResponse)
 	for i := 0; i < 4; i++ {
-		fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(i))
+		fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(i))
 	}
 	mb2.Returns(fr)
 
@@ -238,20 +238,20 @@ func TestConsumerRebalancingMultiplePartitions(t *testing.T) {
 
 	fr = new(FetchResponse)
 	for i := 0; i < 5; i++ {
-		fr.AddMessage("my_topic", 1, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(i))
+		fr.AddMessage("my_topic", 1, nil, []byte{0x00, 0x0E}, int64(i))
 	}
 	mb3.Returns(fr)
 
 	fr = new(FetchResponse)
 	for i := 0; i < 3; i++ {
-		fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(i+4))
-		fr.AddMessage("my_topic", 1, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(i+5))
+		fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(i+4))
+		fr.AddMessage("my_topic", 1, nil, []byte{0x00, 0x0E}, int64(i+5))
 	}
 	mb3.Returns(fr)
 
 	fr = new(FetchResponse)
 	for i := 0; i < 3; i++ {
-		fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(i+7))
+		fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(i+7))
 	}
 	fr.AddError("my_topic", 1, NotLeaderForPartition)
 	mb3.Returns(fr)
@@ -263,17 +263,17 @@ func TestConsumerRebalancingMultiplePartitions(t *testing.T) {
 	time.Sleep(5 * time.Millisecond) // dumbest way to force a particular response ordering
 
 	fr = new(FetchResponse)
-	fr.AddMessage("my_topic", 1, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(8))
-	fr.AddMessage("my_topic", 1, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(9))
+	fr.AddMessage("my_topic", 1, nil, []byte{0x00, 0x0E}, int64(8))
+	fr.AddMessage("my_topic", 1, nil, []byte{0x00, 0x0E}, int64(9))
 	mb2.Returns(fr)
 
 	// cleanup
 	fr = new(FetchResponse)
-	fr.AddMessage("my_topic", 1, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(10))
+	fr.AddMessage("my_topic", 1, nil, []byte{0x00, 0x0E}, int64(10))
 	mb2.Returns(fr)
 
 	fr = new(FetchResponse)
-	fr.AddMessage("my_topic", 0, nil, ByteEncoder([]byte{0x00, 0x0E}), int64(10))
+	fr.AddMessage("my_topic", 0, nil, []byte{0x00, 0x0E}, int64(10))
 	mb3.Returns(fr)
 
 	wg.Wait()

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -145,7 +145,7 @@ func (fr *FetchResponse) AddError(topic string, partition int32, err KError) {
 	frb.Err = err
 }
 
-func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value Encoder, offset int64) {
+func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value []byte, offset int64) {
 	if fr.Blocks == nil {
 		fr.Blocks = make(map[string]map[int32]*FetchResponseBlock)
 	}
@@ -159,15 +159,8 @@ func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value En
 		frb = new(FetchResponseBlock)
 		partitions[partition] = frb
 	}
-	var kb []byte
-	var vb []byte
-	if key != nil {
-		kb, _ = key.Encode()
-	}
-	if value != nil {
-		vb, _ = value.Encode()
-	}
-	msg := &Message{Key: kb, Value: vb}
+
+	msg := &Message{Key: key, Value: value}
 	msgBlock := &MessageBlock{Msg: msg, Offset: offset}
 	frb.MsgSet.Messages = append(frb.MsgSet.Messages, msgBlock)
 }

--- a/functional_test.go
+++ b/functional_test.go
@@ -108,7 +108,7 @@ func TestFuncMultiPartitionProduce(t *testing.T) {
 
 		go func(i int, w *sync.WaitGroup) {
 			defer w.Done()
-			msg := &ProducerMessage{Topic: "multi_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("hur %d", i))}
+			msg := &ProducerMessage{Topic: "multi_partition", Key: nil, Value: []byte(fmt.Sprintf("hur %d", i))}
 			producer.Input() <- msg
 			select {
 			case ret := <-producer.Errors():
@@ -151,7 +151,7 @@ func testProducingMessages(t *testing.T, config *ProducerConfig) {
 
 	expectedResponses := TestBatchSize
 	for i := 1; i <= TestBatchSize; {
-		msg := &ProducerMessage{Topic: "single_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("testing %d", i))}
+		msg := &ProducerMessage{Topic: "single_partition", Key: nil, Value: []byte(fmt.Sprintf("testing %d", i))}
 		select {
 		case producer.Input() <- msg:
 			i++

--- a/functional_test.go
+++ b/functional_test.go
@@ -108,7 +108,7 @@ func TestFuncMultiPartitionProduce(t *testing.T) {
 
 		go func(i int, w *sync.WaitGroup) {
 			defer w.Done()
-			msg := &MessageToSend{Topic: "multi_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("hur %d", i))}
+			msg := &ProducerMessage{Topic: "multi_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("hur %d", i))}
 			producer.Input() <- msg
 			select {
 			case ret := <-producer.Errors():
@@ -151,7 +151,7 @@ func testProducingMessages(t *testing.T, config *ProducerConfig) {
 
 	expectedResponses := TestBatchSize
 	for i := 1; i <= TestBatchSize; {
-		msg := &MessageToSend{Topic: "single_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("testing %d", i))}
+		msg := &ProducerMessage{Topic: "single_partition", Key: nil, Value: StringEncoder(fmt.Sprintf("testing %d", i))}
 		select {
 		case producer.Input() <- msg:
 			i++

--- a/partitioner_test.go
+++ b/partitioner_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func assertPartitioningConsistent(t *testing.T, partitioner Partitioner, key Encoder, numPartitions int32) {
+func assertPartitioningConsistent(t *testing.T, partitioner Partitioner, key []byte, numPartitions int32) {
 	choice, err := partitioner.Partition(key, numPartitions)
 	if err != nil {
 		t.Error(partitioner, err)
@@ -93,7 +93,7 @@ func TestHashPartitioner(t *testing.T) {
 	buf := make([]byte, 256)
 	for i := 1; i < 50; i++ {
 		rand.Read(buf)
-		assertPartitioningConsistent(t, partitioner, ByteEncoder(buf), 50)
+		assertPartitioningConsistent(t, partitioner, buf, 50)
 	}
 }
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const TestMessage = "ABC THE MESSAGE"
+var TestMessage = []byte("ABC THE MESSAGE")
 
 func TestDefaultProducerConfigValidates(t *testing.T) {
 	config := NewProducerConfig()
@@ -41,7 +41,7 @@ func TestSimpleProducer(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		err = producer.SendMessage("my_topic", nil, StringEncoder(TestMessage))
+		err = producer.SendMessage("my_topic", nil, TestMessage)
 		if err != nil {
 			t.Error(err)
 		}
@@ -83,7 +83,7 @@ func TestConcurrentSimpleProducer(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			err := producer.SendMessage("my_topic", nil, StringEncoder(TestMessage))
+			err := producer.SendMessage("my_topic", nil, TestMessage)
 			if err != nil {
 				t.Error(err)
 			}
@@ -125,7 +125,7 @@ func TestProducer(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage), Metadata: i}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: TestMessage, Metadata: i}
 	}
 	for i := 0; i < 10; i++ {
 		select {
@@ -180,7 +180,7 @@ func TestProducerMultipleFlushes(t *testing.T) {
 
 	for flush := 0; flush < 3; flush++ {
 		for i := 0; i < 5; i++ {
-			producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+			producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: TestMessage}
 		}
 		for i := 0; i < 5; i++ {
 			select {
@@ -238,7 +238,7 @@ func TestProducerMultipleBrokers(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: TestMessage}
 	}
 	for i := 0; i < 10; i++ {
 		select {
@@ -286,7 +286,7 @@ func TestProducerFailureRetry(t *testing.T) {
 	broker1.Close()
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: TestMessage}
 	}
 	response2 := new(ProduceResponse)
 	response2.AddTopicPartition("my_topic", 0, NotLeaderForPartition)
@@ -316,7 +316,7 @@ func TestProducerFailureRetry(t *testing.T) {
 	broker2.Close()
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: TestMessage}
 	}
 	broker3.Returns(response4)
 	for i := 0; i < 10; i++ {
@@ -355,7 +355,7 @@ func ExampleProducer() {
 
 	for {
 		select {
-		case producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder("testing 123")}:
+		case producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: []byte("testing 123")}:
 			fmt.Println("> message queued")
 		case err := <-producer.Errors():
 			panic(err.Err)
@@ -379,7 +379,7 @@ func ExampleSimpleProducer() {
 	defer producer.Close()
 
 	for {
-		err = producer.SendMessage("my_topic", nil, StringEncoder("testing 123"))
+		err = producer.SendMessage("my_topic", nil, []byte("testing 123"))
 		if err != nil {
 			panic(err)
 		} else {

--- a/producer_test.go
+++ b/producer_test.go
@@ -125,7 +125,7 @@ func TestProducer(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &MessageToSend{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage), Metadata: i}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage), Metadata: i}
 	}
 	for i := 0; i < 10; i++ {
 		select {
@@ -180,7 +180,7 @@ func TestProducerMultipleFlushes(t *testing.T) {
 
 	for flush := 0; flush < 3; flush++ {
 		for i := 0; i < 5; i++ {
-			producer.Input() <- &MessageToSend{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+			producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
 		}
 		for i := 0; i < 5; i++ {
 			select {
@@ -238,7 +238,7 @@ func TestProducerMultipleBrokers(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &MessageToSend{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
 	}
 	for i := 0; i < 10; i++ {
 		select {
@@ -286,7 +286,7 @@ func TestProducerFailureRetry(t *testing.T) {
 	broker1.Close()
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &MessageToSend{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
 	}
 	response2 := new(ProduceResponse)
 	response2.AddTopicPartition("my_topic", 0, NotLeaderForPartition)
@@ -316,7 +316,7 @@ func TestProducerFailureRetry(t *testing.T) {
 	broker2.Close()
 
 	for i := 0; i < 10; i++ {
-		producer.Input() <- &MessageToSend{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
 	}
 	broker3.Returns(response4)
 	for i := 0; i < 10; i++ {
@@ -355,7 +355,7 @@ func ExampleProducer() {
 
 	for {
 		select {
-		case producer.Input() <- &MessageToSend{Topic: "my_topic", Key: nil, Value: StringEncoder("testing 123")}:
+		case producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder("testing 123")}:
 			fmt.Println("> message queued")
 		case err := <-producer.Errors():
 			panic(err.Err)

--- a/simple_producer.go
+++ b/simple_producer.go
@@ -37,7 +37,7 @@ func NewSimpleProducer(client *Client, config *ProducerConfig) (*SimpleProducer,
 }
 
 // SendMessage produces a message to the given topic with the given key and value. To send strings as either key or value, see the StringEncoder type.
-func (sp *SimpleProducer) SendMessage(topic string, key, value Encoder) error {
+func (sp *SimpleProducer) SendMessage(topic string, key, value []byte) error {
 	msg := &ProducerMessage{Topic: topic, Key: key, Value: value}
 	expectation := &spExpect{msg: msg, result: make(chan error)}
 	sp.newExpectations <- expectation

--- a/simple_producer.go
+++ b/simple_producer.go
@@ -9,7 +9,7 @@ type SimpleProducer struct {
 }
 
 type spExpect struct {
-	msg    *MessageToSend
+	msg    *ProducerMessage
 	result chan error
 }
 
@@ -38,7 +38,7 @@ func NewSimpleProducer(client *Client, config *ProducerConfig) (*SimpleProducer,
 
 // SendMessage produces a message to the given topic with the given key and value. To send strings as either key or value, see the StringEncoder type.
 func (sp *SimpleProducer) SendMessage(topic string, key, value Encoder) error {
-	msg := &MessageToSend{Topic: topic, Key: key, Value: value}
+	msg := &ProducerMessage{Topic: topic, Key: key, Value: value}
 	expectation := &spExpect{msg: msg, result: make(chan error)}
 	sp.newExpectations <- expectation
 	sp.producer.Input() <- msg
@@ -48,7 +48,7 @@ func (sp *SimpleProducer) SendMessage(topic string, key, value Encoder) error {
 
 func (sp *SimpleProducer) matchResponses() {
 	newExpectations := sp.newExpectations
-	unmatched := make(map[*MessageToSend]chan error)
+	unmatched := make(map[*ProducerMessage]chan error)
 	unmatched[nil] = nil // prevent it from emptying entirely
 
 	for len(unmatched) > 0 {

--- a/utils.go
+++ b/utils.go
@@ -50,38 +50,3 @@ func safeAsyncClose(b *Broker) {
 		}
 	})
 }
-
-// Encoder is a simple interface for any type that can be encoded as an array of bytes
-// in order to be sent as the key or value of a Kafka message. Length() is provided as an
-// optimization, and must return the same as len() on the result of Encode().
-type Encoder interface {
-	Encode() ([]byte, error)
-	Length() int
-}
-
-// make strings and byte slices encodable for convenience so they can be used as keys
-// and/or values in kafka messages
-
-// StringEncoder implements the Encoder interface for Go strings so that you can do things like
-//	producer.SendMessage(nil, sarama.StringEncoder("hello world"))
-type StringEncoder string
-
-func (s StringEncoder) Encode() ([]byte, error) {
-	return []byte(s), nil
-}
-
-func (s StringEncoder) Length() int {
-	return len(s)
-}
-
-// ByteEncoder implements the Encoder interface for Go byte slices so that you can do things like
-//	producer.SendMessage(nil, sarama.ByteEncoder([]byte{0x00}))
-type ByteEncoder []byte
-
-func (b ByteEncoder) Encode() ([]byte, error) {
-	return b, nil
-}
-
-func (b ByteEncoder) Length() int {
-	return len(b)
-}


### PR DESCRIPTION
Start of #269.

1. New names: `ConsumerEvent` becomes `ConsumerMessage` and in the producer, `MessageToSend` becomes `ProducerMessage`. Once we're ready to unite it I'd like to simply call it `Message`, but right now that is in used internally for messages between client and broker. Can we find a new name for this, e.g. `BrokerMessage` or `ProtocolMessage`?

2. Remove encoder interface, and simply use `[]byte` for keys and values.

Still to resolve: `Metadata`, and `Err`.
