### PR TITLE
Fix snappy import and Encode return types

### DIFF
--- a/snappy.go
+++ b/snappy.go
@@ -11,7 +11,7 @@ var snappyMagic = []byte{130, 83, 78, 65, 80, 80, 89, 0}
 
 // SnappyEncode encodes binary data
 func snappyEncode(src []byte) ([]byte, error) {
-	return snappy.Encode(nil, src)
+	return snappy.Encode(nil, src), nil
 }
 
 // SnappyDecode decodes snappy data

--- a/snappy.go
+++ b/snappy.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/golang/snappy/snappy"
+	"github.com/golang/snappy"
 )
 
 var snappyMagic = []byte{130, 83, 78, 65, 80, 80, 89, 0}


### PR DESCRIPTION
Seems like over night the snappy library merged in some breaking changes.

https://github.com/golang/snappy/commits/master