### PR TITLE
Make Broker.Open truly non-blocking

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,8 +20,8 @@ var ErrIncompleteResponse = errors.New("kafka: Response did not contain all the 
 // (meaning one outside of the range [0...numPartitions-1]).
 var ErrInvalidPartition = errors.New("kafka: Partitioner returned an invalid partition index")
 
-// ErrAlreadyConnected is the error returned when calling Open() on a Broker that is already connected.
-var ErrAlreadyConnected = errors.New("kafka: broker already connected")
+// ErrAlreadyConnected is the error returned when calling Open() on a Broker that is already connected or connecting.
+var ErrAlreadyConnected = errors.New("kafka: broker connection already initiated")
 
 // ErrNotConnected is the error returned when trying to send or call Close() on a Broker that is not connected.
 var ErrNotConnected = errors.New("kafka: broker not connected")


### PR DESCRIPTION
The intent behind the design was so that the method was always safe to call e.g.
when a lock was held, by making it async, however there were still certain cases
where it could have blocked:
 - if another thread had already called Open, subsequent calls would block until
   that network io completed
 - if the connection was already open *and* the pipeline was full
   (MaxOpenRequests were in flight) then calling Open would block until at least
   one response was received

This adds a simple atomic flag we can use to short-circuit appropriately, such
that Open should now have the following properties
 - it *never* blocks on network IO
 - it guarantees that the broker is connected or connecting when it returns
   (modulo another thread calling Close in the interim)

AFAICT these are the properties it needs for lazy broker connection to be
possible in the client.

@Shopify/kafka 