### PR TITLE
Only log metadata retry refreshes when using a list of topics

### DIFF
--- a/client.go
+++ b/client.go
@@ -527,8 +527,6 @@ func (client *Client) refreshMetadata(topics []string, retriesRemaining int) err
 	for broker := client.any(); broker != nil; broker = client.any() {
 		if len(topics) > 0 {
 			Logger.Printf("Fetching metadata for %v from broker %s\n", topics, broker.addr)
-		} else {
-			Logger.Printf("Fetching metadata for all topics from broker %s\n", broker.addr)
 		}
 		response, err := broker.GetMetadata(client.id, &MetadataRequest{Topics: topics})
 


### PR DESCRIPTION
Right now, our logs are full of "starting metadata refresh" lines due to the 10 minute background refresh interval we have in place. This makes the logs noisy.

I think we only request the metadata for all topics:
- during startup
- during background refresh.

I think we can live without the logs in these cases.

Not sure if this is a good idea. @Shopify/kafka, what do you think?