### PR TITLE
Functional failover test using toxiproxy.

### DIFF
--- a/functional_client_test.go
+++ b/functional_client_test.go
@@ -7,17 +7,24 @@ import (
 )
 
 func TestFuncConnectionFailure(t *testing.T) {
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	Proxies["kafka1"].Enabled = false
+	SaveProxy(t, "kafka1")
+
 	config := NewConfig()
 	config.Metadata.Retry.Max = 1
 
-	_, err := NewClient([]string{"localhost:9000"}, config)
+	_, err := NewClient([]string{kafkaBrokers[0]}, config)
 	if err != ErrOutOfBrokers {
 		t.Fatal("Expected returned error to be ErrOutOfBrokers, but was: ", err)
 	}
 }
 
 func TestFuncClientMetadata(t *testing.T) {
-	checkKafkaAvailability(t)
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
 
 	config := NewConfig()
 	config.Metadata.Retry.Max = 1


### PR DESCRIPTION
@Shopify/kafka @Sirupsen 

- Create `setupFunctionalTest()` and `teardownFunctionalTest()` that handle
  testing for kafka presence, resetting toxiproxy, etc, and use them everywhere.
- Move `testProducingMessages` to immediately below all the tests that use it.
- Rename `kafkaIsAvailable` to `kafkaAvailable` and `kafkaShouldBeAvailable` to
  `kafkaRequired`.
- Implement a couple of helper methods for managing proxies.
- Use toxiproxy for `TestFuncConnectionFailure` so that we know there won't ever
  be anything else listening on that port.
- Write a new test `TestReliableProducing` that uses toxiproxy to take down
  zookeeper connections and ensures that everything produces correctly.

Two notes:
- This adds a *substantial* amount of time (up to 3 minutes depending on how fast the container is) to CI runs, I'm wondering if there's a way we should run it on only one job per run or something.
- It appears that this sometimes leaves the kafka cluster in a slightly funky state, with one node spinning at 30% CPU and spamming the log with failed-to-replicate messages at ever increasing offsets. Filed as https://issues.apache.org/jira/browse/KAFKA-2082.