### PR TITLE
replace label & goto with a method

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -581,7 +581,8 @@ func (bp *brokerProducer) run() {
 		select {
 		case msg := <-bp.input:
 			if msg == nil {
-				goto shutdown
+				bp.shutdown()
+				return
 			}
 
 			if msg.flags&syn == syn {
@@ -637,8 +638,9 @@ func (bp *brokerProducer) run() {
 			output = nil
 		}
 	}
+}
 
-shutdown:
+func (bp *brokerProducer) shutdown() {
 	for !bp.buffer.empty() {
 		select {
 		case response := <-bp.responses:


### PR DESCRIPTION
Work around the const/label conflict bug in go16beta1 by replacing a label & goto with a method.

golang/go#13684