### PR TITLE
Simplify how we manage seed brokers

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -45,8 +45,10 @@ func withRecover(fn func()) {
 func safeAsyncClose(b *Broker) {
 	tmp := b // local var prevents clobbering in goroutine
 	go withRecover(func() {
-		if err := tmp.Close(); err != nil {
-			Logger.Println("Error closing broker", tmp.ID(), ":", err)
+		if connected, _ := tmp.Connected(); connected {
+			if err := tmp.Close(); err != nil {
+				Logger.Println("Error closing broker", tmp.ID(), ":", err)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Create all the Broker objects themselves right up front rather than storing the
addresses. Don't eagerly open the seed connection in the constructor, we open it
lazily in `any()` already. Never add non-seed brokers to the dead set.
Substantially simplify `resurrectDeadBrokers`. Don't try and close a broker that
isn't even connected.

The good bits as extracted from #380. Fixes #375.

@Shopify/kafka 