### PR TITLE
Kazoo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 env:
   global:
   - KAFKA_PEERS=localhost:9091,localhost:9092,localhost:9093,localhost:9094,localhost:9095
+  - ZOOKEEPER_PEERS=localhost:2181,localhost:2182,localhost:2183,localhost:2184,localhost:2185
   - TOXIPROXY_ADDR=http://localhost:8474
   - KAFKA_INSTALL_ROOT=/home/travis/kafka
   - KAFKA_HOSTNAME=localhost

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ install_go_vet:
 	go get golang.org/x/tools/cmd/vet
 
 get:
-	go get -t
+	go get -t ./...

--- a/kazoo/consumergroup.go
+++ b/kazoo/consumergroup.go
@@ -1,0 +1,293 @@
+package kazoo
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/samuel/go-zookeeper/zk"
+)
+
+var (
+	ErrRunningInstances          = errors.New("Cannot deregister a consumergroup with running instances")
+	ErrInstanceAlreadyRegistered = errors.New("Cannot register consumer instance because it already is registered")
+	ErrInstanceNotRegistered     = errors.New("Cannot deregister consumer instance because it not registered")
+	ErrPartitionClaimedByOther   = errors.New("Cannot claim partition: it is already claimed by another instance")
+	ErrPartitionNotClaimed       = errors.New("Cannot release partition: it is not claimed by this instance")
+)
+
+// Consumergroup represents a high-level consumer that is registered in Zookeeper,
+type Consumergroup struct {
+	kz   *Kazoo
+	Name string
+}
+
+// ConsumergroupInstance represents an instance of a Consumergroup.
+type ConsumergroupInstance struct {
+	cg *Consumergroup
+	ID string
+}
+
+// Consumergroups returns all the registered consumergroups
+func (kz *Kazoo) Consumergroups() (map[string]*Consumergroup, error) {
+	root := fmt.Sprintf("%s/consumers", kz.conf.Chroot)
+	cgs, _, err := kz.conn.Children(root)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*Consumergroup)
+	for _, cg := range cgs {
+		result[cg] = kz.Consumergroup(cg)
+	}
+	return result, nil
+}
+
+// Consumergroup instantiates a new consumergroup.
+func (kz *Kazoo) Consumergroup(name string) *Consumergroup {
+	return &Consumergroup{Name: name, kz: kz}
+}
+
+// Exists checks whether the consumergroup has been registered in Zookeeper
+func (cg *Consumergroup) Exists() (bool, error) {
+	return cg.kz.exists(fmt.Sprintf("%s/consumers/%s", cg.kz.conf.Chroot, cg.Name))
+}
+
+// Create registers the consumergroup in zookeeper
+func (cg *Consumergroup) Create() error {
+	return cg.kz.mkdirRecursive(fmt.Sprintf("%s/consumers/%s", cg.kz.conf.Chroot, cg.Name))
+}
+
+// Delete removes the consumergroup from zookeeper
+func (cg *Consumergroup) Delete() error {
+	if instances, err := cg.Instances(); err != nil {
+		return err
+	} else if len(instances) > 0 {
+		return ErrRunningInstances
+	}
+
+	return cg.kz.deleteRecursive(fmt.Sprintf("%s/consumers/%s", cg.kz.conf.Chroot, cg.Name))
+}
+
+// Instances returns a map of all running instances inside this consumergroup.
+func (cg *Consumergroup) Instances() (map[string]*ConsumergroupInstance, error) {
+	result := make(map[string]*ConsumergroupInstance)
+
+	root := fmt.Sprintf("%s/consumers/%s/ids", cg.kz.conf.Chroot, cg.Name)
+	if exists, err := cg.kz.exists(root); err != nil {
+		return nil, err
+	} else if exists {
+		cgis, _, err := cg.kz.conn.Children(root)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cgi := range cgis {
+			result[cgi] = cg.Instance(cgi)
+		}
+	}
+
+	return result, nil
+}
+
+// NewInstance instantiates a new ConsumergroupInstance inside this consumer group,
+// using a newly generated ID.
+func (cg *Consumergroup) NewInstance() *ConsumergroupInstance {
+	id, err := generateConsumerInstanceID()
+	if err != nil {
+		panic(err)
+	}
+	return cg.Instance(id)
+}
+
+// Instance instantiates a new ConsumergroupInstance inside this consumer group,
+// using an existing ID.
+func (cg *Consumergroup) Instance(id string) *ConsumergroupInstance {
+	return &ConsumergroupInstance{cg: cg, ID: id}
+}
+
+// PartitionOwner returns the ConsumergroupInstance that has claimed the given partition.
+// This can be nil if nobody has claime dit yet.
+func (cg *Consumergroup) PartitionOwner(topic string, partition int32) (*ConsumergroupInstance, error) {
+	node := fmt.Sprintf("%s/consumers/%s/owners/%s/%d", cg.kz.conf.Chroot, cg.Name, topic, partition)
+	val, _, err := cg.kz.conn.Get(node)
+
+	// If the node does not exists, nobody has claimed it.
+	switch err {
+	case nil:
+		return &ConsumergroupInstance{cg: cg, ID: string(val)}, nil
+	case zk.ErrNoNode:
+		return nil, nil
+	default:
+		return nil, err
+	}
+}
+
+// Registered checks whether the consumergroup instance is registered in Zookeeper.
+func (cgi *ConsumergroupInstance) Registered() (bool, error) {
+	node := fmt.Sprintf("%s/consumers/%s/ids/%s", cgi.cg.kz.conf.Chroot, cgi.cg.Name, cgi.ID)
+	return cgi.cg.kz.exists(node)
+}
+
+// Register registers the consumergroup instance in Zookeeper.
+func (cgi *ConsumergroupInstance) Register(topics []string) error {
+	if exists, err := cgi.Registered(); err != nil {
+		return err
+	} else if exists {
+		return ErrInstanceAlreadyRegistered
+	}
+
+	// Create a JSON record that is compatible with the JVM consumer.
+	// I am not quite sure what this information is used for.
+
+	subscription := make(map[string]int)
+	for _, topic := range topics {
+		subscription[topic] = 1
+	}
+
+	data, err := json.Marshal(map[string]interface{}{
+		"pattern":      "white_list",
+		"subscription": subscription,
+		"timestamp":    fmt.Sprintf("%d", time.Now().Unix()),
+		"version":      1,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Create an ephemeral node for the the consumergroup instance.
+	node := fmt.Sprintf("%s/consumers/%s/ids/%s", cgi.cg.kz.conf.Chroot, cgi.cg.Name, cgi.ID)
+	return cgi.cg.kz.create(node, data, true)
+}
+
+// Deregister removes the registration of the instance from zookeeper.
+func (cgi *ConsumergroupInstance) Deregister() error {
+	if exists, err := cgi.Registered(); err != nil {
+		return err
+	} else if !exists {
+		return ErrInstanceNotRegistered
+	}
+
+	node := fmt.Sprintf("%s/consumers/%s/ids/%s", cgi.cg.kz.conf.Chroot, cgi.cg.Name, cgi.ID)
+	return cgi.cg.kz.conn.Delete(node, 0)
+}
+
+// Claim claims a topic/partition ownership for a consumer ID within a group. If the
+// partition is already claimed by another running instance, it will return ErrAlreadyClaimed.
+func (cgi *ConsumergroupInstance) ClaimPartition(topic string, partition int32) error {
+	root := fmt.Sprintf("%s/consumers/%s/owners/%s", cgi.cg.kz.conf.Chroot, cgi.cg.Name, topic)
+	if err := cgi.cg.kz.mkdirRecursive(root); err != nil {
+		return err
+	}
+
+	// Create an ephemeral node for the partition to claim the partition for this instance
+	node := fmt.Sprintf("%s/%d", root, partition)
+	err := cgi.cg.kz.create(node, []byte(cgi.ID), true)
+	switch err {
+	case zk.ErrNodeExists:
+		// Return a separate error for this, to allow for implementing a retry mechanism.
+		return ErrPartitionClaimedByOther
+	default:
+		return err
+	}
+}
+
+// ReleasePartition releases a claim to a partition.
+func (cgi *ConsumergroupInstance) ReleasePartition(topic string, partition int32) error {
+	owner, err := cgi.cg.PartitionOwner(topic, partition)
+	if err != nil {
+		return err
+	}
+	if owner == nil || owner.ID != cgi.ID {
+		return ErrPartitionNotClaimed
+	}
+
+	node := fmt.Sprintf("%s/consumers/%s/owners/%s/%d", cgi.cg.kz.conf.Chroot, cgi.cg.Name, topic, partition)
+	return cgi.cg.kz.conn.Delete(node, 0)
+}
+
+// CommitOffset commits an offset to a group/topic/partition
+func (cg *Consumergroup) CommitOffset(topic string, partition int32, offset int64) error {
+	root := fmt.Sprintf("%s/consumers/%s/offsets/%s", cg.kz.conf.Chroot, cg.Name, topic)
+	if err := cg.kz.mkdirRecursive(root); err != nil {
+		return err
+	}
+
+	node := fmt.Sprintf("%s/%d", root, partition)
+	data := []byte(fmt.Sprintf("%d", offset))
+
+	_, stat, err := cg.kz.conn.Get(node)
+	switch err {
+	case zk.ErrNoNode: // Create a new node
+		return cg.kz.create(node, data, false)
+
+	case nil: // Update the existing node
+		_, err := cg.kz.conn.Set(node, data, stat.Version)
+		return err
+
+	default:
+		return err
+	}
+}
+
+// Topics retrieves the list of topics the consumergroup has claimed ownership of at some point.
+func (cg *Consumergroup) Topics() (map[string]*Topic, error) {
+	root := fmt.Sprintf("%s/consumers/%s/owners", cg.kz.conf.Chroot, cg.Name)
+	children, _, err := cg.kz.conn.Children(root)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*Topic)
+	for _, name := range children {
+		result[name] = cg.kz.Topic(name)
+	}
+	return result, nil
+}
+
+// FetchOffset retrieves an offset to a group/topic/partition
+func (cg *Consumergroup) FetchOffset(topic string, partition int32) (int64, error) {
+	node := fmt.Sprintf("%s/consumers/%s/offsets/%s/%d", cg.kz.conf.Chroot, cg.Name, topic, partition)
+	val, _, err := cg.kz.conn.Get(node)
+	if err == zk.ErrNoNode {
+		return 0, nil
+	} else if err != nil {
+		return -1, err
+	}
+	return strconv.ParseInt(string(val), 10, 64)
+}
+
+// generateUUID Generates a UUIDv4.
+func generateUUID() (string, error) {
+	uuid := make([]byte, 16)
+	n, err := io.ReadFull(rand.Reader, uuid)
+	if n != len(uuid) || err != nil {
+		return "", err
+	}
+	// variant bits; see section 4.1.1
+	uuid[8] = uuid[8]&^0xc0 | 0x80
+	// version 4 (pseudo-random); see section 4.1.3
+	uuid[6] = uuid[6]&^0xf0 | 0x40
+	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
+}
+
+// generateConsumerInstanceID generates a consumergroup Instance ID
+// that is almost certain to be unique.
+func generateConsumerInstanceID() (string, error) {
+	uuid, err := generateUUID()
+	if err != nil {
+		return "", err
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s:%s", hostname, uuid), nil
+}

--- a/kazoo/functional_cluster_test.go
+++ b/kazoo/functional_cluster_test.go
@@ -1,0 +1,72 @@
+package kazoo
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	// By default, assume we're using Sarama's vagrant cluster when running tests
+	zookeeperPeers []string = []string{"192.168.100.67:2181", "192.168.100.67:2182", "192.168.100.67:2183", "192.168.100.67:2184", "192.168.100.67:2185"}
+)
+
+func init() {
+	if zookeeperPeersEnv := os.Getenv("ZOOKEEPER_PEERS"); zookeeperPeersEnv != "" {
+		zookeeperPeers = strings.Split(zookeeperPeersEnv, ",")
+	}
+
+	fmt.Printf("Using Zookeeper cluster at %v\n", zookeeperPeers)
+}
+
+func TestBrokers(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	brokers, err := kz.Brokers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(brokers) == 0 {
+		t.Error("Expected at least one broker")
+	}
+
+	for id, addr := range brokers {
+		if conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond); err != nil {
+			t.Errorf("Failed to connect to Kafka broker %d at %s", id, addr)
+		} else {
+			_ = conn.Close()
+		}
+	}
+
+	assertSuccessfulClose(t, kz)
+}
+
+func TestController(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	brokers, err := kz.Brokers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controller, err := kz.Controller()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := brokers[controller]; !ok {
+		t.Error("Expected the controller's BrokerID to be an existing one")
+	}
+
+	assertSuccessfulClose(t, kz)
+}

