### PR TITLE
producer: bugfix for broker flushers getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+#### Unreleased
+
+Bug Fixes:
+ - Fix the producer's internal reference counting in certain unusual scenarios
+   ([#367](https://github.com/Shopify/sarama/pull/367)).
+
 #### Version 1.0.0 (2015-03-17)
 
 Version 1.0.0 is the first tagged version, and is almost a complete rewrite. The primary differences with previous untagged versions are:


### PR DESCRIPTION
In certain unusual circumstances, the producer could have added new references
to a flusher that was shutting down, preventing it from shutting down and
causing it to try to produce on a network connection that was already closed.

Track "current" and "active" flushers separately - remove flushers from the
"current" set immediately when they begin shutdown so that nothing else tries to
take a reference, but leave them in "active" so that they can be cleaned up
properly when their reference count hits 0.

Add a test which fails without this fix in place.

@Shopify/kafka 