### PR TITLE
Consumer rebalancing

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -33,7 +33,7 @@ type responsePromise struct {
 	errors        chan error
 }
 
-// NewBroker creates and returns a Broker targetting the given host:port address.
+// NewBroker creates and returns a Broker targeting the given host:port address.
 // This does not attempt to actually connect, you have to call Open() for that.
 func NewBroker(addr string) *Broker {
 	return &Broker{id: -1, addr: addr}

--- a/broker.go
+++ b/broker.go
@@ -191,7 +191,7 @@ func (b *Broker) JoinGroup(request *JoinGroupRequest) (*JoinGroupResponse, error
 
 	err := b.sendAndReceive(request, response)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -203,7 +203,7 @@ func (b *Broker) LeaveGroup(request *LeaveGroupRequest) (*LeaveGroupResponse, er
 
 	err := b.sendAndReceive(request, response)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -227,7 +227,7 @@ func (b *Broker) DescribeGroups(request *DescribeGroupsRequest) (*DescribeGroups
 
 	err := b.sendAndReceive(request, response)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -239,7 +239,7 @@ func (b *Broker) ListGroups(request *ListGroupsRequest) (*ListGroupsResponse, er
 
 	err := b.sendAndReceive(request, response)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 
@@ -251,7 +251,7 @@ func (b *Broker) HeartbeatRequest(request *HeartbeatRequest) (*HeartbeatResponse
 
 	err := b.sendAndReceive(request, response)
 
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/broker.go
+++ b/broker.go
@@ -85,6 +85,7 @@ func (b *Broker) Open(conf *Config) error {
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			return
 		}
+		b.conn = newBufConn(b.conn)
 
 		b.conf = conf
 		b.done = make(chan bool)
@@ -311,17 +312,6 @@ func (b *Broker) FetchOffset(request *OffsetFetchRequest) (*OffsetFetchResponse,
 	return response, nil
 }
 
-func (b *Broker) JoinGroup(request *JoinGroupRequest) (*JoinGroupResponse, error) {
-	response := new(JoinGroupResponse)
-
-	err := b.sendAndReceive(request, response)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
 func (b *Broker) SyncGroup(request *SyncGroupRequest) (*SyncGroupResponse, error) {
 	response := new(SyncGroupResponse)
 
@@ -333,41 +323,8 @@ func (b *Broker) SyncGroup(request *SyncGroupRequest) (*SyncGroupResponse, error
 	return response, nil
 }
 
-func (b *Broker) LeaveGroup(request *LeaveGroupRequest) (*LeaveGroupResponse, error) {
-	response := new(LeaveGroupResponse)
-
-	err := b.sendAndReceive(request, response)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
 func (b *Broker) Heartbeat(request *HeartbeatRequest) (*HeartbeatResponse, error) {
 	response := new(HeartbeatResponse)
-
-	err := b.sendAndReceive(request, response)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
-func (b *Broker) ListGroups(request *ListGroupsRequest) (*ListGroupsResponse, error) {
-	response := new(ListGroupsResponse)
-
-	err := b.sendAndReceive(request, response)
-	if err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
-func (b *Broker) DescribeGroups(request *DescribeGroupsRequest) (*DescribeGroupsResponse, error) {
-	response := new(DescribeGroupsResponse)
 
 	err := b.sendAndReceive(request, response)
 	if err != nil {

--- a/broker.go
+++ b/broker.go
@@ -85,7 +85,6 @@ func (b *Broker) Open(conf *Config) error {
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			return
 		}
-		b.conn = newBufConn(b.conn)
 
 		b.conf = conf
 		b.done = make(chan bool)
@@ -180,6 +179,78 @@ func (b *Broker) GetAvailableOffsets(request *OffsetRequest) (*OffsetResponse, e
 	err := b.sendAndReceive(request, response)
 
 	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Broker) JoinGroup(request *JoinGroupRequest) (*JoinGroupResponse, error) {
+	response := new(JoinGroupResponse)
+
+	err := b.sendAndReceive(request, response)
+
+	if (err != nil) {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Broker) LeaveGroup(request *LeaveGroupRequest) (*LeaveGroupResponse, error) {
+	response := new(LeaveGroupResponse)
+
+	err := b.sendAndReceive(request, response)
+
+	if (err != nil) {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Broker) SyncConsumerGroup(request *SyncGroupRequest) (*SyncGroupResponse, error) {
+	response := new(SyncGroupResponse)
+
+	err := b.sendAndReceive(request, response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Broker) DescribeGroups(request *DescribeGroupsRequest) (*DescribeGroupsResponse, error) {
+	response := new(DescribeGroupsResponse)
+
+	err := b.sendAndReceive(request, response)
+
+	if (err != nil) {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Broker) ListGroups(request *ListGroupsRequest) (*ListGroupsResponse, error) {
+	response := new(ListGroupsResponse)
+
+	err := b.sendAndReceive(request, response)
+
+	if (err != nil) {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (b *Broker) HeartbeatRequest(request *HeartbeatRequest) (*HeartbeatResponse, error) {
+	response := new(HeartbeatResponse)
+
+	err := b.sendAndReceive(request, response)
+
+	if (err != nil) {
 		return nil, err
 	}
 

--- a/config.go
+++ b/config.go
@@ -186,6 +186,8 @@ type Config struct {
 			// Should be OffsetNewest or OffsetOldest. Defaults to OffsetNewest.
 			Initial int64
 		}
+
+		SessionTimeout time.Duration
 	}
 
 	// A user-provided string sent with every request to the brokers for logging,
@@ -228,6 +230,7 @@ func NewConfig() *Config {
 	c.Consumer.Return.Errors = false
 	c.Consumer.Offsets.CommitInterval = 1 * time.Second
 	c.Consumer.Offsets.Initial = OffsetNewest
+	c.Consumer.SessionTimeout = 30 * time.Second
 
 	c.ChannelBufferSize = 256
 

--- a/consumer.go
+++ b/consumer.go
@@ -1164,7 +1164,6 @@ func (c *consumer) heartbeat(heartbeatChannel <-chan string) error {
 					c.joinGroup(c.consumerGroup, activeTopic)
 				} else if resp.Err != ErrNoError {
 					panic(resp.Err)
-					return nil
 				}
 			case controlMessage := <-heartbeatChannel:
 				fmt.Println("Received heartbeat control message: ", controlMessage)

--- a/consumer.go
+++ b/consumer.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 	"container/heap"
-	"encoding/json"
 )
 
 // ConsumerMessage encapsulates a Kafka message returned by the consumer.
@@ -928,9 +927,6 @@ func (c *consumer) communicateSubscriptionChanges(newAssignments *ConsumerGroupM
 			}
 		}
 	}
-
-	derp, _ := json.Marshal(changes)
-	fmt.Println(string(derp))
 
 	if len(changes) != 0 {
 		c.rebalanceEvents <- &RebalanceEvent{Subscriptions: changes, Type: SubscriptionAdd}

--- a/join_group_request.go
+++ b/join_group_request.go
@@ -5,7 +5,7 @@ type JoinGroupRequest struct {
 	SessionTimeout int32
 	MemberId       string
 	ProtocolType   string
-	GroupProtocols map[string]*ProtocolMetadata
+	GroupProtocols map[string][]byte
 }
 
 func (r *JoinGroupRequest) encode(pe packetEncoder) error {
@@ -28,11 +28,7 @@ func (r *JoinGroupRequest) encode(pe packetEncoder) error {
 			return err
 		}
 
-		data, err := encode(metadata)
-		if (err != nil) {
-			return err
-		}
-		if err := pe.putBytes(data); err != nil {
+		if err := pe.putBytes(metadata); err != nil {
 			return err
 		}
 	}
@@ -65,7 +61,7 @@ func (r *JoinGroupRequest) decode(pd packetDecoder) (err error) {
 		return nil
 	}
 
-	r.GroupProtocols = make(map[string]*ProtocolMetadata)
+	r.GroupProtocols = make(map[string][]byte)
 	for i := 0; i < n; i++ {
 		name, err := pd.getString()
 		if err != nil {
@@ -75,12 +71,7 @@ func (r *JoinGroupRequest) decode(pd packetDecoder) (err error) {
 		if data, err := pd.getBytes(); err != nil {
 			return err
 		} else {
-			protocolMetadata := new(ProtocolMetadata)
-			if err := decode(data, protocolMetadata); err != nil {
-				return err
-			}
-
-			r.GroupProtocols[name] = protocolMetadata
+			r.GroupProtocols[name] = data
 		}
 
 	}
@@ -96,9 +87,9 @@ func (r *JoinGroupRequest) version() int16 {
 	return 0
 }
 
-func (r *JoinGroupRequest) AddGroupProtocol(name string, metadata *ProtocolMetadata) {
+func (r *JoinGroupRequest) AddGroupProtocol(name string, metadata []byte) {
 	if r.GroupProtocols == nil {
-		r.GroupProtocols = make(map[string]*ProtocolMetadata)
+		r.GroupProtocols = make(map[string][]byte)
 	}
 
 	r.GroupProtocols[name] = metadata

--- a/join_group_response.go
+++ b/join_group_response.go
@@ -6,7 +6,7 @@ type JoinGroupResponse struct {
 	GroupProtocol string
 	LeaderId      string
 	MemberId      string
-	Members       map[string]*ProtocolMetadata
+	Members       map[string][]byte
 }
 
 func (r *JoinGroupResponse) GetMembers() (map[string]ConsumerGroupMemberMetadata, error) {
@@ -44,12 +44,8 @@ func (r *JoinGroupResponse) encode(pe packetEncoder) error {
 			return err
 		}
 
-		if data, err := encode(memberMetadata); err != nil {
-			return nil
-		} else {
-			if err := pe.putBytes(data); err != nil {
-				return err
-			}
+		if err := pe.putBytes(memberMetadata); err != nil {
+			return err
 		}
 	}
 
@@ -87,7 +83,7 @@ func (r *JoinGroupResponse) decode(pd packetDecoder) (err error) {
 		return nil
 	}
 
-	r.Members = make(map[string]*ProtocolMetadata)
+	r.Members = make(map[string][]byte)
 	for i := 0; i < n; i++ {
 		memberId, err := pd.getString()
 		if err != nil {
@@ -99,12 +95,7 @@ func (r *JoinGroupResponse) decode(pd packetDecoder) (err error) {
 			return err
 		}
 
-		pm := new(ProtocolMetadata)
-		if err := decode(memberMetadata, pm); err != nil {
-			return nil
-		}
-
-		r.Members[memberId] = pm
+		r.Members[memberId] = memberMetadata
 	}
 
 	return nil

--- a/member_assignment.go
+++ b/member_assignment.go
@@ -1,0 +1,78 @@
+package sarama
+
+type MemberAssignment struct {
+	Version             int16
+	PartitionAssignment map[string][]int32
+	UserData            []byte
+}
+
+func (ma *MemberAssignment) encode(pe packetEncoder) error {
+	pe.putInt16(int16(ma.Version))
+
+	if err := pe.putArrayLength(len(ma.PartitionAssignment)); err != nil {
+		return err
+	}
+
+	for topic, partitions := range ma.PartitionAssignment {
+		if err := pe.putString(topic); err != nil {
+			return err
+		}
+
+		if err := pe.putArrayLength(len(partitions)); err != nil {
+			return err
+		}
+
+		for _, part := range partitions {
+			pe.putInt32(int32(part))
+		}
+	}
+
+	if err := pe.putBytes(ma.UserData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ma *MemberAssignment) decode(pd packetDecoder) error {
+	if version, err := pd.getInt16(); err != nil {
+		return err
+	} else {
+		ma.Version = version
+	}
+
+	ma.PartitionAssignment = make(map[string][]int32)
+	if length, err := pd.getArrayLength(); err != nil {
+		return err
+	} else {
+		for i:=0; i < length; i++ {
+			topic, err := pd.getString()
+			if err != nil {
+				return err
+			}
+
+			n, err := pd.getArrayLength()
+			if err != nil {
+				return err
+			}
+
+			ma.PartitionAssignment[topic] = make([]int32, n)
+
+			for pi := 0; pi < n; pi++ {
+				if partition, err := pd.getInt32(); err != nil {
+					return err
+				} else {
+					ma.PartitionAssignment[topic][pi] = partition
+				}
+			}
+		}
+	}
+
+	if userData, err := pd.getBytes(); err != nil {
+		return err
+	} else {
+		ma.UserData = userData
+	}
+
+	return nil
+}

--- a/member_assignment.go
+++ b/member_assignment.go
@@ -45,7 +45,7 @@ func (ma *MemberAssignment) decode(pd packetDecoder) error {
 	if length, err := pd.getArrayLength(); err != nil {
 		return err
 	} else {
-		for i:=0; i < length; i++ {
+		for i := 0; i < length; i++ {
 			topic, err := pd.getString()
 			if err != nil {
 				return err

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -5,7 +5,7 @@ type PartitionMetadata struct {
 	ID       int32
 	Leader   int32
 	Replicas []int32
-	Isr      []int32
+	ISR      []int32
 }
 
 func (pm *PartitionMetadata) decode(pd packetDecoder) (err error) {
@@ -30,7 +30,7 @@ func (pm *PartitionMetadata) decode(pd packetDecoder) (err error) {
 		return err
 	}
 
-	pm.Isr, err = pd.getInt32Array()
+	pm.ISR, err = pd.getInt32Array()
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func (pm *PartitionMetadata) encode(pe packetEncoder) (err error) {
 		return err
 	}
 
-	err = pe.putInt32Array(pm.Isr)
+	err = pe.putInt32Array(pm.ISR)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ foundPartition:
 
 	pmatch.Leader = brokerID
 	pmatch.Replicas = replicas
-	pmatch.Isr = isr
+	pmatch.ISR = isr
 	pmatch.Err = err
 
 }

--- a/metadata_response_test.go
+++ b/metadata_response_test.go
@@ -121,7 +121,7 @@ func TestMetadataResponseWithTopics(t *testing.T) {
 		}
 	}
 
-	if len(response.Topics[0].Partitions[0].Isr) != 0 {
+	if len(response.Topics[0].Partitions[0].ISR) != 0 {
 		t.Error("Decoding produced invalid topic 0 partition 0 isr length.")
 	}
 

--- a/protocol_metadata.go
+++ b/protocol_metadata.go
@@ -1,9 +1,9 @@
 package sarama
 
 type ProtocolMetadata struct {
-	Version int16
+	Version      int16
 	Subscription []string
-	UserData []byte
+	UserData     []byte
 }
 
 func (r *ProtocolMetadata) encode(pe packetEncoder) (err error) {
@@ -13,7 +13,7 @@ func (r *ProtocolMetadata) encode(pe packetEncoder) (err error) {
 		return err
 	}
 
-	for _,sub := range r.Subscription {
+	for _, sub := range r.Subscription {
 		if err := pe.putString(sub); err != nil {
 			return err
 		}

--- a/protocol_metadata.go
+++ b/protocol_metadata.go
@@ -1,0 +1,57 @@
+package sarama
+
+type ProtocolMetadata struct {
+	Version int16
+	Subscription []string
+	UserData []byte
+}
+
+func (r *ProtocolMetadata) encode(pe packetEncoder) (err error) {
+	pe.putInt16(int16(r.Version))
+
+	if err := pe.putArrayLength(len(r.Subscription)); err != nil {
+		return err
+	}
+
+	for _,sub := range r.Subscription {
+		if err := pe.putString(sub); err != nil {
+			return err
+		}
+	}
+
+	if err := pe.putBytes(r.UserData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ProtocolMetadata) decode(pd packetDecoder) (err error) {
+	if version, err := pd.getInt16(); err != nil {
+		return err
+	} else {
+		r.Version = version
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+
+	r.Subscription = make([]string, n)
+	for i := 0; i < n; i++ {
+		if subscription, err := pd.getString(); err != nil {
+			return err
+		} else {
+			r.Subscription[i] = subscription
+		}
+	}
+
+	if userData, err := pd.getBytes(); err != nil {
+		return err
+	} else {
+		r.UserData = userData
+	}
+
+	return nil
+}

--- a/sync_group_request.go
+++ b/sync_group_request.go
@@ -4,7 +4,7 @@ type SyncGroupRequest struct {
 	GroupId         string
 	GenerationId    int32
 	MemberId        string
-	GroupAssignment map[string]*MemberAssignment
+	GroupAssignment map[string][]byte
 }
 
 func (r *SyncGroupRequest) encode(pe packetEncoder) error {
@@ -26,11 +26,7 @@ func (r *SyncGroupRequest) encode(pe packetEncoder) error {
 			return err
 		}
 
-		gaBytes, err := encode(memberAssignment)
-		if err != nil {
-			return err
-		}
-		if err := pe.putBytes(gaBytes); err != nil {
+		if err := pe.putBytes(memberAssignment); err != nil {
 			return err
 		}
 	}
@@ -57,7 +53,7 @@ func (r *SyncGroupRequest) decode(pd packetDecoder) (err error) {
 		return nil
 	}
 
-	r.GroupAssignment = make(map[string]*MemberAssignment, n)
+	r.GroupAssignment = make(map[string][]byte, n)
 	for i := 0; i < n; i++ {
 		memberId, err := pd.getString()
 		if err != nil {
@@ -69,12 +65,7 @@ func (r *SyncGroupRequest) decode(pd packetDecoder) (err error) {
 			return err
 		}
 
-		memberAssignment := new(MemberAssignment)
-		if err := decode(gaBytes, memberAssignment); err != nil {
-			return err
-		}
-
-		r.GroupAssignment[memberId] = memberAssignment
+		r.GroupAssignment[memberId] = gaBytes
 	}
 
 	return nil
@@ -88,9 +79,9 @@ func (r *SyncGroupRequest) version() int16 {
 	return 0
 }
 
-func (r *SyncGroupRequest) AddGroupAssignment(memberId string, memberAssignment *MemberAssignment) {
+func (r *SyncGroupRequest) AddGroupAssignment(memberId string, memberAssignment []byte) {
 	if r.GroupAssignment == nil {
-		r.GroupAssignment = make(map[string]*MemberAssignment)
+		r.GroupAssignment = make(map[string][]byte)
 	}
 
 	r.GroupAssignment[memberId] = memberAssignment

--- a/sync_group_response.go
+++ b/sync_group_response.go
@@ -2,7 +2,7 @@ package sarama
 
 type SyncGroupResponse struct {
 	Err              KError
-	MemberAssignment *MemberAssignment
+	MemberAssignment []byte
 }
 
 func (r *SyncGroupResponse) GetMemberAssignment() (*ConsumerGroupMemberAssignment, error) {
@@ -14,12 +14,7 @@ func (r *SyncGroupResponse) GetMemberAssignment() (*ConsumerGroupMemberAssignmen
 func (r *SyncGroupResponse) encode(pe packetEncoder) error {
 	pe.putInt16(int16(r.Err))
 
-	maBytes, err := encode(r.MemberAssignment)
-	if err != nil {
-		return err
-	}
-
-	if err := pe.putBytes(maBytes); err != nil {
+	if err := pe.putBytes(r.MemberAssignment); err != nil {
 		return err
 	}
 
@@ -38,12 +33,7 @@ func (r *SyncGroupResponse) decode(pd packetDecoder) (err error) {
 		return err
 	}
 
-	memberAssignment := new (MemberAssignment)
-	if err := decode(maBytes, memberAssignment); err != nil {
-		return err
-	}
-
-	r.MemberAssignment = memberAssignment
+	r.MemberAssignment = maBytes
 
 	return nil
 }

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,9 @@
 package sarama
 
 import (
-	"sort"
 	"bufio"
 	"net"
+	"sort"
 )
 
 type none struct{}

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,8 @@ package sarama
 
 import (
 	"sort"
+	"bufio"
+	"net"
 )
 
 type none struct{}
@@ -90,6 +92,23 @@ func (b ByteEncoder) Length() int {
 	return len(b)
 }
 
+// bufConn wraps a net.Conn with a buffer for reads to reduce the number of
+// reads that trigger syscalls.
+type bufConn struct {
+	net.Conn
+	buf *bufio.Reader
+}
+
+func newBufConn(conn net.Conn) *bufConn {
+	return &bufConn{
+		Conn: conn,
+		buf:  bufio.NewReader(conn),
+	}
+}
+
+func (bc *bufConn) Read(b []byte) (n int, err error) {
+	return bc.buf.Read(b)
+}
 
 // An IntHeap is a min-heap of ints.
 // https://golang.org/pkg/container/heap/#example__intHeap


### PR DESCRIPTION
We require the automatic consumer rebalancing throughout a new project using Kafka 0.9.

This PR contains tested code to support the automatic rebalancing in a consumer group using a round-robin partition assignment scheme. 

This PR introduces a `topicConsumer`, providing a `Messages` and `Error` channel which is published to by all the `partitionConsumer` to allow the client to consume from one single stream.

In addition, the client API is extended with a `RebalanceEvent` channel, which informs the client of partition consumer changes, inspired by the [Consumer Rebalance Listener](http://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.html) in the Java API. The `SubscriptionOperation` constant specifies the type of operation (addition, removal).

Example:

>select {
		case msg := <-topicConsumer.Messages():
			log.Printf("Consumed message offset %d\n", msg.Offset)
			consumed++
		case event := <-rebalanceEvents:
			log.Printf("Performing rebalance with %d changes", len(event.Subscriptions))
		case <-signals:
			break ConsumerLoop
		}

As I'm new to golang and to sarama, I expect that some code will be out of place or already present somewhere else. If so, please point this out to me, I had a hard time figuring out al the different parts of the sarama consumer.

I'd appreciate all feedback towards making this production ready and merge-able.

Thanks!