### PR TITLE
Don't try to send partition timestamps in v2 OCRs

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -484,7 +484,9 @@ func (bom *brokerOffsetManager) flushToBroker() {
 
 func (bom *brokerOffsetManager) constructRequest() *OffsetCommitRequest {
 	var r *OffsetCommitRequest
+	var perPartitionTimestamp int64
 	if bom.parent.conf.Consumer.Offsets.Retention == 0 {
+		perPartitionTimestamp = ReceiveTime
 		r = &OffsetCommitRequest{
 			Version:                 1,
 			ConsumerGroup:           bom.parent.group,
@@ -503,7 +505,7 @@ func (bom *brokerOffsetManager) constructRequest() *OffsetCommitRequest {
 	for s := range bom.subscriptions {
 		s.lock.Lock()
 		if s.dirty {
-			r.AddBlock(s.topic, s.partition, s.offset, ReceiveTime, s.metadata)
+			r.AddBlock(s.topic, s.partition, s.offset, perPartitionTimestamp, s.metadata)
 		}
 		s.lock.Unlock()
 	}


### PR DESCRIPTION
Only v1 OffsetCommitRequest messages had the per-partition timestamp, so only
send it in that case and let it be 0 otherwise. The `encode` method was already
smart enough to ignore it and log a warning, so this basically just suppresses
the annoying log message.

@wvanbergen @dimchansky fixes the less interesting piece of #650.