### PR TITLE
[experimental] Optionally batch metadata requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,9 @@ type Config struct {
 		// How frequently to refresh the cluster metadata in the background. Defaults to 10 minutes.
 		// Set to 0 to disable. Similar to `topic.metadata.refresh.interval.ms` in the JVM version.
 		RefreshFrequency time.Duration
+		// How long to wait for other metadata requests to come in before actually making the request.
+		// Waiting can batch requests more efficiently, but introduces latency (default 0).
+		BatchDelay time.Duration
 	}
 
 	// Producer is the namespace for configuration related to producing messages, used by the Producer.
@@ -196,6 +199,8 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Invalid Metadata.Retry.Backoff, must be > 0")
 	case c.Metadata.RefreshFrequency < time.Duration(0):
 		return ConfigurationError("Invalid Metadata.RefreshFrequency, must be >= 0")
+	case c.Metadata.BatchDelay < time.Duration(0):
+		return ConfigurationError("Invalid Metadata.BatchDelay, must be >= 0")
 	}
 
 	// validate the Producer values


### PR DESCRIPTION
When a busy broker fails, many goroutines in a producer or consumer may
simultaneously try to refresh metadata for what are only realistically a handful
of topics. Permit batching these requests together with a slight delay to reduce
the number of actual network requests needed.

As it currently stands this has limitation in that it returns the same error to all callers, so if your legit request happens to get batched with an invalid topic, you will get `ErrInvalidTopic` back incorrectly.

cc @Shopify/kafka still playing with this, do not merge