### PR TITLE
Increase memory with vagrant virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,8 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+MEMORY = 3072
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "hashicorp/precise64"
 
@@ -12,6 +14,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "private_network", ip: "192.168.100.67"
 
   config.vm.provider "vmware_fusion" do |v|
-    v.vmx["memsize"] = "3072"
+    v.vmx["memsize"] = MEMORY.to_s
+  end
+  config.vm.provider "virtualbox" do |v|
+    v.memory = MEMORY
   end
 end


### PR DESCRIPTION
@Shopify/kafka otherwise non-vmware users get a useless 512MB by default.