### PR TITLE
Upgrade vagrant from precise to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - DEBUG=true
   matrix:
   - KAFKA_VERSION=0.8.1.1
-  - KAFKA_VERSION=0.8.2.1
+  - KAFKA_VERSION=0.8.2.2
 
 before_install:
 - export REPOSITORY_ROOT=${TRAVIS_BUILD_DIR}
@@ -33,7 +33,7 @@ script:
 matrix:
   include:
     - go: tip
-      env: KAFKA_VERSION=0.8.2.1
+      env: KAFKA_VERSION=0.8.2.2
   allow_failures:
     - go: tip
   fast_finish: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,15 +7,12 @@ VAGRANTFILE_API_VERSION = "2"
 MEMORY = 3072
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.provision :shell, path: "vagrant/provision.sh"
 
   config.vm.network "private_network", ip: "192.168.100.67"
 
-  config.vm.provider "vmware_fusion" do |v|
-    v.vmx["memsize"] = MEMORY.to_s
-  end
   config.vm.provider "virtualbox" do |v|
     v.memory = MEMORY
   end

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -7,7 +7,7 @@ yes | apt-get install default-jre
 
 export KAFKA_INSTALL_ROOT=/opt
 export KAFKA_HOSTNAME=192.168.100.67
-export KAFKA_VERSION=0.8.2.1
+export KAFKA_VERSION=0.8.2.2
 export REPOSITORY_ROOT=/vagrant
 
 sh /vagrant/vagrant/install_cluster.sh


### PR DESCRIPTION
This adds java 7 which will be necessary for kafka 0.9, but drops support for
non-virtualbox hosts.

Also bump kafka 0.8.2.1 to 0.8.2.2 for trivial bug-fixes.

@wvanbergen @kvs 