### PR TITLE
Amortize allocations in snappyDecode

### DIFF
--- a/snappy.go
+++ b/snappy.go
@@ -17,14 +17,17 @@ func snappyEncode(src []byte) ([]byte, error) {
 func snappyDecode(src []byte) ([]byte, error) {
 	if bytes.Equal(src[:8], snappyMagic) {
 		var (
-			pos = uint32(16)
-			max = uint32(len(src))
-			dst []byte
+			pos   = uint32(16)
+			max   = uint32(len(src))
+			dst   = make([]byte, 0, len(src))
+			chunk []byte
+			err   error
 		)
 		for pos < max {
 			size := binary.BigEndian.Uint32(src[pos : pos+4])
 			pos = pos + 4
-			chunk, err := snappy.Decode(nil, src[pos:pos+size])
+
+			chunk, err = snappy.Decode(chunk, src[pos:pos+size])
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Profiling the Kafka consumers at VividCortex showed me that a large portion of the allocated memory in our code comes from sarama.snappyDecode. This change reduces the average number of allocated bytes by pre-allocating the destination slice, and by re-using the chunk slice for cases that make multiple calls to snappy.Decode. Doing so should reduce GC pressure by a modest amount.