### PR TITLE
Fix two decoding bugs found by go-fuzz

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -312,7 +312,10 @@ func (b *Broker) decode(pd packetDecoder) (err error) {
 		return err
 	}
 
-	b.addr = fmt.Sprint(host, ":", port)
+	b.addr = net.JoinHostPort(host, fmt.Sprint(port))
+	if _, _, err := net.SplitHostPort(b.addr); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -22,6 +22,9 @@ func (pr *FetchResponseBlock) decode(pd packetDecoder) (err error) {
 	if err != nil {
 		return err
 	}
+	if msgSetSize < 0 {
+		return PacketDecodingError{"invalid message set size"}
+	}
 
 	msgSetDecoder, err := pd.getSubset(int(msgSetSize))
 	if err != nil {


### PR DESCRIPTION
(https://github.com/dvyukov/go-fuzz)

- handle negative message-set sizes in FetchResponses
- handle IPv6 and/or malformed broker addresses

@Shopify/kafka 