### PR TITLE
Drop official support for go 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.2
 - 1.3
 - 1.4
 - tip
@@ -17,8 +16,6 @@ before_install:
 - vagrant/install_cluster.sh
 - vagrant/boot_cluster.sh
 - vagrant/create_topics.sh
-- go install -a -race regexp # Fix for go 1.2
-- go get code.google.com/p/go.tools/cmd/vet || true # Fix for go 1.2
 - go get golang.org/x/tools/cmd/vet
 - go get github.com/kisielk/errcheck
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation is available via godoc at http://godoc.org/github.com/Shopify/sara
 
 There is a google group for Kafka client users and authors at https://groups.google.com/forum/#!forum/kafka-clients
 
-Sarama is compatible with Go 1.2, 1.3, and 1.4.
+Sarama is compatible with Go 1.3, and 1.4.
 
 A word of warning: the API is not 100% stable. It won't change much (in particular the low-level
 Broker and Request/Response objects could *probably* be considered frozen) but there may be the occasional


### PR DESCRIPTION
Should still work of course, but we don't care to test it anymore.

Part of #319 

@Shopify/kafka 