### PR TITLE
Prep docs for Sarama 1.8 supporting kafka 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
 - 1.4.3
-- 1.5.2
+- 1.5.3
 
 env:
   global:
@@ -11,7 +11,6 @@ env:
   - KAFKA_HOSTNAME=localhost
   - DEBUG=true
   matrix:
-  - KAFKA_VERSION=0.8.1.1
   - KAFKA_VERSION=0.8.2.2
   - KAFKA_VERSION=0.9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,23 +3,21 @@
 #### Version 1.8.0 (trunk)
 
 New Features:
- - Add a missing protocol constant, `GroupGenerationUndefined`
-   ([#586](https://github.com/Shopify/sarama/pull/586)).
- - Finish up the last pieces of Kafka 0.9 protocol support
-   ([#588](https://github.com/Shopify/sarama/pull/588),
+ - Full support for Kafka 0.9:
+   - All protocol messages and fields
+   ([#586](https://github.com/Shopify/sarama/pull/586),
+   [#588](https://github.com/Shopify/sarama/pull/588),
    [#590](https://github.com/Shopify/sarama/pull/590)).
+   - Verified that TLS support works
+   ([#581](https://github.com/Shopify/sarama/pull/581)).
+   - Fixed the OffsetManager compatibility
+   ([#585](https://github.com/Shopify/sarama/pull/585)).
 
 Improvements:
  - Optimize for fewer system calls when reading from the network
    ([#584](https://github.com/Shopify/sarama/pull/584)).
  - Automatically retry `InvalidMessage` errors to match upstream behaviour
    ([#589](https://github.com/Shopify/sarama/pull/589)).
- - Verified that TLS support works with Kafka 0.9
-   ([#581](https://github.com/Shopify/sarama/pull/581)).
-
-Bug Fixes:
- - Fix the OffsetManager to be compatible with Kafka 0.9
-   ([#585](https://github.com/Shopify/sarama/pull/585)).
 
 #### Version 1.7.0 (2015-12-11)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sarama is an MIT-licensed Go client library for [Apache Kafka](https://kafka.apa
 Sarama provides a "2 releases + 2 months" compatibility guarantee: we support
 the two latest stable releases of Kafka and Go, and we provide a two month
 grace period for older releases. This means we currently officially support
-Go 1.4 and 1.5, and Kafka 0.8.1 and 0.8.2, although older releases are still
+Go 1.4 and 1.5, and Kafka 0.8.2 and 0.9.0, although older releases are still
 likely to work.
 
 Sarama follows semantic versioning and provides API stability via the gopkg.in service.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sarama is an MIT-licensed Go client library for [Apache Kafka](https://kafka.apa
 Sarama provides a "2 releases + 2 months" compatibility guarantee: we support
 the two latest stable releases of Kafka and Go, and we provide a two month
 grace period for older releases. This means we currently officially support
-Go 1.4 and 1.5, and Kafka 0.8.2 and 0.9.0, although older releases are still
+Go 1.5 and 1.4, and Kafka 0.9.0 and 0.8.2, although older releases are still
 likely to work.
 
 Sarama follows semantic versioning and provides API stability via the gopkg.in service.


### PR DESCRIPTION
- Declare 0.9 supported in the readme
- Stop testing 0.8.1 in CI, it's outside our 2+2 policy now
- Rejig changelog to make "0.9 support" the primary item for the next release
- Bump the tested go minor version because why not

@wvanbergen did you have anything else you wanted in 1.8? If this looks good I'll merge it and release 1.8 on Monday.