### PR TITLE
Cleanup disconnectBroker a bit

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -177,7 +177,6 @@ func TestClientRefreshBehaviour(t *testing.T) {
 		t.Error("Leader for my_topic had incorrect ID.")
 	}
 
-	client.disconnectBroker(tst)
 	leader.Close()
 	seedBroker.Close()
 	safeClose(t, client)


### PR DESCRIPTION
- Remove the stale comment about how it sucks and shouldn't be public (it
  isn't).
- Remove a useless bit of logging.
- Move the `broker.Close()` call up to the caller, and make it synchronous now
  that it's not inside the lock.
- Remove a useless call to it inside tests.
- Add a comment explaining the next thing that should happen in order for it to
  go away completely.

cc @Shopify/kafka 