### PR TITLE
Automatically construct a broker from the ConsumerMetadataResponse

### DIFF
--- a/consumer_metadata_response_test.go
+++ b/consumer_metadata_response_test.go
@@ -58,4 +58,12 @@ func TestConsumerMetadataResponseSuccess(t *testing.T) {
 	if response.CoordinatorPort != 0xCCDD {
 		t.Error("Decoding produced incorrect coordinator port.")
 	}
+
+	if response.Coordinator.ID() != 0xAB {
+		t.Error("Decoding produced incorrect coordinator ID.")
+	}
+
+	if response.Coordinator.Addr() != "foo:52445" {
+		t.Error("Decoding produced incorrect coordinator address.")
+	}
 }


### PR DESCRIPTION
@Shopify/kafka 

The three deprecated fields can go away whenever we decide to do 2.0.