### PR TITLE
Enhance mock broker

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -447,13 +447,13 @@ func TestConsumerBounceWithReferenceOpen(t *testing.T) {
 	}
 
 	//redirect partition 1 back to main leader
-	fetchResponse := new(FetchResponse)
-	fetchResponse.AddError("my_topic", 1, ErrNotLeaderForPartition)
-	tmp.Returns(fetchResponse)
 	metadataResponse = new(MetadataResponse)
 	metadataResponse.AddTopicPartition("my_topic", 0, leader.BrokerID(), nil, nil, ErrNoError)
 	metadataResponse.AddTopicPartition("my_topic", 1, leader.BrokerID(), nil, nil, ErrNoError)
 	seedBroker.Returns(metadataResponse)
+	fetchResponse := new(FetchResponse)
+	fetchResponse.AddError("my_topic", 1, ErrNotLeaderForPartition)
+	tmp.Returns(fetchResponse)
 	time.Sleep(5 * time.Millisecond)
 
 	// now send one message to each partition to make sure everything is primed
@@ -493,10 +493,6 @@ func TestConsumerBounceWithReferenceOpen(t *testing.T) {
 	case <-c0.Errors():
 	case <-c1.Errors():
 	}
-	// send it back to the same broker
-	seedBroker.Returns(metadataResponse)
-
-	time.Sleep(5 * time.Millisecond)
 
 	select {
 	case <-c0.Messages():


### PR DESCRIPTION
EDIT: This PR introduces `SetHandler` method to the mock broker that allows setting a function that can generate responses based on actual incoming requests. That allows writing tests that account for concurrent execution non-determinism. By default a handler function that returns responses read from the expectations channel populated by the `Returns` method is used. Besides the broker can accept many connections now.

Old PR description:
Let me explain why I have made these changes first: The thing is that the current consumer implementation can block if a message channel of one of consumed partitions is not being drained. This logic does not play well with our use case, we cannot allow one partition consumer affect others, so we have reimplemented the consumer (our [implementation](https://github.com/mailgun/sarama/blob/maxim/develop/consumer.go) in case you are interested). It would be great if we could reuse the same unit test suite to validate our consumer. Alas the mock broker turned out to be too limited in the sense that it was only capable of generating a particular sequence of responses regardless of actually incoming requests. But requests can come in an undefined order when you test concurrent code. To address this deficiency we introduced the following changes that are included in this PR:
* **mockbrocker_test.go**:
  * `SetHandler` function allows to setup a request handler function that can generate responses based on incoming requests;
  * `defaultRequestHandler` function implements the old behavior - reads responses from the expectation channel and returns them one by one. It is used by default;
  * `SetHandlerByMap` function is a syntactic sugar that along with mock response objects (see below) allows defining mockbroker logic in a concise way [e.g.](https://github.com/mailgun/sarama/blob/maxim/mockbroker/consumer_test.go#L68-L80)
* **mockresponses_test.go** provides a set of mock response helpers that can be used in the request handler function to generate responses based on received requests;
* **consumer_test.go** was refactored to take advantage of the mockbrocker request handler and the mock responses. Note that one of the tests is commented out, this is where the original consumer blocks and our implementation keeps working.

So if you guys are interested in the proposed changes or a part of them, then let's begin a code review, if not then just close this PR and we will live with out own clone.