### PR TITLE
producer: wrap partitioning in a circuit-breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 #### Unreleased
 
+Improvements:
+ - Wrap the producer's partitioner call in a circuit-breaker so that repeatedly
+   broken topics don't choke throughput
+   ([#373](https://github.com/Shopify/sarama/pull/373)).
+
 Bug Fixes:
  - Fix the producer's internal reference counting in certain unusual scenarios
    ([#367](https://github.com/Shopify/sarama/pull/367)).


### PR DESCRIPTION
This prevents repeatedly broken topics (e.g. ones that don't even exist) from
choking throughput for other topics.

@Shopify/kafka 

No tests because:
- the breaker itself is well-tested in https://github.com/eapache/go-resiliency/blob/master/breaker/breaker_test.go
- the change itself is stupidly simple
- I'm sick of writing complex producer tests