### PR TITLE
Consilidate refresh metadata methods into one

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -296,7 +296,7 @@ func (child *partitionConsumer) dispatcher() {
 }
 
 func (child *partitionConsumer) dispatch() error {
-	if err := child.consumer.client.RefreshTopicMetadata(child.topic); err != nil {
+	if err := child.consumer.client.RefreshMetadata(child.topic); err != nil {
 		return err
 	}
 

--- a/producer.go
+++ b/producer.go
@@ -312,7 +312,7 @@ func (p *producer) leaderDispatcher(topic string, partition int32, input chan *P
 
 	breaker := breaker.New(3, 1, 10*time.Second)
 	doUpdate := func() (err error) {
-		if err = p.client.RefreshTopicMetadata(topic); err != nil {
+		if err = p.client.RefreshMetadata(topic); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
1 method to rule them all. @Shopify/kafka 