### PR TITLE
Publish GroupGenerationUndefined constant

### DIFF
--- a/offset_commit_request.go
+++ b/offset_commit_request.go
@@ -5,6 +5,11 @@ package sarama
 // The timestamp is only used if message version 1 is used, which requires kafka 0.8.2.
 const ReceiveTime int64 = -1
 
+// GroupGenerationUndefined is a special value of group generation field of
+// Offset Commit Request that should be used when a consumer group does not rely
+// on Kafka for partition management.
+const GroupGenerationUndefined = -1
+
 type offsetCommitRequestBlock struct {
 	offset    int64
 	timestamp int64

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -7,8 +7,6 @@ import (
 
 // Offset Manager
 
-const groupGenerationUndefined = -1
-
 // OffsetManager uses Kafka to store and fetch consumed partition offsets.
 type OffsetManager interface {
 	// ManagePartition creates a PartitionOffsetManager on the given topic/partition.
@@ -480,7 +478,7 @@ func (bom *brokerOffsetManager) constructRequest() *OffsetCommitRequest {
 	r := &OffsetCommitRequest{
 		Version:                 1,
 		ConsumerGroup:           bom.parent.group,
-		ConsumerGroupGeneration: groupGenerationUndefined,
+		ConsumerGroupGeneration: GroupGenerationUndefined,
 	}
 
 	for s := range bom.subscriptions {


### PR DESCRIPTION
In #585 I made a mistake declaring `groupGenerationUndefined` as module internal. It is a part of protocol and therefore should be public. It also belongs to **offset_commit_request.go** file along with `ReceiveTime` constant.