### PR TITLE
Add support for SASL plain text authentication

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -85,7 +85,7 @@ func (b *Broker) Open(conf *Config) error {
 		b.conf = conf
 
 		if conf.Net.SASL.Enable {
-			b.connErr = b.doSASLPlainAuth()
+			b.connErr = b.sendAndReceiveSASLPlainAuth()
 			if b.connErr != nil {
 				err = b.conn.Close()
 				if err == nil {
@@ -490,7 +490,7 @@ func (b *Broker) responseReceiver() {
 // When credentials are valid, Kafka returns a 4 byte array of null characters.
 // When credentials are invalid, Kafka closes the connection. This does not seem to be the ideal way
 // of responding to bad credentials but thats how its being done today.
-func (b *Broker) doSASLPlainAuth() error {
+func (b *Broker) sendAndReceiveSASLPlainAuth() error {
 	length := 1 + len(b.conf.Net.SASL.User) + 1 + len(b.conf.Net.SASL.Password)
 	authBytes := make([]byte, length+4) //4 byte length header + auth data
 	binary.BigEndian.PutUint32(authBytes, uint32(length))

--- a/broker.go
+++ b/broker.go
@@ -86,34 +86,14 @@ func (b *Broker) Open(conf *Config) error {
 		b.conf = conf
 
 		if conf.Net.SASL.Enable {
-			//
-			// Begin SASL/PLAIN authentication
-			//
-			authBytes := []byte("\x00" + b.conf.Net.SASL.User + "\x00" + b.conf.Net.SASL.Password)
-			buf := new(bytes.Buffer)
-
-			err = binary.Write(buf, binary.BigEndian, int32(len(authBytes)))
+			err = b.doSASLPlainAuth()
 			if err != nil {
-				Logger.Printf("Failed to encode payload size (SASL credentials): %s", err.Error())
+				Logger.Printf("SASL authentication with broker %s failed\n", b.addr)
+				_ = b.Close()
+				return
+			} else {
+				Logger.Printf("SASL authentication with broker %s succeeded\n", b.addr)
 			}
-
-			err = binary.Write(buf, binary.BigEndian, authBytes)
-			if err != nil {
-				Logger.Printf("Failed to encode payload (SASL credentials): %s", err.Error())
-			}
-
-			b.conn.SetWriteDeadline(time.Now().Add(b.conf.Net.WriteTimeout))
-			b.conn.Write(buf.Bytes())
-
-			header := make([]byte, 4)
-			n, err := io.ReadFull(b.conn, header)
-			if err != nil {
-				Logger.Printf("Failed to read response while authenticating with SASL: %s", err.Error())
-			}
-			Logger.Printf("SASL authentication successful:\n%v\n%v\n%v", n, header, string(header))
-			//
-			// End SASL/PLAIN authentication
-			//
 		}
 
 		b.done = make(chan bool)
@@ -487,4 +467,54 @@ func (b *Broker) responseReceiver() {
 		response.packets <- buf
 	}
 	close(b.done)
+}
+
+// Kafka 0.10.0 plans to support SASL Plain and Kerberos as per PR #812 (KIP-43)/(JIRA KAFKA-3149)
+// Some hosted kafka services such as IBM Message Hub already offer SASL/PLAIN auth with Kafka 0.9
+//
+// In SASL Plain, Kafka expects the auth header to be in the following format
+// Message format (from https://tools.ietf.org/html/rfc4616):
+//
+//   message   = [authzid] UTF8NUL authcid UTF8NUL passwd
+//   authcid   = 1*SAFE ; MUST accept up to 255 octets
+//   authzid   = 1*SAFE ; MUST accept up to 255 octets
+//   passwd    = 1*SAFE ; MUST accept up to 255 octets
+//   UTF8NUL   = %x00 ; UTF-8 encoded NUL character
+//
+//   SAFE      = UTF1 / UTF2 / UTF3 / UTF4
+//                  ;; any UTF-8 encoded Unicode character except NUL
+//
+// When credentials are valid, Kafka returns a 4 byte array of null characters.
+// When credentials are invalid, Kafka closes the connection. This does not seem to be the ideal way
+// of responding to bad credentials but thats how its being done today. 
+func (b *Broker) doSASLPlainAuth() error {
+	authBytes := []byte("\x00" + b.conf.Net.SASL.User + "\x00" + b.conf.Net.SASL.Password)
+	buf := new(bytes.Buffer)
+
+	err := binary.Write(buf, binary.BigEndian, int32(len(authBytes)))
+	if err != nil {
+		Logger.Printf("Failed to encode payload size (SASL credentials): %s", err.Error())
+		return err
+	}
+
+	err = binary.Write(buf, binary.BigEndian, authBytes)
+	if err != nil {
+		Logger.Printf("Failed to encode payload (SASL credentials): %s", err.Error())
+		return err
+	}
+
+	b.conn.SetWriteDeadline(time.Now().Add(b.conf.Net.WriteTimeout))
+	b.conn.Write(buf.Bytes())
+
+	header := make([]byte, 4)
+	n, err := io.ReadFull(b.conn, header)
+	// If the credentials are valid, we would get a 4 byte response filled with null characters.
+	// Otherwise, the broker closes the connection and we get an EOF
+	if err != nil {
+		Logger.Printf("Failed to read response while authenticating with SASL: %s", err.Error())
+		return err
+	}
+
+	Logger.Printf("SASL authentication successful:%v - %v", n, header)
+	return nil
 }

--- a/broker.go
+++ b/broker.go
@@ -488,9 +488,9 @@ func (b *Broker) responseReceiver() {
 // of responding to bad credentials but thats how its being done today.
 func (b *Broker) doSASLPlainAuth() error {
 	length := 1 + len(b.conf.Net.SASL.User) + 1 + len(b.conf.Net.SASL.Password)
-	authBytes := make([]byte, length + 4)  //4 byte length header + auth data
+	authBytes := make([]byte, length+4) //4 byte length header + auth data
 	binary.BigEndian.PutUint32(authBytes, uint32(length))
-	copy(authBytes[4:], []byte("\x00" + b.conf.Net.SASL.User + "\x00" + b.conf.Net.SASL.Password))
+	copy(authBytes[4:], []byte("\x00"+b.conf.Net.SASL.User+"\x00"+b.conf.Net.SASL.Password))
 
 	b.conn.SetWriteDeadline(time.Now().Add(b.conf.Net.WriteTimeout))
 	b.conn.Write(authBytes)

--- a/broker.go
+++ b/broker.go
@@ -1,7 +1,9 @@
 package sarama
 
 import (
+	"bytes"
 	"crypto/tls"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -9,8 +11,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"bytes"
-	"encoding/binary"
 )
 
 // Broker represents a single Kafka broker connection. All operations on this object are entirely concurrency-safe.
@@ -486,7 +486,7 @@ func (b *Broker) responseReceiver() {
 //
 // When credentials are valid, Kafka returns a 4 byte array of null characters.
 // When credentials are invalid, Kafka closes the connection. This does not seem to be the ideal way
-// of responding to bad credentials but thats how its being done today. 
+// of responding to bad credentials but thats how its being done today.
 func (b *Broker) doSASLPlainAuth() error {
 	authBytes := []byte("\x00" + b.conf.Net.SASL.User + "\x00" + b.conf.Net.SASL.Password)
 	buf := new(bytes.Buffer)

--- a/config.go
+++ b/config.go
@@ -313,9 +313,9 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Net.WriteTimeout must be > 0")
 	case c.Net.KeepAlive < 0:
 		return ConfigurationError("Net.KeepAlive must be >= 0")
-	case (c.Net.SASL.Enable == true) && (c.Net.SASL.User == ""):
+	case c.Net.SASL.Enable == true && c.Net.SASL.User == "":
 		return ConfigurationError("Net.SASL.User must not be empty when SASL is enabled")
-	case (c.Net.SASL.Enable == true) && (c.Net.SASL.Password == ""):
+	case c.Net.SASL.Enable == true && c.Net.SASL.Password == "":
 		return ConfigurationError("Net.SASL.Password must not be empty when SASL is enabled")
 	}
 

--- a/config.go
+++ b/config.go
@@ -33,6 +33,17 @@ type Config struct {
 			Config *tls.Config
 		}
 
+		// SASL based authentication with broker. While there are multiple SASL authentication methods
+		// the current implementation is limited to plaintext (SASL/PLAIN) authentication
+		SASL struct {
+			// Whether or not to use SASL authentication when connecting to the broker
+			// (defaults to false).
+			Enable bool
+			//username and password for SASL/PLAIN authentication
+			User string
+			Password string
+		}
+
 		// KeepAlive specifies the keep-alive period for an active network connection.
 		// If zero, keep-alives are disabled. (default is 0: disabled).
 		KeepAlive time.Duration
@@ -222,6 +233,7 @@ func NewConfig() *Config {
 	c.Net.DialTimeout = 30 * time.Second
 	c.Net.ReadTimeout = 30 * time.Second
 	c.Net.WriteTimeout = 30 * time.Second
+	c.Net.SASL.Enable = false
 
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond
@@ -255,6 +267,14 @@ func (c *Config) Validate() error {
 	// some configuration values should be warned on but not fail completely, do those first
 	if c.Net.TLS.Enable == false && c.Net.TLS.Config != nil {
 		Logger.Println("Net.TLS is disabled but a non-nil configuration was provided.")
+	}
+	if c.Net.SASL.Enable == false {
+		if c.Net.SASL.User != "" {
+			Logger.Println("Net.SASL is disabled but a non-empty username was provided.")
+		}
+		if c.Net.SASL.Password != "" {
+			Logger.Println("Net.SASL is disabled but a non-empty password was provided.")
+		}
 	}
 	if c.Producer.RequiredAcks > 1 {
 		Logger.Println("Producer.RequiredAcks > 1 is deprecated and will raise an exception with kafka >= 0.8.2.0.")

--- a/config.go
+++ b/config.go
@@ -40,7 +40,7 @@ type Config struct {
 			// (defaults to false).
 			Enable bool
 			//username and password for SASL/PLAIN authentication
-			User string
+			User     string
 			Password string
 		}
 

--- a/config.go
+++ b/config.go
@@ -234,7 +234,6 @@ func NewConfig() *Config {
 	c.Net.DialTimeout = 30 * time.Second
 	c.Net.ReadTimeout = 30 * time.Second
 	c.Net.WriteTimeout = 30 * time.Second
-	c.Net.SASL.Enable = false
 
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond
@@ -314,6 +313,10 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Net.WriteTimeout must be > 0")
 	case c.Net.KeepAlive < 0:
 		return ConfigurationError("Net.KeepAlive must be >= 0")
+	case (c.Net.SASL.Enable == true) && (c.Net.SASL.User == ""):
+		return ConfigurationError("Net.SASL.User must not be empty when SASL is enabled")
+	case (c.Net.SASL.Enable == true) && (c.Net.SASL.Password == ""):
+		return ConfigurationError("Net.SASL.Password must not be empty when SASL is enabled")
 	}
 
 	// validate the Metadata values


### PR DESCRIPTION
Hi
 This is a simple patch that adds support for SASL plain text authentication to Kafka brokers, if enabled. This feature is useful when people want to leverage hosted Kafka services such as IBM Bluemix's Message Hub service (Kafka 0.9 with SASL plain text authentication). By default, the authentication is disabled.

