### PR TITLE
Gimme expects 1.5 not 1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 go:
 - 1.3.3
 - 1.4.2
-- 1.5.0
+- 1.5
 
 env:
   global:


### PR DESCRIPTION
@wvanbergen noticed this in the CI logs:

```
$ eval "$(gimme 1.5.0)"
I don't have any idea what to do with '1.5.0'.
  (using type 'auto')
$ gimme version
v0.2.3
$ go version
go version go1.4.1 linux/amd64
```