### PR TITLE
Collapse two sync.atomic calls

### DIFF
--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -264,10 +264,9 @@ func (pc *PartitionConsumer) YieldMessage(msg *sarama.ConsumerMessage) {
 	pc.l.Lock()
 	defer pc.l.Unlock()
 
-	atomic.AddInt64(&pc.highWaterMarkOffset, 1)
 	msg.Topic = pc.topic
 	msg.Partition = pc.partition
-	msg.Offset = atomic.LoadInt64(&pc.highWaterMarkOffset)
+	msg.Offset = atomic.AddInt64(&pc.highWaterMarkOffset, 1)
 
 	pc.messages <- msg
 }


### PR DESCRIPTION
It doesn't matter since we're inside a mutex anyways, but this is cleaner.

cc @wvanbergen @aaronkavlie-wf 