### PR TITLE
Introduce mockSequence and further simplify tests

### DIFF
--- a/mockbroker_test.go
+++ b/mockbroker_test.go
@@ -59,17 +59,8 @@ func (b *mockBroker) SetLatency(latency time.Duration) {
 	b.latency = latency
 }
 
-// SetHandler sets the specified function as the request handler. Whenever
-// a mock broker reads a request from the wire it passes the request to the
-// function and sends back whatever the handler function returns.
-func (b *mockBroker) SetHandler(handler requestHandlerFunc) {
-	b.lock.Lock()
-	b.handler = handler
-	b.lock.Unlock()
-}
-
 func (b *mockBroker) SetHandlerByMap(handlerMap map[string]MockResponse) {
-	b.SetHandler(func(req *request) (res encoder) {
+	b.setHandler(func(req *request) (res encoder) {
 		reqTypeName := reflect.TypeOf(req.body).Elem().Name()
 		mockResponse := handlerMap[reqTypeName]
 		if mockResponse == nil {
@@ -110,6 +101,15 @@ func (b *mockBroker) Close() {
 	}
 	close(b.closing)
 	<-b.stopper
+}
+
+// setHandler sets the specified function as the request handler. Whenever
+// a mock broker reads a request from the wire it passes the request to the
+// function and sends back whatever the handler function returns.
+func (b *mockBroker) setHandler(handler requestHandlerFunc) {
+	b.lock.Lock()
+	b.handler = handler
+	b.lock.Unlock()
 }
 
 func (b *mockBroker) serverLoop() {


### PR DESCRIPTION
This PR introduces `mockSequence` response builder that is created of a sequence of (mock)responses and everytime when `MockBroker` calls its `For` method it returns the next response from the sequence. When the last element in the sequence is reached it is returned for every subsequent call of the `For` method.

This change allows to define `MockBrocker` handler with `SetHandlerByMap` exclusively, that makes tests a bit shorter and easier to read.