### PR TITLE
producer: simplify initial "too large" check

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -249,9 +249,7 @@ func (p *asyncProducer) dispatcher() {
 			p.inFlight.Add(1)
 		}
 
-		if (p.conf.Producer.Compression == CompressionNone && msg.Value != nil && msg.Value.Length() > p.conf.Producer.MaxMessageBytes) ||
-			(msg.byteSize() > p.conf.Producer.MaxMessageBytes) {
-
+		if msg.byteSize() > p.conf.Producer.MaxMessageBytes {
 			p.returnError(msg, ErrMessageSizeTooLarge)
 			continue
 		}


### PR DESCRIPTION
Minor oddity I noticed while working on the aggregator/flusher refactor; this
looks like vestigial code from some attempt at handling the weird size
requirements of compressed message batches, but since `msg.byteSize()`
*includes* `msg.Value.Length()` if appropriate, the entire first condition of
this `||` is superceded by the second.

@wvanbergen Saturday's not-so-scary PR :)