### PR TITLE
Improve async_producer tests and prep for more

### DIFF
--- a/produce_request.go
+++ b/produce_request.go
@@ -93,8 +93,12 @@ func (p *ProduceRequest) decode(pd packetDecoder) error {
 			if messageSetSize == 0 {
 				continue
 			}
+			msgSetDecoder, err := pd.getSubset(int(messageSetSize))
+			if err != nil {
+				return err
+			}
 			msgSet := &MessageSet{}
-			err = msgSet.decode(pd)
+			err = msgSet.decode(msgSetDecoder)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- implement a mockProduceResponse
- fix decoding of produceRequests (bless my foresight in making getSubset a
  method on the packetDecoder)
- collapse three of the simpler existing producer tests into one as a
  proof-of-concept

Heavily influenced by Maxim's recent work on the consumer tests.

@Shopify/kafka cc @horkhe 