### PR TITLE
consumer: bugfix for broker workers getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Bug Fixes:
  - Fix the producer's internal reference counting in certain unusual scenarios
    ([#367](https://github.com/Shopify/sarama/pull/367)).
+ - Fix the consumer's internal reference counting in certain unusual scenarios
+   ([#369](https://github.com/Shopify/sarama/pull/369)).
  - Fix a condition where the producer's internal control messages could have
    gotten stuck ([#368](https://github.com/Shopify/sarama/pull/368)).
 


### PR DESCRIPTION
Very similar to #367 (on the producer): the consumer could have added new
references to a brokerConsumer that was shutting down, leading it to spin with
an error unnecessarily.

Add a test for this case.

@Shopify/kafka 