### PR TITLE
client: stop the background thread before closing

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -387,6 +387,7 @@ func TestClientResurrectDeadSeeds(t *testing.T) {
 
 	conf := NewConfig()
 	conf.Metadata.Retry.Backoff = 0
+	conf.Metadata.RefreshFrequency = 0
 	c, err := NewClient([]string{addr1, addr2, addr3}, conf)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Otherwise, in the rare case where a background metadata refresh coincided
exactly with a call to `Client.Close()` there was a race where we might have
potentially tried to write to a nil map. Also add a test for this.

Fixes #422.

@Shopify/kafka @epsniff 