### PR TITLE
Lazily connect to brokers in the client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -28,15 +28,14 @@ func TestSimpleClient(t *testing.T) {
 
 func TestCachedPartitions(t *testing.T) {
 	seedBroker := newMockBroker(t, 1)
-	leader := newMockBroker(t, 5)
 
 	replicas := []int32{3, 1, 5}
 	isr := []int32{5, 1}
 
 	metadataResponse := new(MetadataResponse)
-	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
-	metadataResponse.AddTopicPartition("my_topic", 0, leader.BrokerID(), replicas, isr, ErrNoError)
-	metadataResponse.AddTopicPartition("my_topic", 1, leader.BrokerID(), replicas, isr, ErrLeaderNotAvailable)
+	metadataResponse.AddBroker("localhost:12345", 2)
+	metadataResponse.AddTopicPartition("my_topic", 0, 2, replicas, isr, ErrNoError)
+	metadataResponse.AddTopicPartition("my_topic", 1, 2, replicas, isr, ErrLeaderNotAvailable)
 	seedBroker.Returns(metadataResponse)
 
 	config := NewConfig()
@@ -61,17 +60,15 @@ func TestCachedPartitions(t *testing.T) {
 		t.Fatal("Not using the cache!")
 	}
 
-	leader.Close()
 	seedBroker.Close()
 	safeClose(t, client)
 }
 
 func TestClientSeedBrokers(t *testing.T) {
 	seedBroker := newMockBroker(t, 1)
-	discoveredBroker := newMockBroker(t, 2)
 
 	metadataResponse := new(MetadataResponse)
-	metadataResponse.AddBroker(discoveredBroker.Addr(), discoveredBroker.BrokerID())
+	metadataResponse.AddBroker("localhost:12345", 2)
 	seedBroker.Returns(metadataResponse)
 
 	client, err := NewClient([]string{seedBroker.Addr()}, nil)
@@ -79,7 +76,6 @@ func TestClientSeedBrokers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	discoveredBroker.Close()
 	seedBroker.Close()
 	safeClose(t, client)
 }


### PR DESCRIPTION
Instead of opening a connection to all brokers immediately upon receiving their
information in metadata, wait until we are asked for them either via a call to
`Leader` or a call to `any`.

It seems simple enough (simpler than I was expecting actually) but I'm a bit wary, since it changes the internal semantics so much. Strong opinions and careful review please.

@Shopify/kafka 