### PR TITLE
Add additional error handling based on spec

### DIFF
--- a/client.go
+++ b/client.go
@@ -632,7 +632,7 @@ func (client *client) updateMetadata(data *MetadataResponse) (retry bool, err er
 		switch topic.Err {
 		case ErrNoError:
 			break
-		case ErrInvalidTopic: // don't retry, don't store partial results
+		case ErrInvalidTopic, ErrTopicAuthorizationFailed: // don't retry, don't store partial results
 			err = topic.Err
 			continue
 		case ErrUnknownTopicOrPartition: // retry, do not store partial partition results

--- a/consumer.go
+++ b/consumer.go
@@ -642,7 +642,7 @@ func (bc *brokerConsumer) handleResponses() {
 			Logger.Printf("consumer/%s/%d shutting down because %s\n", child.topic, child.partition, result)
 			close(child.trigger)
 			delete(bc.subscriptions, child)
-		case ErrUnknownTopicOrPartition, ErrNotLeaderForPartition, ErrLeaderNotAvailable:
+		case ErrUnknownTopicOrPartition, ErrNotLeaderForPartition, ErrLeaderNotAvailable, ErrReplicaNotAvailable:
 			// not an error, but does need redispatching
 			Logger.Printf("consumer/broker/%d abandoned subscription to %s/%d because %s\n",
 				bc.broker.ID(), child.topic, child.partition, result)


### PR DESCRIPTION
Gwen posted to the spec a list of expected error codes for each
request/response. This adds handling for the listed codes for consumer, client,
and offset manager. Some errors (e.g. around group membership) have been ignored
because we don't implement the relevant feature yet anyways.
Possible errors for the producer are not yet listed in the spec.

@wvanbergen closes #596 