### PR TITLE
Add a buffer around the broker's net.Conn for reads

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -85,7 +85,7 @@ func (b *Broker) Open(conf *Config) error {
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			return
 		}
-		b.conn = NewBufConn(b.conn)
+		b.conn = newBufConn(b.conn)
 
 		b.conf = conf
 		b.done = make(chan bool)

--- a/broker.go
+++ b/broker.go
@@ -85,6 +85,7 @@ func (b *Broker) Open(conf *Config) error {
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			return
 		}
+		b.conn = NewBufConn(b.conn)
 
 		b.conf = conf
 		b.done = make(chan bool)

--- a/utils.go
+++ b/utils.go
@@ -99,7 +99,7 @@ type bufConn struct {
 	buf *bufio.Reader
 }
 
-func NewBufConn(conn net.Conn) *bufConn {
+func newBufConn(conn net.Conn) *bufConn {
 	return &bufConn{
 		Conn: conn,
 		buf:  bufio.NewReader(conn),

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,10 @@
 package sarama
 
-import "sort"
+import (
+	"bufio"
+	"net"
+	"sort"
+)
 
 type none struct{}
 
@@ -86,4 +90,22 @@ func (b ByteEncoder) Encode() ([]byte, error) {
 
 func (b ByteEncoder) Length() int {
 	return len(b)
+}
+
+// bufConn wraps a net.Conn with a buffer for reads to reduce the number of
+// reads that trigger syscalls.
+type bufConn struct {
+	net.Conn
+	buf *bufio.Reader
+}
+
+func NewBufConn(conn net.Conn) *bufConn {
+	return &bufConn{
+		Conn: conn,
+		buf:  bufio.NewReader(conn),
+	}
+}
+
+func (bc *bufConn) Read(b []byte) (n int, err error) {
+	return bc.buf.Read(b)
 }


### PR DESCRIPTION
Reduces the number of read syscalls issued by short, sequential reads on the broker's net.Conn. A similar technique is used in the [`net/http`](https://github.com/golang/go/blob/master/src/net/http/server.go#L482) package.