### PR TITLE
Producer refactor

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -681,9 +681,11 @@ func (f *flusher) parseBlock(topic string, partition int32, msgs []*ProducerMess
 	switch block.Err {
 	// Success
 	case ErrNoError:
-		for i := range msgs {
-			if msgs[i] != nil {
-				msgs[i].Offset = block.Offset + int64(i) // FIXME: offsets wrong now
+		i := 0
+		for _, msg := range msgs {
+			if msg != nil {
+				msg.Offset = block.Offset + int64(i)
+				i++
 			}
 		}
 		f.parent.returnSuccesses(msgs)

--- a/async_producer.go
+++ b/async_producer.go
@@ -702,8 +702,6 @@ func (bp *brokerProducer) handleResponse(response *ProduceResponse) {
 
 func (bp *brokerProducer) handleError(err error) {
 	switch err.(type) {
-	case nil:
-		break
 	case PacketEncodingError:
 		bp.pending.eachPartition(func(topic string, partition int32, msgs []*ProducerMessage) {
 			bp.parent.returnErrors(msgs, err)
@@ -731,10 +729,6 @@ type flusher struct {
 func (f *flusher) run() {
 	for set := range f.input {
 		request := set.buildRequest()
-		if request == nil {
-			f.errors <- nil
-			continue
-		}
 
 		response, err := f.broker.Produce(request)
 
@@ -836,10 +830,6 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 }
 
 func (ps *produceSet) buildRequest() *ProduceRequest {
-	if ps.empty() {
-		return nil
-	}
-
 	req := &ProduceRequest{
 		RequiredAcks: ps.parent.conf.Producer.RequiredAcks,
 		Timeout:      int32(ps.parent.conf.Producer.Timeout / time.Millisecond),

--- a/async_producer.go
+++ b/async_producer.go
@@ -876,8 +876,10 @@ func (ps *produceSet) wouldOverflow(msg *ProducerMessage) bool {
 	// Would we overflow our maximum possible size-on-the-wire? 10KiB is arbitrary overhead for safety.
 	case ps.bufferBytes+msg.byteSize() >= int(MaxRequestSize-(10*1024)):
 		return true
-	// Would we overflow the size-limit of a compressed message-batch?
-	case ps.parent.conf.Producer.Compression != CompressionNone && ps.bufferBytes+msg.byteSize() >= ps.parent.conf.Producer.MaxMessageBytes:
+	// Would we overflow the size-limit of a compressed message-batch for this partition?
+	case ps.parent.conf.Producer.Compression != CompressionNone &&
+		ps.msgs[msg.Topic] != nil && ps.msgs[msg.Topic][msg.Partition] != nil &&
+		ps.msgs[msg.Topic][msg.Partition].bufferBytes+msg.byteSize() >= ps.parent.conf.Producer.MaxMessageBytes:
 		return true
 	// Would we overflow simply in number of messages?
 	case ps.parent.conf.Producer.Flush.MaxMessages > 0 && ps.bufferCount >= ps.parent.conf.Producer.Flush.MaxMessages:

--- a/async_producer.go
+++ b/async_producer.go
@@ -944,17 +944,12 @@ func (p *asyncProducer) returnError(msg *ProducerMessage, err error) {
 
 func (p *asyncProducer) returnErrors(batch []*ProducerMessage, err error) {
 	for _, msg := range batch {
-		if msg != nil {
-			p.returnError(msg, err)
-		}
+		p.returnError(msg, err)
 	}
 }
 
 func (p *asyncProducer) returnSuccesses(batch []*ProducerMessage) {
 	for _, msg := range batch {
-		if msg == nil {
-			continue
-		}
 		if p.conf.Producer.Return.Successes {
 			msg.clear()
 			p.successes <- msg
@@ -965,9 +960,6 @@ func (p *asyncProducer) returnSuccesses(batch []*ProducerMessage) {
 
 func (p *asyncProducer) retryMessages(batch []*ProducerMessage, err error) {
 	for _, msg := range batch {
-		if msg == nil {
-			continue
-		}
 		if msg.retries >= p.conf.Producer.Retry.Max {
 			p.returnError(msg, err)
 		} else {

--- a/async_producer.go
+++ b/async_producer.go
@@ -585,7 +585,7 @@ func (bp *brokerProducer) run() {
 				continue
 			}
 
-			if bp.buffer.readyToFlush(msg) {
+			if bp.buffer.readyToFlush() {
 				output = bp.output
 			} else if bp.parent.conf.Producer.Flush.Frequency > 0 && bp.timer == nil {
 				bp.timer = time.After(bp.parent.conf.Producer.Flush.Frequency)
@@ -879,7 +879,7 @@ func (ps *produceSet) wouldOverflow(msg *ProducerMessage) bool {
 	}
 }
 
-func (ps *produceSet) readyToFlush(msg *ProducerMessage) bool {
+func (ps *produceSet) readyToFlush() bool {
 	switch {
 	// If all three config values are 0, we always flush as-fast-as-possible
 	case ps.parent.conf.Producer.Flush.Frequency == 0 && ps.parent.conf.Producer.Flush.Bytes == 0 && ps.parent.conf.Producer.Flush.Messages == 0:

--- a/async_producer.go
+++ b/async_producer.go
@@ -889,9 +889,6 @@ func (ps *produceSet) readyToFlush(msg *ProducerMessage) bool {
 	// If all three config values are 0, we always flush as-fast-as-possible
 	case ps.parent.conf.Producer.Flush.Frequency == 0 && ps.parent.conf.Producer.Flush.Bytes == 0 && ps.parent.conf.Producer.Flush.Messages == 0:
 		return true
-	// If the messages is a chaser we must flush to maintain the state-machine
-	case msg.flags&chaser == chaser:
-		return true
 	// If we've passed the message trigger-point
 	case ps.parent.conf.Producer.Flush.Messages > 0 && ps.bufferCount >= ps.parent.conf.Producer.Flush.Messages:
 		return true

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -320,7 +320,7 @@ func TestAsyncProducerEncoderFailures(t *testing.T) {
 	leader.Returns(prodSuccess)
 
 	config := NewConfig()
-	config.Producer.Flush.Messages = 3
+	config.Producer.Flush.Messages = 1
 	config.Producer.Return.Successes = true
 	config.Producer.Partitioner = NewManualPartitioner
 	producer, err := NewAsyncProducer([]string{seedBroker.Addr()}, config)
@@ -330,8 +330,8 @@ func TestAsyncProducerEncoderFailures(t *testing.T) {
 
 	for flush := 0; flush < 3; flush++ {
 		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: flakyEncoder(true), Value: flakyEncoder(false)}
-		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: flakyEncoder(true), Value: flakyEncoder(true)}
 		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: flakyEncoder(false), Value: flakyEncoder(true)}
+		producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: flakyEncoder(true), Value: flakyEncoder(true)}
 		expectResults(t, producer, 1, 2)
 	}
 


### PR DESCRIPTION
This is an experimental refactor of the entire aggregator/flusher pipeline. If successful it would close #433 as well as properly solve the issue papered over by #538.

I did a decent job of making each commit stand-alone and self-explanatory, so you can read commit-at-a-time, or just treat it as entirely new code. The total diff against the old code is impossible to follow.

High-level, this is what I did:
- Introduce a `produceSet` structure which collects messages, rejecting those which fail to encode and incrementally constructing a `ProduceRequest` out of those which succeed.
- Keep a running `produceSet` in the aggregator instead of just a `[]*ProducerMessage`. Move all the "how many bytes/messages in this batch so far?" logic into the `produceSet`.
- Merge the flusher and the aggregator into a single `brokerProducer`. Revive the flusher as a trivial goroutine whose sole purpose is to let the aggregator `select` on the result of its network calls.
- Clean up a bunch of now-dead code.

This new layout has a number of benefits:
- Messages live solely in the `produceSet`, which makes them much easier to track vs. having them spread across a slice, a map, and a long-lived request object.
- Messages only even enter the `produceSet` when they encode properly, which means that a whole raft of logic can go away around handling requests which encoded successfully but contained no successful messages. This also means that we no longer need to nil out array entries for failed messages, getting rid of another bunch of ugly logic.
- Retry state is handled message-at-a-time as the messages enter the `brokerProducer`, rather than batch-at-a-time as they enter the `flusher`. This is much easier to follow, cleans up a few hacks that were necessary for the aggregator to correctly pass along flagged messages, and makes for a sane state machine that clearly terminates in all cases.
- The `produceSet` can track how many bytes it has accumulated in each individual partition. It also has access to the actual encoded length, not just the estimate provided by the `Encoder` interface. This makes it more precise, and lets it accumulate much larger batches safely. In particular, this lets it accumulate requests larger than `MaxMessageSize` (usually 1MB) when using compression.
- It is now substantially easier to add support for request pipelining if that project ever gets off the ground on the server side.

@wvanbergen 
cc @kvs @andremedeiros @bai @cep21 

P.S. I don't want to make any claims about performance without measurements to back them up, but in theory this is a performance win too: we do fewer passes over each message, we generate less garbage for the collector, and we do more work without needing to context-switch.