### PR TITLE
Update producer's MaxRetries and RetryBackoff default values

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -28,8 +28,8 @@ type ProducerConfig struct {
 	MaxMessageBytes   int                    // The maximum permitted size of a message (defaults to 1000000). Equivalent to the broker's `message.max.bytes`.
 	MaxMessagesPerReq int                    // The maximum number of messages the producer will send in a single broker request. Defaults to 0 for unlimited. The global setting MaxRequestSize still applies. Similar to `queue.buffering.max.messages` in the JVM producer.
 	ChannelBufferSize int                    // The size of the buffers of the channels between the different goroutines (defaults to 256).
-	RetryBackoff      time.Duration          // The amount of time to wait for the cluster to elect a new leader before processing retries (defaults to 250ms). Similar to the retry.backoff.ms setting of the JVM producer.
-	MaxRetries        int                    // The total number of times to retry sending a message. Currently only supports 0 or 1 (the default). Similar to the message.send.max.retries setting of the JVM producer.
+	RetryBackoff      time.Duration          // The amount of time to wait for the cluster to elect a new leader before processing retries (defaults to 100ms). Similar to the retry.backoff.ms setting of the JVM producer.
+	MaxRetries        int                    // The total number of times to retry sending a message (defaults to 3). Similar to the message.send.max.retries setting of the JVM producer.
 }
 
 // NewProducerConfig creates a new ProducerConfig instance with sensible defaults.
@@ -39,9 +39,9 @@ func NewProducerConfig() *ProducerConfig {
 		RequiredAcks:      WaitForLocal,
 		MaxMessageBytes:   1000000,
 		ChannelBufferSize: 256,
-		RetryBackoff:      250 * time.Millisecond,
+		RetryBackoff:      100 * time.Millisecond,
 		Timeout:           10 * time.Second,
-		MaxRetries:        1,
+		MaxRetries:        3,
 	}
 }
 


### PR DESCRIPTION
Matches the default values of the JVM producer. Also updates godoc.

@Shopify/kafka 