### PR TITLE
Tweak travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 go:
 - 1.3.3
 - 1.4.2
-- tip
 
 env:
   global:
@@ -32,7 +31,11 @@ script:
 - make fmt
 
 matrix:
+  include:
+    - go: tip
+      env: KAFKA_VERSION=0.8.2.1
   allow_failures:
     - go: tip
+  fast_finish: true
 
 sudo: false


### PR DESCRIPTION
- only run go tip against latest kafka, there's no reason to add it to the full
  matrix
- let travis finish fast by reporting success as soon as all the required builds
  pass (so the tip build might still be running)

@Shopify/kafka 