### PR TITLE
Don't use a RetryBackoff in tests

### DIFF
--- a/producer_test.go
+++ b/producer_test.go
@@ -279,6 +279,7 @@ func TestProducerFailureRetry(t *testing.T) {
 	config := NewProducerConfig()
 	config.FlushMsgCount = 10
 	config.AckSuccesses = true
+	config.RetryBackoff = 0
 	producer, err := NewProducer(client, config)
 	if err != nil {
 		t.Fatal(err)
@@ -357,6 +358,7 @@ func TestProducerBrokerBounce(t *testing.T) {
 	config := NewProducerConfig()
 	config.FlushMsgCount = 10
 	config.AckSuccesses = true
+	config.RetryBackoff = 0
 	producer, err := NewProducer(client, config)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
With mockbrokers we control the relevant ordering of messages and broker
starts/stops so it isn't necessary, all it does is slow down the tests and give
room for time-dependent behaviour to creep in.

Also shaves 500ms off the test suite.

cc @Shopify/kafka @Sirupsen 