### PR TITLE
Instead of sleeping, poll for the socket to be ready

### DIFF
--- a/vagrant/boot_cluster.sh
+++ b/vagrant/boot_cluster.sh
@@ -4,14 +4,15 @@ set -ex
 
 vagrant/run_toxiproxy.sh &
 
-sleep 5
+while ! nc -q 1 localhost 2181 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost 9092 </dev/null; do echo "Waiting"; sleep 1; done
 
 for i in 1 2 3 4 5; do
     KAFKA_PORT=`expr $i + 9090`
     cd ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT} && bin/zookeeper-server-start.sh -daemon config/zookeeper.properties
 done
 
-sleep 5
+while ! nc -q 1 localhost 21805 </dev/null; do echo "Waiting"; sleep 1; done
 
 for i in 1 2 3 4 5; do
     KAFKA_PORT=`expr $i + 9090`

--- a/vagrant/create_topics.sh
+++ b/vagrant/create_topics.sh
@@ -2,7 +2,8 @@
 
 set -ex
 
-sleep 10
+while ! nc -q 1 localhost 21801 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost 29092 </dev/null; do echo "Waiting"; sleep 1; done
 
 cd ${KAFKA_INSTALL_ROOT}/kafka-9092
 bin/kafka-topics.sh --create --partitions 1 --replication-factor 3 --topic single_partition --zookeeper localhost:2181

--- a/vagrant/create_topics.sh
+++ b/vagrant/create_topics.sh
@@ -8,5 +8,3 @@ while ! nc -q 1 localhost 29092 </dev/null; do echo "Waiting"; sleep 1; done
 cd ${KAFKA_INSTALL_ROOT}/kafka-9092
 bin/kafka-topics.sh --create --partitions 1 --replication-factor 3 --topic single_partition --zookeeper localhost:2181
 bin/kafka-topics.sh --create --partitions 2 --replication-factor 3 --topic multi_partition  --zookeeper localhost:2181
-
-sleep 5

--- a/vagrant/run_toxiproxy.sh
+++ b/vagrant/run_toxiproxy.sh
@@ -5,7 +5,7 @@ set -ex
 ${KAFKA_INSTALL_ROOT}/toxiproxy -port 8474 -host 0.0.0.0 &
 PID=$!
 
-sleep 5
+while ! nc -q 1 localhost 8474 </dev/null; do echo "Waiting"; sleep 1; done
 
 wget -S --post-data='{"name":"zk1", "upstream":"localhost:21801", "listen":"0.0.0.0:2181"}' localhost:8474/proxies
 wget -S --post-data='{"name":"zk2", "upstream":"localhost:21802", "listen":"0.0.0.0:2182"}' localhost:8474/proxies


### PR DESCRIPTION
Hopefully this fixes the heisenbug where we try to set up the topics before the
cluster has actually booted.

Fixes #399 and shaves a good 20 seconds off of CI.

@Shopify/kafka 