### PR TITLE
producer: bugfix for aggregators getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Bug Fixes:
  - Fix the producer's internal reference counting in certain unusual scenarios
    ([#367](https://github.com/Shopify/sarama/pull/367)).
+ - Fix a condition where the producer's internal control messages could have
+   gotten stuck ([#368](https://github.com/Shopify/sarama/pull/368)).
 
 #### Version 1.0.0 (2015-03-17)
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -458,6 +458,7 @@ func (p *asyncProducer) messageAggregator(broker *Broker, input chan *ProducerMe
 			bytesAccumulated += msg.byteSize()
 
 			if defaultFlush ||
+				msg.flags&chaser == chaser ||
 				(p.conf.Producer.Flush.Messages > 0 && len(buffer) >= p.conf.Producer.Flush.Messages) ||
 				(p.conf.Producer.Flush.Bytes > 0 && bytesAccumulated >= p.conf.Producer.Flush.Bytes) {
 				doFlush = flusher


### PR DESCRIPTION
In circumstances where Flush.Messages and/or Flush.Bytes were set but
Flush.Frequency was not, the producer's aggregator could get stuck on a retry
because a metadata-only chaser message would not be enough on its own to trigger
a flush, and so it would sit in limbo forever.

Always trigger a flush in the aggregator when the message is a chaser. This has
the additional benefit of reducing retry latency when Flush.Frequency *is* set.

Add a test for this case.

@Shopify/kafka 