### PR TITLE
Hardcode integer sizes

### DIFF
--- a/prep_encoder.go
+++ b/prep_encoder.go
@@ -1,7 +1,6 @@
 package sarama
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math"
 )
@@ -13,19 +12,19 @@ type prepEncoder struct {
 // primitives
 
 func (pe *prepEncoder) putInt8(in int8) {
-	pe.length += binary.Size(in)
+	pe.length += 1
 }
 
 func (pe *prepEncoder) putInt16(in int16) {
-	pe.length += binary.Size(in)
+	pe.length += 2
 }
 
 func (pe *prepEncoder) putInt32(in int32) {
-	pe.length += binary.Size(in)
+	pe.length += 4
 }
 
 func (pe *prepEncoder) putInt64(in int64) {
-	pe.length += binary.Size(in)
+	pe.length += 8
 }
 
 func (pe *prepEncoder) putArrayLength(in int) error {

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -19,7 +19,7 @@ func (rd *realDecoder) getInt8() (int8, error) {
 		return -1, ErrInsufficientData
 	}
 	tmp := int8(rd.raw[rd.off])
-	rd.off += binary.Size(tmp)
+	rd.off += 1
 	return tmp, nil
 }
 
@@ -29,7 +29,7 @@ func (rd *realDecoder) getInt16() (int16, error) {
 		return -1, ErrInsufficientData
 	}
 	tmp := int16(binary.BigEndian.Uint16(rd.raw[rd.off:]))
-	rd.off += binary.Size(tmp)
+	rd.off += 2
 	return tmp, nil
 }
 
@@ -39,7 +39,7 @@ func (rd *realDecoder) getInt32() (int32, error) {
 		return -1, ErrInsufficientData
 	}
 	tmp := int32(binary.BigEndian.Uint32(rd.raw[rd.off:]))
-	rd.off += binary.Size(tmp)
+	rd.off += 4
 	return tmp, nil
 }
 
@@ -49,7 +49,7 @@ func (rd *realDecoder) getInt64() (int64, error) {
 		return -1, ErrInsufficientData
 	}
 	tmp := int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
-	rd.off += binary.Size(tmp)
+	rd.off += 8
 	return tmp, nil
 }
 
@@ -147,7 +147,7 @@ func (rd *realDecoder) getInt32Array() ([]int32, error) {
 	ret := make([]int32, n)
 	for i := range ret {
 		ret[i] = int32(binary.BigEndian.Uint32(rd.raw[rd.off:]))
-		rd.off += binary.Size(ret[i])
+		rd.off += 4
 	}
 	return ret, nil
 }
@@ -176,7 +176,7 @@ func (rd *realDecoder) getInt64Array() ([]int64, error) {
 	ret := make([]int64, n)
 	for i := range ret {
 		ret[i] = int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
-		rd.off += binary.Size(ret[i])
+		rd.off += 8
 	}
 	return ret, nil
 }

--- a/real_encoder.go
+++ b/real_encoder.go
@@ -12,22 +12,22 @@ type realEncoder struct {
 
 func (re *realEncoder) putInt8(in int8) {
 	re.raw[re.off] = byte(in)
-	re.off += binary.Size(in)
+	re.off += 1
 }
 
 func (re *realEncoder) putInt16(in int16) {
 	binary.BigEndian.PutUint16(re.raw[re.off:], uint16(in))
-	re.off += binary.Size(in)
+	re.off += 2
 }
 
 func (re *realEncoder) putInt32(in int32) {
 	binary.BigEndian.PutUint32(re.raw[re.off:], uint32(in))
-	re.off += binary.Size(in)
+	re.off += 4
 }
 
 func (re *realEncoder) putInt64(in int64) {
 	binary.BigEndian.PutUint64(re.raw[re.off:], uint64(in))
-	re.off += binary.Size(in)
+	re.off += 8
 }
 
 func (re *realEncoder) putArrayLength(in int) error {


### PR DESCRIPTION
My recent playing with benchmarks led me down the slippery slop into profiling,
where I found this oddity. Calling `binary.Size()` actually involves reflection
on the argument which is expensive (of course). There was really no reason not
to hardcode these other than vague hand-waving towards portability (really).

Saves us about 2.5% of profiled time in the producer benchmarks.

@Shopify/kafka 