### PR TITLE
Use an optimized crc32 library which is faster

### DIFF
--- a/crc32_field.go
+++ b/crc32_field.go
@@ -2,7 +2,8 @@ package sarama
 
 import (
 	"encoding/binary"
-	"hash/crc32"
+
+	"github.com/klauspost/crc32"
 )
 
 // crc32Field implements the pushEncoder and pushDecoder interfaces for calculating CRC32s.


### PR DESCRIPTION
Needs testing to ensure that this is actually faster (and is still correct), but may solve #255.