### PR TITLE
Make toxiproxy provisioning optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 env:
   global:
   - KAFKA_PEERS=localhost:9091,localhost:9092,localhost:9093,localhost:9094,localhost:9095
+  - TOXIPROXY_VERSION=1.0.3
   - TOXIPROXY_ADDR=http://localhost:8474
   - KAFKA_INSTALL_ROOT=/home/travis/kafka
   - KAFKA_HOSTNAME=localhost

--- a/vagrant/boot_cluster.sh
+++ b/vagrant/boot_cluster.sh
@@ -2,21 +2,28 @@
 
 set -ex
 
-# Launch and wait for toxiproxy
-${REPOSITORY_ROOT}/vagrant/run_toxiproxy.sh &
-while ! nc -q 1 localhost 2181 </dev/null; do echo "Waiting"; sleep 1; done
-while ! nc -q 1 localhost 9092 </dev/null; do echo "Waiting"; sleep 1; done
+# Launch and wait for toxiproxy if it is configured
+if [ -n "${TOXIPROXY_VERSION}" ]; then
+    ${REPOSITORY_ROOT}/vagrant/run_toxiproxy.sh &
+    while ! nc -q 1 localhost 2181 </dev/null; do echo "Waiting"; sleep 1; done
+    while ! nc -q 1 localhost 9092 </dev/null; do echo "Waiting"; sleep 1; done
+    ZOOKEEPER_WAIT_PORT=21805
+    KAFKA_WAIT_PORT=29095
+else
+    ZOOKEEPER_WAIT_PORT=2185
+    KAFKA_WAIT_PORT=9095
+fi
 
 # Launch and wait for Zookeeper
 for i in 1 2 3 4 5; do
     KAFKA_PORT=`expr $i + 9090`
     cd ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT} && bin/zookeeper-server-start.sh -daemon config/zookeeper.properties
 done
-while ! nc -q 1 localhost 21805 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost ${ZOOKEEPER_WAIT_PORT} </dev/null; do echo "Waiting"; sleep 1; done
 
 # Launch and wait for Kafka
 for i in 1 2 3 4 5; do
     KAFKA_PORT=`expr $i + 9090`
     cd ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT} && bin/kafka-server-start.sh -daemon config/server.properties
 done
-while ! nc -q 1 localhost 29095 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost ${KAFKA_WAIT_PORT} </dev/null; do echo "Waiting"; sleep 1; done

--- a/vagrant/install_cluster.sh
+++ b/vagrant/install_cluster.sh
@@ -2,24 +2,32 @@
 
 set -ex
 
-TOXIPROXY_VERSION=1.0.3
-
 mkdir -p ${KAFKA_INSTALL_ROOT}
 if [ ! -f ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz ]; then
     wget --quiet http://apache.mirror.gtcomm.net/kafka/${KAFKA_VERSION}/kafka_2.10-${KAFKA_VERSION}.tgz -O ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz
 fi
-if [ ! -f ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ]; then
-    wget --quiet https://github.com/Shopify/toxiproxy/releases/download/v${TOXIPROXY_VERSION}/toxiproxy-linux-amd64 -O ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}
-    chmod +x ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}
+
+if [ -n "${TOXIPROXY_VERSION}" ]; then
+    if [ ! -f ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ]; then
+        wget --quiet https://github.com/Shopify/toxiproxy/releases/download/v${TOXIPROXY_VERSION}/toxiproxy-linux-amd64 -O ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}
+        chmod +x ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}
+    fi
+    rm -f ${KAFKA_INSTALL_ROOT}/toxiproxy
+    ln -s ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ${KAFKA_INSTALL_ROOT}/toxiproxy
 fi
-rm -f ${KAFKA_INSTALL_ROOT}/toxiproxy
-ln -s ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ${KAFKA_INSTALL_ROOT}/toxiproxy
 
 for i in 1 2 3 4 5; do
     ZK_PORT=`expr $i + 2180`
