### PR TITLE
Don't pre-emptively test the leader connectedness

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -378,11 +378,6 @@ func (p *Producer) leaderDispatcher(topic string, partition int32, input chan *M
 			return err
 		}
 
-		if _, err = leader.Connected(); err != nil {
-			p.client.disconnectBroker(leader)
-			return err
-		}
-
 		output = p.getBrokerWorker(leader)
 		return nil
 	}


### PR DESCRIPTION
Write a test, find a bug (well, not really).

Before multiple-retries were in place, I'd added this pre-emptive check for
leader connectedness in the leaderDispatcher so that if we got back stale
metadata we didn't bother going through the whole retry rigamarole and failing
anyways. Now that we have multiple-retries, this check is actually causing us to
short-circuit our retries in one case, which isn't nice. Since it isn't
necessary anymore, just remove it.

Discovered because the test I wrote for stale metadata tried to make more
metadata requests than I was expecting, and subsequently hung.

@Shopify/kafka 

P.S. I will fix all the tests to be understandable in a following PR, I promise.