### PR TITLE
SyncProducer’s SendMessage accepts a sarama.ProducerMessage

### DIFF
--- a/mocks/sync_producer_test.go
+++ b/mocks/sync_producer_test.go
@@ -25,26 +25,25 @@ func TestSyncProducerReturnsExpectationsToSendMessage(t *testing.T) {
 	sp.ExpectSendMessageAndSucceed()
 	sp.ExpectSendMessageAndFail(sarama.ErrOutOfBrokers)
 
-	var err error
-
 	msg := &sarama.ProducerMessage{Topic: "test", Value: sarama.StringEncoder("test")}
-	err = sp.SendMessage(msg)
+
+	_, offset, err := sp.SendMessage(msg)
 	if err != nil {
 		t.Errorf("The first message should have been produced successfully, but got %s", err)
 	}
-	if msg.Offset != 1 {
+	if offset != 1 || offset != msg.Offset {
 		t.Errorf("The first message should have been assigned offset 1, but got %d", msg.Offset)
 	}
 
-	err = sp.SendMessage(msg)
+	_, offset, err = sp.SendMessage(msg)
 	if err != nil {
 		t.Errorf("The second message should have been produced successfully, but got %s", err)
 	}
-	if msg.Offset != 2 {
-		t.Errorf("The second message should have been assigned offset 2, but got %d", msg.Offset)
+	if offset != 2 || offset != msg.Offset {
+		t.Errorf("The second message should have been assigned offset 2, but got %d", offset)
 	}
 
-	err = sp.SendMessage(msg)
+	_, _, err = sp.SendMessage(msg)
 	if err != sarama.ErrOutOfBrokers {
 		t.Errorf("The third message should not have been produced successfully")
 	}
@@ -62,7 +61,7 @@ func TestSyncProducerWithTooManyExpectations(t *testing.T) {
 	sp.ExpectSendMessageAndFail(sarama.ErrOutOfBrokers)
 
 	msg := &sarama.ProducerMessage{Topic: "test", Value: sarama.StringEncoder("test")}
-	if err := sp.SendMessage(msg); err != nil {
+	if _, _, err := sp.SendMessage(msg); err != nil {
 		t.Error("No error expected on first SendMessage call", err)
 	}
 
@@ -82,10 +81,10 @@ func TestSyncProducerWithTooFewExpectations(t *testing.T) {
 	sp.ExpectSendMessageAndSucceed()
 
 	msg := &sarama.ProducerMessage{Topic: "test", Value: sarama.StringEncoder("test")}
-	if err := sp.SendMessage(msg); err != nil {
+	if _, _, err := sp.SendMessage(msg); err != nil {
 		t.Error("No error expected on first SendMessage call", err)
 	}
-	if err := sp.SendMessage(msg); err != errOutOfExpectations {
+	if _, _, err := sp.SendMessage(msg); err != errOutOfExpectations {
 		t.Error("errOutOfExpectations expected on second SendMessage call, found:", err)
 	}
 

--- a/mocks/sync_producer_test.go
+++ b/mocks/sync_producer_test.go
@@ -25,28 +25,26 @@ func TestSyncProducerReturnsExpectationsToSendMessage(t *testing.T) {
 	sp.ExpectSendMessageAndSucceed()
 	sp.ExpectSendMessageAndFail(sarama.ErrOutOfBrokers)
 
-	var (
-		offset int64
-		err    error
-	)
+	var err error
 
-	_, offset, err = sp.SendMessage("test", nil, sarama.StringEncoder("test"))
+	msg := &sarama.ProducerMessage{Topic: "test", Value: sarama.StringEncoder("test")}
+	err = sp.SendMessage(msg)
 	if err != nil {
 		t.Errorf("The first message should have been produced successfully, but got %s", err)
 	}
-	if offset != 1 {
-		t.Errorf("The first message should have been assigned offset 1, but got %d", offset)
+	if msg.Offset != 1 {
+		t.Errorf("The first message should have been assigned offset 1, but got %d", msg.Offset)
 	}
 
-	_, offset, err = sp.SendMessage("test", nil, sarama.StringEncoder("test"))
+	err = sp.SendMessage(msg)
 	if err != nil {
 		t.Errorf("The second message should have been produced successfully, but got %s", err)
 	}
-	if offset != 2 {
-		t.Errorf("The second message should have been assigned offset 2, but got %d", offset)
+	if msg.Offset != 2 {
+		t.Errorf("The second message should have been assigned offset 2, but got %d", msg.Offset)
 	}
 
-	_, offset, err = sp.SendMessage("test", nil, sarama.StringEncoder("test"))
+	err = sp.SendMessage(msg)
 	if err != sarama.ErrOutOfBrokers {
 		t.Errorf("The third message should not have been produced successfully")
 	}
@@ -63,7 +61,8 @@ func TestSyncProducerWithTooManyExpectations(t *testing.T) {
 	sp.ExpectSendMessageAndSucceed()
 	sp.ExpectSendMessageAndFail(sarama.ErrOutOfBrokers)
 
-	if _, _, err := sp.SendMessage("test", nil, sarama.StringEncoder("test")); err != nil {
+	msg := &sarama.ProducerMessage{Topic: "test", Value: sarama.StringEncoder("test")}
+	if err := sp.SendMessage(msg); err != nil {
 		t.Error("No error expected on first SendMessage call", err)
 	}
 
@@ -82,10 +81,11 @@ func TestSyncProducerWithTooFewExpectations(t *testing.T) {
 	sp := NewSyncProducer(trm, nil)
 	sp.ExpectSendMessageAndSucceed()
 
-	if _, _, err := sp.SendMessage("test", nil, sarama.StringEncoder("test")); err != nil {
+	msg := &sarama.ProducerMessage{Topic: "test", Value: sarama.StringEncoder("test")}
+	if err := sp.SendMessage(msg); err != nil {
 		t.Error("No error expected on first SendMessage call", err)
 	}
-	if _, _, err := sp.SendMessage("test", nil, sarama.StringEncoder("test")); err != errOutOfExpectations {
+	if err := sp.SendMessage(msg); err != errOutOfExpectations {
 		t.Error("errOutOfExpectations expected on second SendMessage call, found:", err)
 	}
 

--- a/sync_producer.go
+++ b/sync_producer.go
@@ -6,9 +6,10 @@ import "sync"
 // and parses responses for errors. You must call Close() on a producer to avoid leaks, it may not be garbage-collected automatically when
 // it passes out of scope (this is in addition to calling Close on the underlying client, which is still necessary).
 type SyncProducer interface {
-	// SendMessage produces a message to the given topic with the given key and value. To send strings as either key or value, see the StringEncoder type.
-	// It returns the partition and offset of the successfully-produced message, or the error (if any).
-	SendMessage(topic string, key, value Encoder) (partition int32, offset int64, err error)
+
+	// SendMessage produces a given message, and returns when it has succeeded or failed.
+	// It will set the OPartition and Offset fields for a successfully produced message.
+	SendMessage(*ProducerMessage) error
 
 	// Close shuts down the producer and flushes any messages it may have buffered. You must call this function before
 	// a producer object passes out of scope, as it may otherwise leak memory. You must call this before calling Close
@@ -51,14 +52,16 @@ func newSyncProducerFromAsyncProducer(p *asyncProducer) *syncProducer {
 	return sp
 }
 
-func (sp *syncProducer) SendMessage(topic string, key, value Encoder) (partition int32, offset int64, err error) {
+func (sp *syncProducer) SendMessage(msg *ProducerMessage) error {
+	oldMetadata := msg.Metadata
+	defer func() {
+		msg.Metadata = oldMetadata
+	}()
+
 	expectation := make(chan error, 1)
-	msg := &ProducerMessage{Topic: topic, Key: key, Value: value, Metadata: expectation}
+	msg.Metadata = expectation
 	sp.producer.Input() <- msg
-	err = <-expectation
-	partition = msg.Partition
-	offset = msg.Offset
-	return
+	return <-expectation
 }
 
 func (sp *syncProducer) handleSuccesses() {

--- a/sync_producer_test.go
+++ b/sync_producer_test.go
@@ -33,12 +33,12 @@ func TestSyncProducer(t *testing.T) {
 			Metadata: "test",
 		}
 
-		err := producer.SendMessage(msg)
+		partition, offset, err := producer.SendMessage(msg)
 
-		if msg.Partition != 0 {
+		if partition != 0 || msg.Partition != partition {
 			t.Error("Unexpected partition")
 		}
-		if msg.Offset != 0 {
+		if offset != 0 || msg.Offset != offset {
 			t.Error("Unexpected offset")
 		}
 		if str, ok := msg.Metadata.(string); !ok || str != "test" {
@@ -80,8 +80,8 @@ func TestConcurrentSyncProducer(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			msg := &ProducerMessage{Topic: "my_topic", Value: StringEncoder(TestMessage)}
-			err := producer.SendMessage(msg)
-			if msg.Partition != 0 {
+			partition, _, err := producer.SendMessage(msg)
+			if partition != 0 {
 				t.Error("Unexpected partition")
 			}
 			if err != nil {
@@ -110,10 +110,10 @@ func ExampleSyncProducer() {
 	}()
 
 	msg := &ProducerMessage{Topic: "my_topic", Value: StringEncoder("testing 123")}
-	err = producer.SendMessage(msg)
+	partition, offset, err := producer.SendMessage(msg)
 	if err != nil {
 		log.Printf("FAILED to send message: %s\n", err)
 	} else {
-		log.Printf("> message sent to partition %d at offset %d\n", msg.Partition, msg.Offset)
+		log.Printf("> message sent to partition %d at offset %d\n", partition, offset)
 	}
 }

--- a/sync_producer_test.go
+++ b/sync_producer_test.go
@@ -1,0 +1,119 @@
+package sarama
+
+import (
+	"log"
+	"sync"
+	"testing"
+)
+
+func TestSyncProducer(t *testing.T) {
+	seedBroker := newMockBroker(t, 1)
+	leader := newMockBroker(t, 2)
+
+	metadataResponse := new(MetadataResponse)
+	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+	metadataResponse.AddTopicPartition("my_topic", 0, leader.BrokerID(), nil, nil, ErrNoError)
+	seedBroker.Returns(metadataResponse)
+
+	prodSuccess := new(ProduceResponse)
+	prodSuccess.AddTopicPartition("my_topic", 0, ErrNoError)
+	for i := 0; i < 10; i++ {
+		leader.Returns(prodSuccess)
+	}
+
+	producer, err := NewSyncProducer([]string{seedBroker.Addr()}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		msg := &ProducerMessage{
+			Topic:    "my_topic",
+			Value:    StringEncoder(TestMessage),
+			Metadata: "test",
+		}
+
+		err := producer.SendMessage(msg)
+
+		if msg.Partition != 0 {
+			t.Error("Unexpected partition")
+		}
+		if msg.Offset != 0 {
+			t.Error("Unexpected offset")
+		}
+		if str, ok := msg.Metadata.(string); !ok || str != "test" {
+			t.Error("Unexpected metadata")
+		}
+		if err != nil {
+			t.Error(err)
+		}
+	}
+
+	safeClose(t, producer)
+	leader.Close()
+	seedBroker.Close()
+}
+
+func TestConcurrentSyncProducer(t *testing.T) {
+	seedBroker := newMockBroker(t, 1)
+	leader := newMockBroker(t, 2)
+
+	metadataResponse := new(MetadataResponse)
+	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+	metadataResponse.AddTopicPartition("my_topic", 0, leader.BrokerID(), nil, nil, ErrNoError)
+	seedBroker.Returns(metadataResponse)
+
+	prodSuccess := new(ProduceResponse)
+	prodSuccess.AddTopicPartition("my_topic", 0, ErrNoError)
+	leader.Returns(prodSuccess)
+
+	config := NewConfig()
+	config.Producer.Flush.Messages = 100
+	producer, err := NewSyncProducer([]string{seedBroker.Addr()}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			msg := &ProducerMessage{Topic: "my_topic", Value: StringEncoder(TestMessage)}
+			err := producer.SendMessage(msg)
+			if msg.Partition != 0 {
+				t.Error("Unexpected partition")
+			}
+			if err != nil {
+				t.Error(err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	safeClose(t, producer)
+	leader.Close()
+	seedBroker.Close()
+}
+
+// This example shows the basic usage pattern of the SyncProducer.
+func ExampleSyncProducer() {
+	producer, err := NewSyncProducer([]string{"localhost:9092"}, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer func() {
+		if err := producer.Close(); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	msg := &ProducerMessage{Topic: "my_topic", Value: StringEncoder("testing 123")}
+	err = producer.SendMessage(msg)
+	if err != nil {
+		log.Printf("FAILED to send message: %s\n", err)
+	} else {
+		log.Printf("> message sent to partition %d at offset %d\n", msg.Partition, msg.Offset)
+	}
+}


### PR DESCRIPTION
Rationale:

- This is in line with the AsyncProducer.
- This makes it easier to switch between SyncProducer and AsyncProducer if the need arises.
- This allows you to use to `ManualPartioner`, because now you can set the Partition field.

@Shopify/kafka Last API change I promise :)