### PR TITLE
More test prep for toxiproxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXIPROXY_ADDR=http://localhost:8474
   - KAFKA_INSTALL_ROOT=/home/travis/kafka
   - KAFKA_HOSTNAME=localhost
+  - DEBUG=true
   matrix:
   - KAFKA_VERSION=0.8.1.1
   - KAFKA_VERSION=0.8.2.1

--- a/functional_test.go
+++ b/functional_test.go
@@ -2,6 +2,7 @@ package sarama
 
 import (
 	"log"
+	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -25,6 +26,17 @@ var (
 )
 
 func init() {
+	if os.Getenv("DEBUG") == "true" {
+		Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
+	}
+
+	seed := time.Now().UTC().UnixNano()
+	if tmp := os.Getenv("TEST_SEED"); tmp != "" {
+		seed, _ = strconv.ParseInt(tmp, 0, 64)
+	}
+	Logger.Println("Using random seed:", seed)
+	rand.Seed(seed)
+
 	proxyAddr := os.Getenv("TOXIPROXY_ADDR")
 	if proxyAddr == "" {
 		proxyAddr = VagrantToxiproxy
@@ -44,10 +56,6 @@ func init() {
 	}
 
 	kafkaShouldBeAvailable = os.Getenv("CI") != ""
-
-	if os.Getenv("DEBUG") == "true" {
-		Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
-	}
 }
 
 func checkKafkaAvailability(t *testing.T) {

--- a/vagrant/create_topics.sh
+++ b/vagrant/create_topics.sh
@@ -8,3 +8,4 @@ while ! nc -q 1 localhost 29092 </dev/null; do echo "Waiting"; sleep 1; done
 cd ${KAFKA_INSTALL_ROOT}/kafka-9092
 bin/kafka-topics.sh --create --partitions 1 --replication-factor 3 --topic single_partition --zookeeper localhost:2181
 bin/kafka-topics.sh --create --partitions 2 --replication-factor 3 --topic multi_partition  --zookeeper localhost:2181
+bin/kafka-topics.sh --create --partitions 32 --replication-factor 3 --topic many_partition  --zookeeper localhost:2181

--- a/vagrant/install_cluster.sh
+++ b/vagrant/install_cluster.sh
@@ -8,10 +8,12 @@ mkdir -p ${KAFKA_INSTALL_ROOT}
 if [ ! -f ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz ]; then
     wget --quiet http://apache.mirror.gtcomm.net/kafka/${KAFKA_VERSION}/kafka_2.10-${KAFKA_VERSION}.tgz -O ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz
 fi
-if [ ! -f ${KAFKA_INSTALL_ROOT}/toxiproxy ]; then
-    wget --quiet https://github.com/Shopify/toxiproxy/releases/download/v${TOXIPROXY_VERSION}/toxiproxy-linux-amd64 -O ${KAFKA_INSTALL_ROOT}/toxiproxy
-    chmod +x ${KAFKA_INSTALL_ROOT}/toxiproxy
+if [ ! -f ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ]; then
+    wget --quiet https://github.com/Shopify/toxiproxy/releases/download/v${TOXIPROXY_VERSION}/toxiproxy-linux-amd64 -O ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}
+    chmod +x ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}
 fi
+rm -f ${KAFKA_INSTALL_ROOT}/toxiproxy
+ln -s ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ${KAFKA_INSTALL_ROOT}/toxiproxy
 
 for i in 1 2 3 4 5; do
     ZK_PORT=`expr $i + 2180`

--- a/vagrant/install_cluster.sh
+++ b/vagrant/install_cluster.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-TOXIPROXY_VERSION=1.0.0
+TOXIPROXY_VERSION=1.0.1
 
 mkdir -p ${KAFKA_INSTALL_ROOT}
 if [ ! -f ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz ]; then

--- a/vagrant/server.properties
+++ b/vagrant/server.properties
@@ -122,4 +122,5 @@ log.cleaner.enable=false
 zookeeper.connect=localhost:ZK_PORT
 
 # Timeout in ms for connecting to zookeeper
-zookeeper.connection.timeout.ms=1000000
+zookeeper.session.timeout.ms=3000
+zookeeper.connection.timeout.ms=3000


### PR DESCRIPTION
@Shopify/kafka so I thought after the last one I was ready to actually write a test, but apparently not :)

This is a grab bag of changes to CI configuration in preparation for toxiproxy tests:
- Always run CI with `DEBUG=true`, it's just useful and it doesn't cost us
  anything.
- Initialize the logger first thing in `init()` when `DEBUG=true` so it can be used
  by other parts of the init.
- Seed the random number generator (and permit overriding the seed via an
  environment variable), this will be used for toxiproxy tests.
- Bump toxiproxy to 1.0.1 to fix a bug resetting proxies.
- Create a topic with 32 partitions for testing multiple partitions per broker.
- Lower the zookeeper timeouts so that we don't have to wait forever for a node
  to die when we use toxiproxy to kill its zookeeper connection.