### PR TITLE
Shuffle seed brokers so we don't always connect to the first one provided

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"math/rand"
 	"sort"
 	"sync"
 	"time"
@@ -117,8 +118,10 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 		cachedPartitionsResults: make(map[string][maxPartitionIndex][]int32),
 		coordinators:            make(map[string]int32),
 	}
-	for _, addr := range addrs {
-		client.seedBrokers = append(client.seedBrokers, NewBroker(addr))
+
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for _, index := range random.Perm(len(addrs)) {
+		client.seedBrokers = append(client.seedBrokers, NewBroker(addrs[index]))
 	}
 
 	// do an initial fetch of all cluster metadata by specifing an empty list of topics


### PR DESCRIPTION
I stole this idea from the Zookeeper library because is such a simple yet powerful way to load balance the metadata requests in the cluster over the different brokers. After the initial seed broker shuffle, seed broker handling is deterministic, and will work the exact same way before.

The way I fixed the "resurrect dead brokers" test is not great, but that is primarily because of the limitation of the mock broker implementation. If you have ideas to do this in a better way, tell me :)

@Shopify/kafka 