### PR TITLE
Improve expectation API to allow for testing of more intricate scenarios

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -212,8 +212,8 @@ func TestSingleSlowBroker(t *testing.T) {
 	metadataResponse.AddTopicPartition("my_topic", 0, cluster[1].BrokerID(), []int32{cluster[1].BrokerID()}, []int32{cluster[1].BrokerID()}, NoError)
 	metadataResponse.AddTopicPartition("my_topic", 1, cluster[2].BrokerID(), []int32{cluster[2].BrokerID()}, []int32{cluster[2].BrokerID()}, NoError)
 
-	cluster[1].Expects(&BrokerExpectation{Response: metadataResponse, Latency: 500 * time.Millisecond}) // will timeout
-	cluster[2].Expects(&BrokerExpectation{Response: metadataResponse})                                  // will succeed
+	cluster[1].Expects(&BrokerExpectation{Response: metadataResponse, Latency: 500 * time.Millisecond, IgnoreServerErrors: true}) // will timeout
+	cluster[2].Expects(&BrokerExpectation{Response: metadataResponse})                                                            // will succeed
 
 	config := NewClientConfig()
 	config.DefaultBrokerConf = NewBrokerConfig()
@@ -232,8 +232,9 @@ func TestSlowCluster(t *testing.T) {
 	defer cluster.Close()
 
 	slowMetadataResponse := &BrokerExpectation{
-		Response: new(MetadataResponse),
-		Latency:  500 * time.Millisecond,
+		Response:           new(MetadataResponse),
+		Latency:            500 * time.Millisecond,
+		IgnoreServerErrors: true,
 	}
 
 	cluster[1].Expects(slowMetadataResponse)


### PR DESCRIPTION
This makes the API for mock broker expectations a bit more powerful. 

- Allow setting a latency for the response (this replaces the previous broker-wide latency setting)
- Allow setting a `Before` and `After` callback around the response.

Use these capabilities to add some tests:

- The first client tests asserts that if one broker times out, it will continue to use the second broker to discover metadata.
- The second client test will make sure that eventually `NewClient` will return an error if all brokers have high latency.
- Test the producer with multiple batches in flight at different retry levels.

@Shopify/kafka 