### PR TITLE
Consumer: check offset before returning ConsumePartition.

### DIFF
--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -1,0 +1,25 @@
+package sarama
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFuncConsumerOffsetOutOfRange(t *testing.T) {
+	checkKafkaAvailability(t)
+
+	consumer, err := NewConsumer(kafkaBrokers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := consumer.ConsumePartition("single_partition", 0, -10); err != ErrOffsetOutOfRange {
+		t.Error("Expected ErrOffsetOutOfRange, got:", err)
+	}
+
+	if _, err := consumer.ConsumePartition("single_partition", 0, math.MaxInt64); err != ErrOffsetOutOfRange {
+		t.Error("Expected ErrOffsetOutOfRange, got:", err)
+	}
+
+	safeClose(t, consumer)
+}

--- a/mockbroker_test.go
+++ b/mockbroker_test.go
@@ -146,6 +146,7 @@ func newMockBrokerAddr(t *testing.T, brokerID int32, addr string) *mockBroker {
 	if err != nil {
 		t.Fatal(err)
 	}
+	Logger.Printf("mockbroker/%d listening on %s\n", brokerID, broker.listener.Addr().String())
 	_, portStr, err := net.SplitHostPort(broker.listener.Addr().String())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When calling ConsumePartition, always check whether the offset is within the offset range. This means we now have to do two OffsetRequests for every ConsumePartition call, even if the offset is provided. The good news is that the method will immediately return an error and never start a goroutine, instead of starting the goroutine and returning an error in the Errors() channel which you can easily ignore.

This replaces #378. It now uses two OffsetRequests instead of changing OffsetRequests to allow obtaiing multiple offsets for a single partition. 
