### PR TITLE
Set default producer request timeout to 10 seconds

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -35,6 +35,7 @@ func NewProducerConfig() *ProducerConfig {
 		RequiredAcks:    WaitForLocal,
 		MaxMessageBytes: 1000000,
 		RetryBackoff:    250 * time.Millisecond,
+		Timeout:         10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
This value should be at least the amount of time it takes for a non-responsive broker to be considered out of sync. The default value for that is 10 seconds. So I set it to 10 seconds, which matches the default setting of the JVM producer. Maybe we should set it a bit higher as a safety buffer?

@Shopify/kafka @mkobetic 