### PR TITLE
Totally remove consumer.children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - KAFKA_PEERS=localhost:6667,localhost:6668,localhost:6669,localhost:6670,localhost:6671
   - KAFKA_INSTALL_ROOT=/home/travis/kafka
   - KAFKA_HOSTNAME=localhost
+  - DEBUG=true
   matrix:
   - KAFKA_VERSION=0.8.1.1
   - KAFKA_VERSION=0.8.2.1

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -4,6 +4,7 @@ type FetchResponseBlock struct {
 	Err                 KError
 	HighWaterMarkOffset int64
 	MsgSet              MessageSet
+	Next                *FetchResponseBlock
 }
 
 func (pr *FetchResponseBlock) decode(pd packetDecoder) (err error) {
@@ -79,6 +80,9 @@ func (fr *FetchResponse) decode(pd packetDecoder) (err error) {
 			err = block.decode(pd)
 			if err != nil {
 				return err
+			}
+			if _, exists := fr.Blocks[name][id]; exists {
+				block.Next = fr.Blocks[name][id]
 			}
 			fr.Blocks[name][id] = block
 		}

--- a/functional_test.go
+++ b/functional_test.go
@@ -190,6 +190,31 @@ func TestProducingToInvalidTopic(t *testing.T) {
 	safeClose(t, producer)
 }
 
+func TestFetchRequestTwoOffsets(t *testing.T) {
+	checkKafkaAvailability(t)
+
+	client, err := NewClient(kafkaBrokers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	broker, err := client.Leader("single_partition", 0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	req := new(FetchRequest)
+	for i := 0; i < 5; i++ {
+		req.AddBlock("single_partition", 0, int64(i*10), 1000)
+	}
+	res, err := broker.Fetch(req)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(res)
+
+	safeClose(t, client)
+}
+
 func testProducingMessages(t *testing.T, config *Config) {
 	checkKafkaAvailability(t)
 


### PR DESCRIPTION
There's something fishy about this change, since it seems really odd for the
consumer not to actually have any references to its children, but I can't
actually come up with any problems, it's much simpler, and it permits (in
theory) multiple PartitionConsumers for the same partition to share a single
consumer.

@Shopify/kafka 