### PR TITLE
Doc that Offset.Retention requires kafka 0.9

### DIFF
--- a/config.go
+++ b/config.go
@@ -197,7 +197,8 @@ type Config struct {
 			// The retention duration for committed offsets. If zero, disabled
 			// (in which case the `offsets.retention.minutes` option on the
 			// broker will be used).  Kafka only supports precision up to
-			// milliseconds; nanoseconds will be truncated.
+			// milliseconds; nanoseconds will be truncated. Requires Kafka
+			// broker version 0.9.0 or later.
 			// (default is 0: disabled).
 			Retention time.Duration
 		}


### PR DESCRIPTION
It requires v2 of the OffsetCommitRequest which was only introduced in Kafka
0.9; trying to use it with earlier broker versions will fail.

From #650.

@wvanbergen @dimchansky