### PR TITLE
Add kafka-console-partitionconsumer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Sarama is an MIT-licensed Go client library for Apache Kafka 0.8 (and later).
 - API documentation and example are available via godoc at https://godoc.org/github.com/Shopify/sarama.
 - Mocks for testing are available in the [mocks](./mocks) subpackage.
 - The [examples](./examples) directory contains more elaborate example applications.
+- The [tools](./tools) directory contains command line tools that can be useful for testing, diagnostics, and instrumentation.
 - There is a google group for Kafka client users and authors at https://groups.google.com/forum/#!forum/kafka-clients
 
 ### Compatibility and API stability

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,7 @@
+# Sarama tools
+
+This folder contains applications that are useful for exploration of your Kafka cluster, or instrumentation.
+Some of these tools mirror tools that ship with Kafka, but these tools won't require installing the JVM to function.
+
+- [kafka-console-producer](./kafka-console-producer): a command line tool to produce a single message to your Kafka custer.
+- [kafka-console-partitionconsumer](./kafka-console-producer): a command line tool to consume a single partition fo a topic on your Kafka cluster.

--- a/tools/kafka-console-partitionconsumer/.gitignore
+++ b/tools/kafka-console-partitionconsumer/.gitignore
@@ -1,0 +1,2 @@
+kafka-console-partitionconsumer
+kafka-console-partitionconsumer.test

--- a/tools/kafka-console-partitionconsumer/README.md
+++ b/tools/kafka-console-partitionconsumer/README.md
@@ -1,0 +1,25 @@
+# kafka-console-partitionconsumer
+
+A simple command line tool to consume a partition of a topic and print the messages
+on the standard output.
+
+### Installation
+
+    go install github.com/Shopify/sarama/tools/kafka-console-partitionconsumer
+
+### Usage
+
+    # Minimum invocation
+    kafka-console-partitionconsumer -topic=test -partition=4 -brokers=kafka1:9092
+
+    # It will pick up a KAFKA_PEERS environment variable
+    export KAFKA_PEERS=kafka1:9092,kafka2:9092,kafka3:9092
+    kafka-console-producer -topic=test -partition=4
+
+    # You can specify the offset you want to start at. It can be either
+    # `oldest`, `newest`, or a specific offset number
+    kafka-console-producer -topic=test -partition=3 -offset=oldest
+    kafka-console-producer -topic=test -partition=2 -offset=1337
+
+    # Display all command line options
+    kafka-console-producer -help

--- a/tools/kafka-console-partitionconsumer/kafka-console-partitionconsumer.go
+++ b/tools/kafka-console-partitionconsumer/kafka-console-partitionconsumer.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+
+	"github.com/Shopify/sarama"
+)
+
+var (
+	brokerList = flag.String("brokers", os.Getenv("KAFKA_PEERS"), "The comma separated list of brokers in the Kafka cluster")
+	topic      = flag.String("topic", "", "REQUIRED: the topic to consume")
+	partition  = flag.Int("partition", -1, "REQUIRED: the partition to consume")
+	offset     = flag.String("offset", "newest", "The offset to start with. Can be `oldest`, `newest`, or an actual offset")
+	verbose    = flag.Bool("verbose", false, "Whether to turn on sarama logging")
+
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+)
+
+func main() {
+	flag.Parse()
+
+	if *brokerList == "" {
+		printUsageErrorAndExit("You have to provide -brokers as a comma-separated list, or set the KAFKA_PEERS environment variable.")
+	}
+
+	if *topic == "" {
+		printUsageErrorAndExit("-topic is required")
+	}
+
+	if *partition == -1 {
+		printUsageErrorAndExit("-partition is required")
+	}
+
+	if *verbose {
+		sarama.Logger = logger
+	}
+
+	var (
+		initialOffset int64
+		offsetError   error
+	)
+	switch *offset {
+	case "oldest":
+		initialOffset = sarama.OffsetOldest
+	case "newest":
+		initialOffset = sarama.OffsetNewest
+	default:
+		initialOffset, offsetError = strconv.ParseInt(*offset, 10, 64)
+	}
+
+	if offsetError != nil {
+		printUsageErrorAndExit("Invalid initial offset: %s", *offset)
+	}
+
+	c, err := sarama.NewConsumer(strings.Split(*brokerList, ","), nil)
+	if err != nil {
+		printErrorAndExit(69, "Failed to start consumer: %s", err)
+	}
+
+	pc, err := c.ConsumePartition(*topic, int32(*partition), initialOffset)
+	if err != nil {
+		printErrorAndExit(69, "Failed to start partition consumer: %s", err)
+	}
+
+	go func() {
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, os.Kill, os.Interrupt)
+		<-signals
+		pc.AsyncClose()
+	}()
+
+	for msg := range pc.Messages() {
+		fmt.Printf("Offset:\t%d\n", msg.Offset)
+		fmt.Printf("Key:\t%s\n", string(msg.Key))
+		fmt.Printf("Value:\t%s\n", string(msg.Value))
+		fmt.Println()
+	}
+
+	if err := c.Close(); err != nil {
+		logger.Println("Failed to close consumer: ", err)
+	}
+}
+
+func printErrorAndExit(code int, format string, values ...interface{}) {
+	fmt.Fprintf(os.Stderr, "ERROR: %s\n", fmt.Sprintf(format, values...))
+	fmt.Fprintln(os.Stderr)
+	os.Exit(code)
+}
+
+func printUsageErrorAndExit(format string, values ...interface{}) {
+	fmt.Fprintf(os.Stderr, "ERROR: %s\n", fmt.Sprintf(format, values...))
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Available command line options:")
+	flag.PrintDefaults()
+	os.Exit(64)
+}


### PR DESCRIPTION
A simple command line tool to consume a single partition of a topic on your Kafka cluster.

@Shopify/kafka 