### PR TITLE
Fix go fmt makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ errcheck:
 	errcheck github.com/Shopify/sarama/...
 
 fmt:
-	@if [[ -n $$(go fmt ./...) ]]; then echo 'Please run go fmt on your code.' && exit 1; fi
+	@if [ -n "$$(go fmt ./...)" ]; then echo 'Please run go fmt on your code.' && exit 1; fi
 
 install_dependencies: install_errcheck install_go_vet get
 


### PR DESCRIPTION
This wasn't failing CI, but it was effectively not running the expected step so misformatted code might have snuck in accidentally.

@Shopify/kafka 