### PR TITLE
client: connect to a random seed broker

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,9 +69,9 @@ type client struct {
 	// the broker addresses given to us through the constructor are not guaranteed to be returned in
 	// the cluster metadata (I *think* it only returns brokers who are currently leading partitions?)
 	// so we store them separately
-	seedBrokerAddrs []string
-	seedBroker      *Broker
-	deadBrokerAddrs map[string]none
+	seedBroker  *Broker
+	seedBrokers map[*Broker]none
+	deadBrokers map[*Broker]none
 
 	brokers  map[int32]*Broker                       // maps broker ids to brokers
 	metadata map[string]map[int32]*PartitionMetadata // maps topics to partition ids to metadata
@@ -103,14 +103,15 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 	client := &client{
 		conf:                    conf,
 		closer:                  make(chan none),
-		seedBrokerAddrs:         addrs,
-		seedBroker:              NewBroker(addrs[0]),
-		deadBrokerAddrs:         make(map[string]none),
+		seedBrokers:             make(map[*Broker]none, len(addrs)),
+		deadBrokers:             make(map[*Broker]none, len(addrs)),
 		brokers:                 make(map[int32]*Broker),
 		metadata:                make(map[string]map[int32]*PartitionMetadata),
 		cachedPartitionsResults: make(map[string][maxPartitionIndex][]int32),
 	}
-	_ = client.seedBroker.Open(conf)
+	for _, addr := range addrs {
+		client.seedBrokers[NewBroker(addr)] = none{}
+	}
 
 	// do an initial fetch of all cluster metadata by specifing an empty list of topics
 	err := client.RefreshMetadata()
@@ -326,16 +327,10 @@ func (client *client) disconnectBroker(broker *Broker) {
 	client.lock.Lock()
 	defer client.lock.Unlock()
 
-	client.deadBrokerAddrs[broker.addr] = none{}
-
 	if broker == client.seedBroker {
-		client.seedBrokerAddrs = client.seedBrokerAddrs[1:]
-		if len(client.seedBrokerAddrs) > 0 {
-			client.seedBroker = NewBroker(client.seedBrokerAddrs[0])
-			_ = client.seedBroker.Open(client.conf)
-		} else {
-			client.seedBroker = nil
-		}
+		client.deadBrokers[broker] = none{}
+		delete(client.seedBrokers, broker)
+		client.seedBroker = nil
 	} else {
 		// we do this so that our loop in `tryRefreshMetadata` doesn't go on forever,
 		// but we really shouldn't have to; once that loop is made better this case can be
@@ -349,23 +344,22 @@ func (client *client) resurrectDeadBrokers() {
 	client.lock.Lock()
 	defer client.lock.Unlock()
 
-	for _, addr := range client.seedBrokerAddrs {
-		client.deadBrokerAddrs[addr] = none{}
+	for broker := range client.deadBrokers {
+		client.seedBrokers[broker] = none{}
 	}
-
-	client.seedBrokerAddrs = []string{}
-	for addr := range client.deadBrokerAddrs {
-		client.seedBrokerAddrs = append(client.seedBrokerAddrs, addr)
-	}
-	client.deadBrokerAddrs = make(map[string]none)
-
-	client.seedBroker = NewBroker(client.seedBrokerAddrs[0])
-	_ = client.seedBroker.Open(client.conf)
+	client.deadBrokers = make(map[*Broker]none)
 }
 
 func (client *client) any() *Broker {
 	client.lock.RLock()
 	defer client.lock.RUnlock()
+
+	if client.seedBroker == nil {
+		for broker := range client.seedBrokers {
+			client.seedBroker = broker
+			break
+		}
+	}
 
 	if client.seedBroker != nil {
 		_ = client.seedBroker.Open(client.conf)


### PR DESCRIPTION
Rather than walking them in order, walk them randomly using go's map iterator.
This should lighten the load on the first seed in a lot of failover scenarios.

Also rework a bunch of how seeds are stored:
- store both seeds and dead brokers as Broker objects, not addresses, to avoid
  constructing new Brokers all the time
- lazily set `seedBroker` in `any()` rather than eagerly in the constructor and
  in `disconnectBroker()`
- never add non-seed brokers to `deadBrokers`
- substantially simplify `resurrectDeadBrokers`

This doesn't break the predictability of any of our tests, fortunately, because
we only ever pass one seed in anyways.

@Shopify/kafka 