### PR TITLE
Tweak where and how we wait for kafka to boot

### DIFF
--- a/vagrant/boot_cluster.sh
+++ b/vagrant/boot_cluster.sh
@@ -2,19 +2,21 @@
 
 set -ex
 
+# Launch and wait for toxiproxy
 vagrant/run_toxiproxy.sh &
-
 while ! nc -q 1 localhost 2181 </dev/null; do echo "Waiting"; sleep 1; done
 while ! nc -q 1 localhost 9092 </dev/null; do echo "Waiting"; sleep 1; done
 
+# Launch and wait for Zookeeper
 for i in 1 2 3 4 5; do
     KAFKA_PORT=`expr $i + 9090`
     cd ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT} && bin/zookeeper-server-start.sh -daemon config/zookeeper.properties
 done
-
 while ! nc -q 1 localhost 21805 </dev/null; do echo "Waiting"; sleep 1; done
 
+# Launch and wait for Kafka
 for i in 1 2 3 4 5; do
     KAFKA_PORT=`expr $i + 9090`
     cd ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT} && bin/kafka-server-start.sh -daemon config/server.properties
 done
+while ! nc -q 1 localhost 29095 </dev/null; do echo "Waiting"; sleep 1; done

--- a/vagrant/create_topics.sh
+++ b/vagrant/create_topics.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-while ! nc -q 1 localhost 21801 </dev/null; do echo "Waiting"; sleep 1; done
-while ! nc -q 1 localhost 29092 </dev/null; do echo "Waiting"; sleep 1; done
-
 cd ${KAFKA_INSTALL_ROOT}/kafka-9092
 bin/kafka-topics.sh --create --partitions 1 --replication-factor 3 --topic test.1 --zookeeper localhost:2181
 bin/kafka-topics.sh --create --partitions 4 --replication-factor 3 --topic test.4 --zookeeper localhost:2181

--- a/vagrant/setup_services.sh
+++ b/vagrant/setup_services.sh
@@ -24,3 +24,6 @@ for i in 1 2 3 4 5; do
 
     start zookeeper-${ZK_PORT}
 done
+
+# Wait for the last kafka node to finish booting
+while ! nc -q 1 localhost 29095 </dev/null; do echo "Waiting"; sleep 1; done


### PR DESCRIPTION
This should improve an occasional case where functional tests would fail
because a service wasn't ready yet.

cc @Shopify/kafka 