### PR TITLE
Fix import location of snappy.

### DIFF
--- a/snappy.go
+++ b/snappy.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"code.google.com/p/snappy-go/snappy"
+	"github.com/golang/snappy/snappy"
 )
 
 var snappyMagic = []byte{130, 83, 78, 65, 80, 80, 89, 0}


### PR DESCRIPTION
Project has been moved from code.google.com/p/snappy-go/snappy to
github.com/golang/snappy. As the code.google.com redirects to the
new location, it breaks a clean build of the current master.