### PR TITLE
Add Client.Coordinator() to retrieve the coordinating broker for a consumer group

### DIFF
--- a/consumer_metadata_response.go
+++ b/consumer_metadata_response.go
@@ -41,3 +41,18 @@ func (r *ConsumerMetadataResponse) decode(pd packetDecoder) (err error) {
 
 	return nil
 }
+
+func (r *ConsumerMetadataResponse) encode(pe packetEncoder) error {
+
+	pe.putInt16(int16(r.Err))
+
+	pe.putInt32(r.CoordinatorID)
+
+	if err := pe.putString(r.CoordinatorHost); err != nil {
+		return err
+	}
+
+	pe.putInt32(r.CoordinatorPort)
+
+	return nil
+}

--- a/functional_client_test.go
+++ b/functional_client_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -52,6 +53,29 @@ func TestFuncClientMetadata(t *testing.T) {
 	}
 	if len(partitions) != 1 {
 		t.Errorf("Expected single_partition topic to have 1 partitions, found %v", partitions)
+	}
+
+	safeClose(t, client)
+}
+
+func TestFuncClientCoordinator(t *testing.T) {
+	checkKafkaVersion(t, "0.8.2")
+	checkKafkaAvailability(t)
+
+	client, err := NewClient(kafkaBrokers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		broker, err := client.Coordinator(fmt.Sprintf("another_new_consumer_group_%d", i))
+		if err != nil {
+			t.Error(err)
+		}
+
+		if connected, err := broker.Connected(); !connected || err != nil {
+			t.Errorf("Expected to coordinator %s broker to be properly connected.", broker.Addr())
+		}
 	}
 
 	safeClose(t, client)


### PR DESCRIPTION
This is the first step towards consumer group offset management, and later full consumer group management in Kafka 0.8.3.

Careful review of the 2 locks would be appreciated. Do we need to locks or can be just use the single lock for everything?

Extracted from #379.

@Shopify/kafka