### PR TITLE
Do not use partition cache for unknown topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Bug Fixes:
    ([#369](https://github.com/Shopify/sarama/pull/369)).
  - Fix a condition where the producer's internal control messages could have
    gotten stuck ([#368](https://github.com/Shopify/sarama/pull/368)).
+ - Fix an issue where invalid partition lists would be cached when asking for
+   metadata for a non-existing topic ([#372](https://github.com/Shopify/sarama/pull/372)).
+
 
 #### Version 1.0.0 (2015-03-17)
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -58,6 +58,48 @@ func TestFuncConnectionFailure(t *testing.T) {
 	}
 }
 
+func TestFuncClientMetadata(t *testing.T) {
+	checkKafkaAvailability(t)
+
+	config := NewConfig()
+	config.Metadata.Retry.Max = 1
+	config.Metadata.Retry.Backoff = 10 * time.Millisecond
+	client, err := NewClient(kafkaBrokers, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.RefreshMetadata("unknown_topic"); err != ErrUnknownTopicOrPartition {
+		t.Error("Expected ErrUnknownTopicOrPartition, got", err)
+	}
+
+	if _, err := client.Leader("unknown_topic", 0); err != ErrUnknownTopicOrPartition {
+		t.Error("Expected ErrUnknownTopicOrPartition, got", err)
+	}
+
+	if _, err := client.Replicas("invalid/topic", 0); err != ErrUnknownTopicOrPartition {
+		t.Error("Expected ErrUnknownTopicOrPartition, got", err)
+	}
+
+	partitions, err := client.Partitions("multi_partition")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(partitions) != 2 {
+		t.Errorf("Expected multi_partition topic to have 2 partitions, found %v", partitions)
+	}
+
+	partitions, err = client.Partitions("single_partition")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(partitions) != 1 {
+		t.Errorf("Expected single_partition topic to have 1 partitions, found %v", partitions)
+	}
+
+	safeClose(t, client)
+}
+
 func TestFuncProducing(t *testing.T) {
 	config := NewConfig()
 	testProducingMessages(t, config)
@@ -132,12 +174,12 @@ func TestProducingToInvalidTopic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrInvalidTopic {
-		t.Log("Expected ErrInvalidTopic, found", err)
+	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrUnknownTopicOrPartition {
+		t.Error("Expected ErrUnknownTopicOrPartition, found", err)
 	}
 
-	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrInvalidTopic {
-		t.Log("Expected ErrInvalidTopic, found", err)
+	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrUnknownTopicOrPartition {
+		t.Error("Expected ErrUnknownTopicOrPartition, found", err)
 	}
 
 	safeClose(t, producer)

--- a/functional_test.go
+++ b/functional_test.go
@@ -124,6 +124,25 @@ func TestFuncMultiPartitionProduce(t *testing.T) {
 	}
 }
 
+func TestProducingToInvalidTopic(t *testing.T) {
+	checkKafkaAvailability(t)
+
+	producer, err := NewSyncProducer(kafkaBrokers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrInvalidTopic {
+		t.Log("Expected ErrInvalidTopic, found", err)
+	}
+
+	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrInvalidTopic {
+		t.Log("Expected ErrInvalidTopic, found", err)
+	}
+
+	safeClose(t, producer)
+}
+
 func testProducingMessages(t *testing.T, config *Config) {
 	checkKafkaAvailability(t)
 

--- a/vagrant/server.properties
+++ b/vagrant/server.properties
@@ -66,6 +66,7 @@ num.partitions=2
 # more easily.
 default.replication.factor=2
 
+auto.create.topics.enable=false
 delete.topic.enable=true
 
 ############################# Log Flush Policy #############################


### PR DESCRIPTION
If we set the partition cache, we end up return an empty list later on, which ends up causing a weird error message later on.

@Shopify/kafka for review