-    ZK_PORT_REAL=`expr $i + 21800`
     KAFKA_PORT=`expr $i + 9090`
-    KAFKA_PORT_REAL=`expr $i + 29090`
+    if [ -n "${TOXIPROXY_VERSION}" ]; then
+        ZK_PORT_REAL=`expr $i + 21800`
+        KAFKA_PORT_REAL=`expr $i + 29090`
+        KAFKA_HOST=localhost
+    else
+        ZK_PORT_REAL=${ZK_PORT}
+        KAFKA_PORT_REAL=${KAFKA_PORT}
+        KAFKA_HOST=0.0.0.0
+    fi
 
     # unpack kafka
     mkdir -p ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}
@@ -29,6 +37,7 @@ for i in 1 2 3 4 5; do
     cp ${REPOSITORY_ROOT}/vagrant/server.properties ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}/config/
     sed -i s/KAFKAID/${KAFKA_PORT}/g ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}/config/server.properties
     sed -i s/KAFKAPORT/${KAFKA_PORT_REAL}/g ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}/config/server.properties
+    sed -i s/KAFKAHOST/${KAFKA_HOST}/g ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}/config/server.properties
     sed -i s/KAFKA_HOSTNAME/${KAFKA_HOSTNAME}/g ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}/config/server.properties
     sed -i s/ZK_PORT/${ZK_PORT}/g ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}/config/server.properties
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -5,6 +5,7 @@ set -ex
 apt-get update
 yes | apt-get install default-jre
 
+export TOXIPROXY_VERSION=1.0.3
 export KAFKA_INSTALL_ROOT=/opt
 export KAFKA_HOSTNAME=192.168.100.67
 export KAFKA_VERSION=0.8.2.1

--- a/vagrant/server.properties
+++ b/vagrant/server.properties
@@ -25,7 +25,7 @@ broker.id=KAFKAID
 port=KAFKAPORT
 
 # Hostname the broker will bind to. If not set, the server will bind to all interfaces
-host.name=localhost
+host.name=KAFKAHOST
 
 # Hostname the broker will advertise to producers and consumers. If not set, it uses the
 # value for "host.name" if configured.  Otherwise, it will use the value returned from

--- a/vagrant/setup_services.sh
+++ b/vagrant/setup_services.sh
@@ -2,10 +2,15 @@
 
 set -ex
 
-stop toxiproxy || true
-cp ${REPOSITORY_ROOT}/vagrant/toxiproxy.conf /etc/init/toxiproxy.conf
-cp ${REPOSITORY_ROOT}/vagrant/run_toxiproxy.sh ${KAFKA_INSTALL_ROOT}/
-start toxiproxy
+if [ -n "${TOXIPROXY_VERSION}" ]; then
+    stop toxiproxy || true
+    cp ${REPOSITORY_ROOT}/vagrant/toxiproxy.conf /etc/init/toxiproxy.conf
+    cp ${REPOSITORY_ROOT}/vagrant/run_toxiproxy.sh ${KAFKA_INSTALL_ROOT}/
+    start toxiproxy
+    KAFKA_WAIT_PORT=29095
+else
+    KAFKA_WAIT_PORT=9095
+fi
 
 for i in 1 2 3 4 5; do
     ZK_PORT=`expr $i + 2180`
@@ -26,4 +31,4 @@ for i in 1 2 3 4 5; do
 done
 
 # Wait for the last kafka node to finish booting
-while ! nc -q 1 localhost 29095 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost ${KAFKA_WAIT_PORT} </dev/null; do echo "Waiting"; sleep 1; done


### PR DESCRIPTION
Some projects use sarama's vagrant install to run functional tests, but sometimes tests that are supposed to be deterministic are being messed up by toxiproxy. This PR makes it possible to exclude toxiproxy from the setup. If `TOXIPROXY_VERSION` env variable is defined then it is provisioned, otherwise it is not.