--- a/kazoo/functional_consumergroup_test.go
+++ b/kazoo/functional_consumergroup_test.go
@@ -1,0 +1,235 @@
+package kazoo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConsumergroups(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer assertSuccessfulClose(t, kz)
+
+	cg := kz.Consumergroup("test.kazoo.TestConsumergroups")
+
+	cgs, err := kz.Consumergroups()
+	if err != nil {
+		t.Error(err)
+	}
+	originalCount := len(cgs)
+
+	if _, ok := cgs[cg.Name]; ok {
+		t.Error("Consumergoup `test.kazoo.TestConsumergroups` should not be returned")
+	}
+
+	if exists, _ := cg.Exists(); exists {
+		t.Error("Consumergoup `test.kazoo.TestConsumergroups` should not be registered yet")
+	}
+
+	if err := cg.Create(); err != nil {
+		t.Error(err)
+	}
+
+	if exists, _ := cg.Exists(); !exists {
+		t.Error("Consumergoup `test.kazoo.TestConsumergroups` should be registered now")
+	}
+
+	cgs, err = kz.Consumergroups()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(cgs) != originalCount+1 {
+		t.Error("Should have one more consumergroup than at the start")
+	}
+
+	if err := cg.Delete(); err != nil {
+		t.Error(err)
+	}
+
+	if exists, _ := cg.Exists(); exists {
+		t.Error("Consumergoup `test.kazoo.TestConsumergroups` should not be registered anymore")
+	}
+
+	cgs, err = kz.Consumergroups()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(cgs) != originalCount {
+		t.Error("Should have the original number of consumergroups again")
+	}
+}
+
+func TestConsumergroupInstances(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer assertSuccessfulClose(t, kz)
+
+	cg := kz.Consumergroup("test.kazoo.TestConsumergroupInstances")
+	if err := cg.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cg.Delete(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	instances, err := cg.Instances()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(instances) != 0 {
+		t.Error("Expected no active consumergroup instances")
+	}
+
+	// Register a new instance
+	instance1 := cg.NewInstance()
+	if instance1.ID == "" {
+		t.Error("It should generate a valid instance ID")
+	}
+	if err := instance1.Register([]string{"topic"}); err != nil {
+		t.Error(err)
+	}
+
+	// Try to register an instance with the same ID.
+	if err := cg.Instance(instance1.ID).Register([]string{"topic"}); err != ErrInstanceAlreadyRegistered {
+		t.Error("The instance should already be registered")
+	}
+
+	instance2 := cg.Instance("test")
+	if err := instance2.Register([]string{"topic"}); err != nil {
+		t.Error(err)
+	}
+
+	instances, err = cg.Instances()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(instances) != 2 {
+		t.Error("Expected 2 active consumergroup instances")
+	}
+	if _, ok := instances[instance1.ID]; !ok {
+		t.Error("Expected instance1 to be registered.")
+	}
+	if _, ok := instances[instance1.ID]; !ok {
+		t.Error("Expected instance2 to be registered.")
+	}
+
+	// Deregister the two running instances
+	if err := instance1.Deregister(); err != nil {
+		t.Error(err)
+	}
+	if err := instance2.Deregister(); err != nil {
+		t.Error(err)
+	}
+
+	// Try to deregister an instance that was not register
+	instance3 := cg.NewInstance()
+	if err := instance3.Deregister(); err != ErrInstanceNotRegistered {
+		t.Error("Expected new instance to not be registered")
+	}
+
+	instances, err = cg.Instances()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(instances) != 0 {
+		t.Error("Expected no active consumergroup instances")
+	}
+}
+
+func TestConsumergroupInstanceCrash(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer assertSuccessfulClose(t, kz)
+
+	cg := kz.Consumergroup("test.kazoo.TestConsumergroupInstancesEphemeral")
+	if err := cg.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cg.Delete(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Create a kazoo instance on which we will simulate a crash.
+	config := NewConfig()
+	config.Timeout = 10 * time.Millisecond
+	crashingKazoo, err := NewKazoo(zookeeperPeers, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	crashingCG := crashingKazoo.Consumergroup(cg.Name)
+
+	// Instantiate and register the instance.
+	instance := crashingCG.NewInstance()
+	if err := instance.Register([]string{"test.1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	if instances, err := cg.Instances(); err != nil {
+		t.Error(err)
+	} else if len(instances) != 1 {
+		t.Error("Should have 1 running instance, found", len(instances))
+	}
+
+	// Simulate a crash, and wait for Zookeeper to pick it up
+	_ = crashingKazoo.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	if instances, err := cg.Instances(); err != nil {
+		t.Error(err)
+	} else if len(instances) != 0 {
+		t.Error("Should have 0 running instances, found", len(instances))
+	}
+}
+
+func TestConsumergroupOffsets(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer assertSuccessfulClose(t, kz)
+
+	cg := kz.Consumergroup("test.kazoo.TestConsumergroupOffsets")
+	if err := cg.Create(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := cg.Delete(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	offset, err := cg.FetchOffset("test", 0)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if offset != 0 {
+		t.Error("Expected to get offset 0 for a partition that hasn't seen an offset commit yet")
+	}
+
+	if err := cg.CommitOffset("test", 0, 1234); err != nil {
+		t.Error(err)
+	}
+
+	offset, err = cg.FetchOffset("test", 0)
+	if err != nil {
+		t.Error(err)
+	}
+	if offset != 1234 {
+		t.Error("Expected to get the offset that was committed.")
+	}
+}

--- a/kazoo/functional_topic_metadata_test.go
+++ b/kazoo/functional_topic_metadata_test.go
@@ -1,0 +1,109 @@
+package kazoo
+
+import (
+	"testing"
+)
+
+func TestTopics(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topics, err := kz.Topics()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if topic, ok := topics["test.4"]; !ok {
+		t.Error("Expected topic test.4 to be returned")
+	} else if topic.Name != "test.4" {
+		t.Error("Expected topic test.4 to have its name set")
+	}
+
+	if _, ok := topics["__nonexistent__"]; ok {
+		t.Error("Expected __nonexistent__ topic to not be defined")
+	}
+
+	assertSuccessfulClose(t, kz)
+}
+
+func TestTopicPartitions(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	partitions, err := kz.Topic("test.4").Partitions()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(partitions) != 4 {
+		t.Errorf("Expected test.4 to have 4 partitions")
+	}
+
+	brokers, err := kz.Brokers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for partitionID, partition := range partitions {
+		if partition.ID != partitionID {
+			t.Error("partition.ID is not set properly")
+		}
+
+		leader, err := partition.Leader()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, ok := brokers[leader]; !ok {
+			t.Errorf("Expected the leader of test.4/%d to be an existing broker.", partitionID)
+		}
+
+		isr, err := partition.ISR()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, brokerID := range isr {
+			if _, ok := brokers[brokerID]; !ok {
+				t.Errorf("Expected all ISRs of test.4/%d to be existing brokers.", partitionID)
+			}
+		}
+	}
+
+	assertSuccessfulClose(t, kz)
+}
+
+func TestTopicConfig(t *testing.T) {
+	kz, err := NewKazoo(zookeeperPeers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topicConfig, err := kz.Topic("test.4").Config()
+	if err != nil {
+		t.Error(err)
+	}
+	if topicConfig["retention.ms"] != "604800000" {
+		t.Error("Expected retention.ms config for test.4 to be set to 604800000")
+	}
+
+	topicConfig, err = kz.Topic("test.1").Config()
+	if err != nil {
+		t.Error(err)
+	}
+	if len(topicConfig) > 0 {
+		t.Error("Expected no topic level configuration to be set for consumergroup.single")
+	}
+
+	assertSuccessfulClose(t, kz)
+}
+
+func assertSuccessfulClose(t *testing.T, kz *Kazoo) {
+	if err := kz.Close(); err != nil {
+		t.Error(err)
+	}
+}

--- a/kazoo/kazoo.go
+++ b/kazoo/kazoo.go
@@ -1,0 +1,173 @@
+package kazoo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/samuel/go-zookeeper/zk"
+)
+
+var (
+	FailedToClaimPartition = errors.New("Failed to claim partition for this consumer instance. Do you have a rogue consumer running?")
+)
+
+// Kazoo interacts with the Kafka metadata in Zookeeper
+type Kazoo struct {
+	conn *zk.Conn
+	conf *Config
+}
+
+// Config holds configuration values f.
+type Config struct {
+	// The chroot the Kafka installation is registerde under. Defaults to "".
+	Chroot string
+
+	// The amount of time the Zookeeper client can be disconnected from the Zookeeper cluster
+	// before the cluster will get rid of watches and ephemeral nodes. Defaults to 1 second.
+	Timeout time.Duration
+}
+
+// NewConfig instantiates a new Config struct with sane defaults.
+func NewConfig() *Config {
+	return &Config{Timeout: 1 * time.Second}
+}
+
+// NewKazoo creates a new connection instance
+func NewKazoo(servers []string, conf *Config) (*Kazoo, error) {
+	if conf == nil {
+		conf = NewConfig()
+	}
+
+	serversCopy := make([]string, len(servers))
+	copy(serversCopy, servers)
+
+	conn, _, err := zk.Connect(serversCopy, conf.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &Kazoo{conn, conf}, nil
+}
+
+// Brokers returns a map of all the brokers that make part of the
+// Kafka cluster that is regeistered in Zookeeper.
+func (kz *Kazoo) Brokers() (map[int32]string, error) {
+	root := fmt.Sprintf("%s/brokers/ids", kz.conf.Chroot)
+	children, _, err := kz.conn.Children(root)
+	if err != nil {
+		return nil, err
+	}
+
+	type brokerEntry struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	}
+
+	result := make(map[int32]string)
+	for _, child := range children {
+		brokerID, err := strconv.ParseInt(child, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		value, _, err := kz.conn.Get(path.Join(root, child))
+		if err != nil {
+			return nil, err
+		}
+
+		var brokerNode brokerEntry
+		if err := json.Unmarshal(value, &brokerNode); err != nil {
+			return nil, err
+		}
+
+		result[int32(brokerID)] = fmt.Sprintf("%s:%d", brokerNode.Host, brokerNode.Port)
+	}
+
+	return result, nil
+}
+
+// Controller returns what broker is currently acting as controller of the Kafka cluster
+func (kz *Kazoo) Controller() (int32, error) {
+	type controllerEntry struct {
+		BrokerID int32 `json:"brokerid"`
+	}
+
+	node := fmt.Sprintf("%s/controller", kz.conf.Chroot)
+	data, _, err := kz.conn.Get(node)
+	if err != nil {
+		return -1, err
+	}
+
+	var controllerNode controllerEntry
+	if err := json.Unmarshal(data, &controllerNode); err != nil {
+		return -1, err
+	}
+
+	return controllerNode.BrokerID, nil
+}
+
+func (kz *Kazoo) Close() error {
+	kz.conn.Close()
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////
+// Util methods
+////////////////////////////////////////////////////////////////////////
+
+// Exists checks existence of a node
+func (kz *Kazoo) exists(node string) (ok bool, err error) {
+	ok, _, err = kz.conn.Exists(node)
+	return
+}
+
+// DeleteAll deletes a node recursively
+func (kz *Kazoo) deleteRecursive(node string) (err error) {
+	children, stat, err := kz.conn.Children(node)
+	if err == zk.ErrNoNode {
+		return nil
+	} else if err != nil {
+		return
+	}
+
+	for _, child := range children {
+		if err = kz.deleteRecursive(path.Join(node, child)); err != nil {
+			return
+		}
+	}
+
+	return kz.conn.Delete(node, stat.Version)
+}
+
+// MkdirAll creates a directory recursively
+func (kz *Kazoo) mkdirRecursive(node string) (err error) {
+	parent := path.Dir(node)
+	if parent != "/" {
+		if err = kz.mkdirRecursive(parent); err != nil {
+			return
+		}
+	}
+
+	_, err = kz.conn.Create(node, nil, 0, zk.WorldACL(zk.PermAll))
+	if err == zk.ErrNodeExists {
+		err = nil
+	}
+	return
+}
+
+// Create stores a new value at node. Fails if already set.
+func (kz *Kazoo) create(node string, value []byte, ephemeral bool) (err error) {
+	if err = kz.mkdirRecursive(path.Dir(node)); err != nil {
+		return
+	}
+
+	flags := int32(0)
+	if ephemeral {
+		flags = zk.FlagEphemeral
+	}
+	_, err = kz.conn.Create(node, value, flags, zk.WorldACL(zk.PermAll))
+	return
+}

--- a/kazoo/topic_metadata.go
+++ b/kazoo/topic_metadata.go
@@ -1,0 +1,136 @@
+package kazoo
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Topic interacts with Kafka's topic metadata in Zookeeper.
+type Topic struct {
+	Name string
+	kz   *Kazoo
+}
+
+// Partition interacts with Kafka's partition metadata in Zookeeper.
+type Partition struct {
+	topic    *Topic
+	ID       int32
+	Replicas []int32
+}
+
+// Topics returns a map of all registered Kafka topics.
+func (kz *Kazoo) Topics() (map[string]*Topic, error) {
+	root := fmt.Sprintf("%s/brokers/topics", kz.conf.Chroot)
+	children, _, err := kz.conn.Children(root)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*Topic)
+	for _, name := range children {
+		result[name] = kz.Topic(name)
+	}
+	return result, nil
+}
+
+// Topic returns a Topic instance for a given topic name
+func (kz *Kazoo) Topic(topic string) *Topic {
+	return &Topic{Name: topic, kz: kz}
+}
+
+// Partitions returns a map of all partitions for the topic.
+func (t *Topic) Partitions() (map[int32]*Partition, error) {
+	node := fmt.Sprintf("%s/brokers/topics/%s", t.kz.conf.Chroot, t.Name)
+	value, _, err := t.kz.conn.Get(node)
+	if err != nil {
+		return nil, err
+	}
+
+	type topicMetadata struct {
+		Partitions map[string][]int32 `json:"partitions"`
+	}
+
+	var tm topicMetadata
+	if err := json.Unmarshal(value, &tm); err != nil {
+		return nil, err
+	}
+
+	result := make(map[int32]*Partition)
+	for partitionNumber, replicas := range tm.Partitions {
+		partitionID, err := strconv.ParseInt(partitionNumber, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		replicaIDs := make([]int32, 0, len(replicas))
+		for _, r := range replicas {
+			replicaIDs = append(replicaIDs, int32(r))
+		}
+
+		result[int32(partitionID)] = t.Partition(int32(partitionID), replicaIDs)
+	}
+
+	return result, nil
+}
+
+// Partition returns a Partition instance for the topic.
+func (t *Topic) Partition(id int32, replicas []int32) *Partition {
+	return &Partition{ID: id, Replicas: replicas, topic: t}
+}
+
+// Config returns topic-level configuration settings as a map.
+func (t *Topic) Config() (map[string]string, error) {
+	value, _, err := t.kz.conn.Get(fmt.Sprintf("%s/config/topics/%s", t.kz.conf.Chroot, t.Name))
+	if err != nil {
+		return nil, err
+	}
+
+	var topicConfig struct {
+		ConfigMap map[string]string `json:"config"`
+	}
+
+	if err := json.Unmarshal(value, &topicConfig); err != nil {
+		return nil, err
+	}
+
+	return topicConfig.ConfigMap, nil
+}
+
+// Leader returns the broker ID of the broker that is currently the leader for the partition.
+func (p *Partition) Leader() (int32, error) {
+	if state, err := p.state(); err != nil {
+		return -1, err
+	} else {
+		return state.Leader, nil
+	}
+}
+
+// ISR returns the broker IDs of the current in-sync replica set for the partition
+func (p *Partition) ISR() ([]int32, error) {
+	if state, err := p.state(); err != nil {
+		return nil, err
+	} else {
+		return state.ISR, nil
+	}
+}
+
+type partitionState struct {
+	Leader int32   `json:"leader"`
+	ISR    []int32 `json:"isr"`
+}
+
+func (p *Partition) state() (partitionState, error) {
+	var state partitionState
+	node := fmt.Sprintf("%s/brokers/topics/%s/partitions/%d/state", p.topic.kz.conf.Chroot, p.topic.Name, p.ID)
+	value, _, err := p.topic.kz.conn.Get(node)
+	if err != nil {
+		return state, err
+	}
+
+	if err := json.Unmarshal(value, &state); err != nil {
+		return state, err
+	}
+
+	return state, nil
+}

--- a/vagrant/create_topics.sh
+++ b/vagrant/create_topics.sh
@@ -7,5 +7,5 @@ while ! nc -q 1 localhost 29092 </dev/null; do echo "Waiting"; sleep 1; done
 
 cd ${KAFKA_INSTALL_ROOT}/kafka-9092
 bin/kafka-topics.sh --create --partitions 1 --replication-factor 3 --topic test.1 --zookeeper localhost:2181
-bin/kafka-topics.sh --create --partitions 4 --replication-factor 3 --topic test.4 --zookeeper localhost:2181
-bin/kafka-topics.sh --create --partitions 64 --replication-factor 3 --topic test.64  --zookeeper localhost:2181
+bin/kafka-topics.sh --create --partitions 4 --replication-factor 3 --topic test.4 --zookeeper localhost:2181 --config retention.ms=604800000
+bin/kafka-topics.sh --create --partitions 64 --replication-factor 3 --topic test.64  --zookeeper localhost:2181 --config retention.ms=604800000


### PR DESCRIPTION
This adds Kazoo, a library to interact with Kafka's metadata in Zookeeper. This allows you to discover the Kafka brokers, and discover with the topic data.

Kazoo also provides most of the functionality to implement high-level consumer groups. The only thing that is missing is wrapper functions for the Zookeeper watches we need. We will need to have at least a watch on this instances of a consumergroup, most likely also on the partitions of the topics you are consuming, and potentially also on the list of topics. I will add these in a separate PR.

@Shopify/kafka @simongui 