### PR TITLE
Added multi version kafka support

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -188,6 +188,7 @@ func (b *Broker) Produce(request *ProduceRequest) (*ProduceResponse, error) {
 		err = b.sendAndReceive(request, nil)
 	} else {
 		response = new(ProduceResponse)
+		response.KafkaVersion = request.KafkaVersion
 		err = b.sendAndReceive(request, response)
 	}
 
@@ -200,6 +201,7 @@ func (b *Broker) Produce(request *ProduceRequest) (*ProduceResponse, error) {
 
 func (b *Broker) Fetch(request *FetchRequest) (*FetchResponse, error) {
 	response := new(FetchResponse)
+	response.KafkaVersion = request.KafkaVersion
 
 	err := b.sendAndReceive(request, response)
 
@@ -212,6 +214,7 @@ func (b *Broker) Fetch(request *FetchRequest) (*FetchResponse, error) {
 
 func (b *Broker) CommitOffset(request *OffsetCommitRequest) (*OffsetCommitResponse, error) {
 	response := new(OffsetCommitResponse)
+	response.KafkaVersion = request.KafkaVersion
 
 	err := b.sendAndReceive(request, response)
 
@@ -224,6 +227,7 @@ func (b *Broker) CommitOffset(request *OffsetCommitRequest) (*OffsetCommitRespon
 
 func (b *Broker) FetchOffset(request *OffsetFetchRequest) (*OffsetFetchResponse, error) {
 	response := new(OffsetFetchResponse)
+	response.KafkaVersion = request.KafkaVersion
 
 	err := b.sendAndReceive(request, response)
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -106,6 +106,7 @@ var brokerTestTable = []struct {
 	{[]byte{},
 		func(t *testing.T, broker *Broker) {
 			request := ProduceRequest{}
+			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 			request.RequiredAcks = NoResponse
 			response, err := broker.Produce(&request)
 			if err != nil {
@@ -119,6 +120,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := ProduceRequest{}
+			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 			request.RequiredAcks = WaitForLocal
 			response, err := broker.Produce(&request)
 			if err != nil {
@@ -132,6 +134,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := FetchRequest{}
+			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 			response, err := broker.Fetch(&request)
 			if err != nil {
 				t.Error(err)
@@ -144,6 +147,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := OffsetFetchRequest{}
+			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 			response, err := broker.FetchOffset(&request)
 			if err != nil {
 				t.Error(err)
@@ -156,6 +160,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := OffsetCommitRequest{}
+			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 			response, err := broker.CommitOffset(&request)
 			if err != nil {
 				t.Error(err)

--- a/broker_test.go
+++ b/broker_test.go
@@ -106,7 +106,7 @@ var brokerTestTable = []struct {
 	{[]byte{},
 		func(t *testing.T, broker *Broker) {
 			request := ProduceRequest{}
-			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+			request.KafkaVersion = V0_8_2_2
 			request.RequiredAcks = NoResponse
 			response, err := broker.Produce(&request)
 			if err != nil {
@@ -120,7 +120,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := ProduceRequest{}
-			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+			request.KafkaVersion = V0_8_2_2
 			request.RequiredAcks = WaitForLocal
 			response, err := broker.Produce(&request)
 			if err != nil {
@@ -134,7 +134,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := FetchRequest{}
-			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+			request.KafkaVersion = V0_8_2_2
 			response, err := broker.Fetch(&request)
 			if err != nil {
 				t.Error(err)
@@ -147,7 +147,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := OffsetFetchRequest{}
-			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+			request.KafkaVersion = V0_8_2_2
 			response, err := broker.FetchOffset(&request)
 			if err != nil {
 				t.Error(err)
@@ -160,7 +160,7 @@ var brokerTestTable = []struct {
 	{[]byte{0x00, 0x00, 0x00, 0x00},
 		func(t *testing.T, broker *Broker) {
 			request := OffsetCommitRequest{}
-			request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+			request.KafkaVersion = V0_8_2_2
 			response, err := broker.CommitOffset(&request)
 			if err != nil {
 				t.Error(err)

--- a/config.go
+++ b/config.go
@@ -8,8 +8,16 @@ import (
 
 var validID *regexp.Regexp = regexp.MustCompile(`\A[A-Za-z0-9._-]*\z`)
 
+type KafkaVersion struct {
+	Release *kVersion
+}
+
 // Config is used to pass multiple configuration options to Sarama's constructors.
 type Config struct {
+
+	// This defines the Kafka broker version and is used for broker version specific behaviour
+	KafkaVersion KafkaVersion
+
 	// Net is the namespace for network-level properties used by the Broker, and
 	// shared by the Client/Producer/Consumer.
 	Net struct {
@@ -219,6 +227,8 @@ type Config struct {
 func NewConfig() *Config {
 	c := &Config{}
 
+	c.KafkaVersion.Release = V0_8_2_2
+
 	c.Net.MaxOpenRequests = 5
 	c.Net.DialTimeout = 30 * time.Second
 	c.Net.ReadTimeout = 30 * time.Second
@@ -362,4 +372,8 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func (v *KafkaVersion) AtLeast(ver *kVersion) bool {
+	return v.Release.GE(ver)
 }

--- a/config.go
+++ b/config.go
@@ -8,15 +8,11 @@ import (
 
 var validID *regexp.Regexp = regexp.MustCompile(`\A[A-Za-z0-9._-]*\z`)
 
-type KafkaVersion struct {
-	Release *kVersion
-}
-
 // Config is used to pass multiple configuration options to Sarama's constructors.
 type Config struct {
 
 	// This defines the Kafka broker version and is used for broker version specific behaviour
-	KafkaVersion KafkaVersion
+	KafkaVersion *KafkaVersion
 
 	// Net is the namespace for network-level properties used by the Broker, and
 	// shared by the Client/Producer/Consumer.
@@ -227,7 +223,7 @@ type Config struct {
 func NewConfig() *Config {
 	c := &Config{}
 
-	c.KafkaVersion.Release = V0_8_2_2
+	c.KafkaVersion = V0_8_2_2
 
 	c.Net.MaxOpenRequests = 5
 	c.Net.DialTimeout = 30 * time.Second
@@ -374,6 +370,6 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (v *KafkaVersion) AtLeast(ver *kVersion) bool {
-	return v.Release.GE(ver)
+func (v *KafkaVersion) AtLeast(ver *KafkaVersion) bool {
+	return v.GE(ver)
 }

--- a/consumer.go
+++ b/consumer.go
@@ -679,8 +679,9 @@ func (bc *brokerConsumer) abort(err error) {
 
 func (bc *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 	request := &FetchRequest{
-		MinBytes:    bc.consumer.conf.Consumer.Fetch.Min,
-		MaxWaitTime: int32(bc.consumer.conf.Consumer.MaxWaitTime / time.Millisecond),
+		MinBytes:     bc.consumer.conf.Consumer.Fetch.Min,
+		MaxWaitTime:  int32(bc.consumer.conf.Consumer.MaxWaitTime / time.Millisecond),
+		KafkaVersion: &bc.consumer.conf.KafkaVersion,
 	}
 
 	for child := range bc.subscriptions {

--- a/consumer.go
+++ b/consumer.go
@@ -681,7 +681,7 @@ func (bc *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 	request := &FetchRequest{
 		MinBytes:     bc.consumer.conf.Consumer.Fetch.Min,
 		MaxWaitTime:  int32(bc.consumer.conf.Consumer.MaxWaitTime / time.Millisecond),
-		KafkaVersion: &bc.consumer.conf.KafkaVersion,
+		KafkaVersion: bc.consumer.conf.KafkaVersion,
 	}
 
 	for child := range bc.subscriptions {

--- a/fetch_request_test.go
+++ b/fetch_request_test.go
@@ -1,6 +1,8 @@
 package sarama
 
-import "testing"
+import (
+	"testing"
+)
 
 var (
 	fetchRequestNoBlocks = []byte{
@@ -21,6 +23,7 @@ var (
 
 func TestFetchRequest(t *testing.T) {
 	request := new(FetchRequest)
+	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	testRequest(t, "no blocks", request, fetchRequestNoBlocks)
 
 	request.MaxWaitTime = 0x20

--- a/fetch_request_test.go
+++ b/fetch_request_test.go
@@ -23,7 +23,7 @@ var (
 
 func TestFetchRequest(t *testing.T) {
 	request := new(FetchRequest)
-	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	request.KafkaVersion = V0_8_2_2
 	testRequest(t, "no blocks", request, fetchRequestNoBlocks)
 
 	request.MaxWaitTime = 0x20

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -34,6 +34,11 @@ func (pr *FetchResponseBlock) decode(pd packetDecoder) (err error) {
 
 type FetchResponse struct {
 	Blocks map[string]map[int32]*FetchResponseBlock
+	// zero means the request did not violate any quota. This value is applicable only on Kafka version >= 0.9.0.0
+	ThrottleTime int32
+
+	// This is not part of the response bytes received from Kafka
+	KafkaVersion *KafkaVersion
 }
 
 func (pr *FetchResponseBlock) encode(pe packetEncoder) (err error) {
@@ -50,6 +55,13 @@ func (pr *FetchResponseBlock) encode(pe packetEncoder) (err error) {
 }
 
 func (fr *FetchResponse) decode(pd packetDecoder) (err error) {
+	if fr.KafkaVersion.AtLeast(V0_9_0_0) {
+		fr.ThrottleTime, err = pd.getInt32()
+		if err != nil {
+			return err
+		}
+	}
+
 	numTopics, err := pd.getArrayLength()
 	if err != nil {
 		return err
@@ -167,7 +179,7 @@ func (fr *FetchResponse) AddMessage(topic string, partition int32, key, value En
 	if value != nil {
 		vb, _ = value.Encode()
 	}
-	msg := &Message{Key: kb, Value: vb}
+	msg := &Message{Key: kb, Value: vb, KafkaVersion: fr.KafkaVersion}
 	msgBlock := &MessageBlock{Msg: msg, Offset: offset}
 	frb.MsgSet.Messages = append(frb.MsgSet.Messages, msgBlock)
 }

--- a/fetch_response_test.go
+++ b/fetch_response_test.go
@@ -30,6 +30,7 @@ var (
 
 func TestEmptyFetchResponse(t *testing.T) {
 	response := FetchResponse{}
+	response.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	testDecodable(t, "empty", &response, emptyFetchResponse)
 
 	if len(response.Blocks) != 0 {
@@ -40,6 +41,7 @@ func TestEmptyFetchResponse(t *testing.T) {
 
 func TestOneMessageFetchResponse(t *testing.T) {
 	response := FetchResponse{}
+	response.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	testDecodable(t, "one message", &response, oneMessageFetchResponse)
 
 	if len(response.Blocks) != 1 {

--- a/fetch_response_test.go
+++ b/fetch_response_test.go
@@ -30,7 +30,7 @@ var (
 
 func TestEmptyFetchResponse(t *testing.T) {
 	response := FetchResponse{}
-	response.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	response.KafkaVersion = V0_8_2_2
 	testDecodable(t, "empty", &response, emptyFetchResponse)
 
 	if len(response.Blocks) != 0 {
@@ -41,7 +41,7 @@ func TestEmptyFetchResponse(t *testing.T) {
 
 func TestOneMessageFetchResponse(t *testing.T) {
 	response := FetchResponse{}
-	response.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	response.KafkaVersion = V0_8_2_2
 	testDecodable(t, "one message", &response, oneMessageFetchResponse)
 
 	if len(response.Blocks) != 1 {

--- a/kafka_versions.go
+++ b/kafka_versions.go
@@ -1,0 +1,10 @@
+package sarama
+
+var LatestStable, _ = NewVersion("0.9.0.1")
+var V0_10_0, _ = NewVersion("0.10.0.0")
+var V0_9_0_1 = LatestStable
+var V0_9_0_0, _ = NewVersion("0.9.0.0")
+var V0_8_2_2, _ = NewVersion("0.8.2.2")
+var V0_8_2_1, _ = NewVersion("0.8.2.1")
+var V0_8_2_0, _ = NewVersion("0.8.2.0")
+var V0_8_1_0, _ = NewVersion("0.8.1.0")

--- a/kafka_versions.go
+++ b/kafka_versions.go
@@ -1,10 +1,10 @@
 package sarama
 
-var LatestStable, _ = NewVersion("0.9.0.1")
-var V0_10_0, _ = NewVersion("0.10.0.0")
-var V0_9_0_1 = LatestStable
-var V0_9_0_0, _ = NewVersion("0.9.0.0")
-var V0_8_2_2, _ = NewVersion("0.8.2.2")
-var V0_8_2_1, _ = NewVersion("0.8.2.1")
-var V0_8_2_0, _ = NewVersion("0.8.2.0")
-var V0_8_1_0, _ = NewVersion("0.8.1.0")
+var V0_10_0 = NewVersion(0, 10, 0, 0)
+var V0_9_0_1 = NewVersion(0, 9, 0, 1)
+var V0_9_0_0 = NewVersion(0, 9, 0, 0)
+var V0_8_2_2 = NewVersion(0, 8, 2, 2)
+var V0_8_2_1 = NewVersion(0, 8, 2, 1)
+var V0_8_2_0 = NewVersion(0, 8, 2, 0)
+var V0_8_1_0 = NewVersion(0, 8, 1, 0)
+var LatestStable = V0_9_0_1

--- a/message.go
+++ b/message.go
@@ -29,6 +29,8 @@ type Message struct {
 	Value []byte           // the message contents
 	Set   *MessageSet      // the message set a message might wrap
 
+	KafkaVersion *KafkaVersion
+
 	compressedCache []byte
 }
 

--- a/message_test.go
+++ b/message_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func TestMessageEncoding(t *testing.T) {
-	message := Message{}
+	message := Message{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
 	testEncodable(t, "empty", &message, emptyMessage)
 
 	message.Value = []byte{}
@@ -53,7 +53,7 @@ func TestMessageEncoding(t *testing.T) {
 }
 
 func TestMessageDecoding(t *testing.T) {
-	message := Message{}
+	message := Message{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
 	testDecodable(t, "empty", &message, emptyMessage)
 	if message.Codec != CompressionNone {
 		t.Error("Decoding produced compression codec where there was none.")

--- a/message_test.go
+++ b/message_test.go
@@ -44,7 +44,7 @@ var (
 )
 
 func TestMessageEncoding(t *testing.T) {
-	message := Message{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
+	message := Message{KafkaVersion: V0_8_2_2}
 	testEncodable(t, "empty", &message, emptyMessage)
 
 	message.Value = []byte{}
@@ -53,7 +53,7 @@ func TestMessageEncoding(t *testing.T) {
 }
 
 func TestMessageDecoding(t *testing.T) {
-	message := Message{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
+	message := Message{KafkaVersion: V0_8_2_2}
 	testDecodable(t, "empty", &message, emptyMessage)
 	if message.Codec != CompressionNone {
 		t.Error("Decoding produced compression codec where there was none.")

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -218,7 +218,9 @@ func (mfr *MockFetchResponse) SetHighWaterMark(topic string, partition int32, of
 
 func (mfr *MockFetchResponse) For(reqBody decoder) encoder {
 	fetchRequest := reqBody.(*FetchRequest)
+	fetchRequest.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	res := &FetchResponse{}
+	res.KafkaVersion = fetchRequest.KafkaVersion
 	for topic, partitions := range fetchRequest.blocks {
 		for partition, block := range partitions {
 			initialOffset := block.fetchOffset

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -218,7 +218,7 @@ func (mfr *MockFetchResponse) SetHighWaterMark(topic string, partition int32, of
 
 func (mfr *MockFetchResponse) For(reqBody decoder) encoder {
 	fetchRequest := reqBody.(*FetchRequest)
-	fetchRequest.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	fetchRequest.KafkaVersion = V0_8_2_2
 	res := &FetchResponse{}
 	res.KafkaVersion = fetchRequest.KafkaVersion
 	for topic, partitions := range fetchRequest.blocks {

--- a/offset_commit_request.go
+++ b/offset_commit_request.go
@@ -46,24 +46,18 @@ type OffsetCommitRequest struct {
 	ConsumerID              string // v1 or later
 	RetentionTime           int64  // v2 or later
 
-	// Version can be:
-	// - 0 (kafka 0.8.1 and later)
-	// - 1 (kafka 0.8.2 and later)
-	// - 2 (kafka 0.8.3 and later)
-	Version int16
-	blocks  map[string]map[int32]*offsetCommitRequestBlock
+	blocks map[string]map[int32]*offsetCommitRequestBlock
+
+	// This is not part of the request bytes sent to Kafka
+	KafkaVersion *KafkaVersion
 }
 
 func (r *OffsetCommitRequest) encode(pe packetEncoder) error {
-	if r.Version < 0 || r.Version > 2 {
-		return PacketEncodingError{"invalid or unsupported OffsetCommitRequest version field"}
-	}
-
 	if err := pe.putString(r.ConsumerGroup); err != nil {
 		return err
 	}
 
-	if r.Version >= 1 {
+	if r.version() >= 1 {
 		pe.putInt32(r.ConsumerGroupGeneration)
 		if err := pe.putString(r.ConsumerID); err != nil {
 			return err
@@ -77,7 +71,7 @@ func (r *OffsetCommitRequest) encode(pe packetEncoder) error {
 		}
 	}
 
-	if r.Version >= 2 {
+	if r.version() >= 2 {
 		pe.putInt64(r.RetentionTime)
 	} else if r.RetentionTime != 0 {
 		Logger.Println("Non-zero RetentionTime specified for OffsetCommitRequest version <2, it will be ignored")
@@ -95,7 +89,7 @@ func (r *OffsetCommitRequest) encode(pe packetEncoder) error {
 		}
 		for partition, block := range partitions {
 			pe.putInt32(partition)
-			if err := block.encode(pe, r.Version); err != nil {
+			if err := block.encode(pe, r.version()); err != nil {
 				return err
 			}
 		}
@@ -108,7 +102,7 @@ func (r *OffsetCommitRequest) decode(pd packetDecoder) (err error) {
 		return err
 	}
 
-	if r.Version >= 1 {
+	if r.version() >= 1 {
 		if r.ConsumerGroupGeneration, err = pd.getInt32(); err != nil {
 			return err
 		}
@@ -117,7 +111,7 @@ func (r *OffsetCommitRequest) decode(pd packetDecoder) (err error) {
 		}
 	}
 
-	if r.Version >= 2 {
+	if r.version() >= 2 {
 		if r.RetentionTime, err = pd.getInt64(); err != nil {
 			return err
 		}
@@ -147,7 +141,7 @@ func (r *OffsetCommitRequest) decode(pd packetDecoder) (err error) {
 				return err
 			}
 			block := &offsetCommitRequestBlock{}
-			if err := block.decode(pd, r.Version); err != nil {
+			if err := block.decode(pd, r.version()); err != nil {
 				return err
 			}
 			r.blocks[topic][partition] = block
@@ -161,7 +155,13 @@ func (r *OffsetCommitRequest) key() int16 {
 }
 
 func (r *OffsetCommitRequest) version() int16 {
-	return r.Version
+	if r.KafkaVersion.AtLeast(V0_9_0_0) {
+		return 2
+	} else if r.KafkaVersion.AtLeast(V0_8_2_0) {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func (r *OffsetCommitRequest) AddBlock(topic string, partitionID int32, offset int64, timestamp int64, metadata string) {

--- a/offset_commit_request_test.go
+++ b/offset_commit_request_test.go
@@ -56,7 +56,7 @@ var (
 
 func TestOffsetCommitRequestV0(t *testing.T) {
 	request := new(OffsetCommitRequest)
-	request.Version = 0
+	request.KafkaVersion = &KafkaVersion{Release: V0_8_1_0}
 	request.ConsumerGroup = "foobar"
 	testRequest(t, "no blocks v0", request, offsetCommitRequestNoBlocksV0)
 
@@ -69,7 +69,7 @@ func TestOffsetCommitRequestV1(t *testing.T) {
 	request.ConsumerGroup = "foobar"
 	request.ConsumerID = "cons"
 	request.ConsumerGroupGeneration = 0x1122
-	request.Version = 1
+	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	testRequest(t, "no blocks v1", request, offsetCommitRequestNoBlocksV1)
 
 	request.AddBlock("topic", 0x5221, 0xDEADBEEF, ReceiveTime, "metadata")
@@ -82,7 +82,7 @@ func TestOffsetCommitRequestV2(t *testing.T) {
 	request.ConsumerID = "cons"
 	request.ConsumerGroupGeneration = 0x1122
 	request.RetentionTime = 0x4433
-	request.Version = 2
+	request.KafkaVersion = &KafkaVersion{Release: V0_9_0_0}
 	testRequest(t, "no blocks v2", request, offsetCommitRequestNoBlocksV2)
 
 	request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, "metadata")

--- a/offset_commit_request_test.go
+++ b/offset_commit_request_test.go
@@ -56,7 +56,7 @@ var (
 
 func TestOffsetCommitRequestV0(t *testing.T) {
 	request := new(OffsetCommitRequest)
-	request.KafkaVersion = &KafkaVersion{Release: V0_8_1_0}
+	request.KafkaVersion = V0_8_1_0
 	request.ConsumerGroup = "foobar"
 	testRequest(t, "no blocks v0", request, offsetCommitRequestNoBlocksV0)
 
@@ -69,7 +69,7 @@ func TestOffsetCommitRequestV1(t *testing.T) {
 	request.ConsumerGroup = "foobar"
 	request.ConsumerID = "cons"
 	request.ConsumerGroupGeneration = 0x1122
-	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	request.KafkaVersion = V0_8_2_2
 	testRequest(t, "no blocks v1", request, offsetCommitRequestNoBlocksV1)
 
 	request.AddBlock("topic", 0x5221, 0xDEADBEEF, ReceiveTime, "metadata")
@@ -82,7 +82,7 @@ func TestOffsetCommitRequestV2(t *testing.T) {
 	request.ConsumerID = "cons"
 	request.ConsumerGroupGeneration = 0x1122
 	request.RetentionTime = 0x4433
-	request.KafkaVersion = &KafkaVersion{Release: V0_9_0_0}
+	request.KafkaVersion = V0_9_0_0
 	testRequest(t, "no blocks v2", request, offsetCommitRequestNoBlocksV2)
 
 	request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, "metadata")

--- a/offset_commit_response.go
+++ b/offset_commit_response.go
@@ -2,6 +2,9 @@ package sarama
 
 type OffsetCommitResponse struct {
 	Errors map[string]map[int32]KError
+
+	// This is not part of the response bytes received from Kafka
+	KafkaVersion *KafkaVersion
 }
 
 func (r *OffsetCommitResponse) AddError(topic string, partition int32, kerror KError) {

--- a/offset_fetch_request.go
+++ b/offset_fetch_request.go
@@ -4,13 +4,11 @@ type OffsetFetchRequest struct {
 	ConsumerGroup string
 	Version       int16
 	partitions    map[string][]int32
+
+	KafkaVersion *KafkaVersion
 }
 
 func (r *OffsetFetchRequest) encode(pe packetEncoder) (err error) {
-	if r.Version < 0 || r.Version > 1 {
-		return PacketEncodingError{"invalid or unsupported OffsetFetchRequest version field"}
-	}
-
 	if err = pe.putString(r.ConsumerGroup); err != nil {
 		return err
 	}
@@ -59,7 +57,11 @@ func (r *OffsetFetchRequest) key() int16 {
 }
 
 func (r *OffsetFetchRequest) version() int16 {
-	return r.Version
+	if r.KafkaVersion.AtLeast(V0_8_2_0) {
+		return 1
+	} else {
+		return 0
+	}
 }
 
 func (r *OffsetFetchRequest) AddPartition(topic string, partitionID int32) {

--- a/offset_fetch_request_test.go
+++ b/offset_fetch_request_test.go
@@ -21,6 +21,7 @@ var (
 
 func TestOffsetFetchRequest(t *testing.T) {
 	request := new(OffsetFetchRequest)
+	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	testRequest(t, "no group, no partitions", request, offsetFetchRequestNoGroupNoPartitions)
 
 	request.ConsumerGroup = "blah"

--- a/offset_fetch_request_test.go
+++ b/offset_fetch_request_test.go
@@ -21,7 +21,7 @@ var (
 
 func TestOffsetFetchRequest(t *testing.T) {
 	request := new(OffsetFetchRequest)
-	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	request.KafkaVersion = V0_8_2_2
 	testRequest(t, "no group, no partitions", request, offsetFetchRequestNoGroupNoPartitions)
 
 	request.ConsumerGroup = "blah"

--- a/offset_fetch_response.go
+++ b/offset_fetch_response.go
@@ -41,6 +41,9 @@ func (r *OffsetFetchResponseBlock) encode(pe packetEncoder) (err error) {
 
 type OffsetFetchResponse struct {
 	Blocks map[string]map[int32]*OffsetFetchResponseBlock
+
+	// This is not part of the response bytes received from Kafka
+	KafkaVersion *KafkaVersion
 }
 
 func (r *OffsetFetchResponse) encode(pe packetEncoder) error {

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -258,7 +258,7 @@ func (pom *partitionOffsetManager) selectBroker() error {
 
 func (pom *partitionOffsetManager) fetchInitialOffset(retries int) error {
 	request := new(OffsetFetchRequest)
-	request.KafkaVersion = &pom.parent.conf.KafkaVersion
+	request.KafkaVersion = pom.parent.conf.KafkaVersion
 	request.ConsumerGroup = pom.parent.group
 	request.AddPartition(pom.topic, pom.partition)
 
@@ -491,13 +491,13 @@ func (bom *brokerOffsetManager) constructRequest() *OffsetCommitRequest {
 			RetentionTime:           int64(bom.parent.conf.Consumer.Offsets.Retention / time.Millisecond),
 			ConsumerGroup:           bom.parent.group,
 			ConsumerGroupGeneration: GroupGenerationUndefined,
-			KafkaVersion:            &bom.parent.conf.KafkaVersion,
+			KafkaVersion:            bom.parent.conf.KafkaVersion,
 		}
 	} else {
 		r = &OffsetCommitRequest{
 			ConsumerGroup:           bom.parent.group,
 			ConsumerGroupGeneration: GroupGenerationUndefined,
-			KafkaVersion:            &bom.parent.conf.KafkaVersion,
+			KafkaVersion:            bom.parent.conf.KafkaVersion,
 		}
 
 	}

--- a/produce_request_test.go
+++ b/produce_request_test.go
@@ -36,12 +36,18 @@ var (
 
 func TestProduceRequest(t *testing.T) {
 	request := new(ProduceRequest)
+	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 	testRequest(t, "empty", request, produceRequestEmpty)
 
 	request.RequiredAcks = 0x123
 	request.Timeout = 0x444
 	testRequest(t, "header", request, produceRequestHeader)
 
-	request.AddMessage("topic", 0xAD, &Message{Codec: CompressionNone, Key: nil, Value: []byte{0x00, 0xEE}})
+	request.AddMessage("topic", 0xAD, &Message{
+		Codec:        CompressionNone,
+		Key:          nil,
+		Value:        []byte{0x00, 0xEE},
+		KafkaVersion: &KafkaVersion{Release: V0_8_2_2},
+	})
 	testRequest(t, "one message", request, produceRequestOneMessage)
 }

--- a/produce_request_test.go
+++ b/produce_request_test.go
@@ -36,7 +36,7 @@ var (
 
 func TestProduceRequest(t *testing.T) {
 	request := new(ProduceRequest)
-	request.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	request.KafkaVersion = V0_8_2_2
 	testRequest(t, "empty", request, produceRequestEmpty)
 
 	request.RequiredAcks = 0x123
@@ -47,7 +47,7 @@ func TestProduceRequest(t *testing.T) {
 		Codec:        CompressionNone,
 		Key:          nil,
 		Value:        []byte{0x00, 0xEE},
-		KafkaVersion: &KafkaVersion{Release: V0_8_2_2},
+		KafkaVersion: V0_8_2_2,
 	})
 	testRequest(t, "one message", request, produceRequestOneMessage)
 }

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -26,6 +26,7 @@ var (
 
 func TestProduceResponse(t *testing.T) {
 	response := ProduceResponse{}
+	response.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
 
 	testDecodable(t, "no blocks", &response, produceResponseNoBlocks)
 	if len(response.Blocks) != 0 {

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -26,7 +26,7 @@ var (
 
 func TestProduceResponse(t *testing.T) {
 	response := ProduceResponse{}
-	response.KafkaVersion = &KafkaVersion{Release: V0_8_2_2}
+	response.KafkaVersion = V0_8_2_2
 
 	testDecodable(t, "no blocks", &response, produceResponseNoBlocks)
 	if len(response.Blocks) != 0 {

--- a/produce_set.go
+++ b/produce_set.go
@@ -56,7 +56,7 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 		Codec:        CompressionNone,
 		Key:          key,
 		Value:        val,
-		KafkaVersion: &ps.parent.conf.KafkaVersion,
+		KafkaVersion: ps.parent.conf.KafkaVersion,
 	})
 
 	size := producerMessageOverhead + len(key) + len(val)
@@ -71,7 +71,7 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 	req := &ProduceRequest{
 		RequiredAcks: ps.parent.conf.Producer.RequiredAcks,
 		Timeout:      int32(ps.parent.conf.Producer.Timeout / time.Millisecond),
-		KafkaVersion: &ps.parent.conf.KafkaVersion,
+		KafkaVersion: ps.parent.conf.KafkaVersion,
 	}
 
 	for topic, partitionSet := range ps.msgs {
@@ -92,7 +92,7 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 					Codec:        ps.parent.conf.Producer.Compression,
 					Key:          nil,
 					Value:        payload,
-					KafkaVersion: &ps.parent.conf.KafkaVersion,
+					KafkaVersion: ps.parent.conf.KafkaVersion,
 				})
 			}
 		}

--- a/request.go
+++ b/request.go
@@ -79,20 +79,46 @@ func decodeRequest(r io.Reader) (req *request, err error) {
 	return req, nil
 }
 
-func allocateBody(key, version int16) requestBody {
+func allocateBody(key int16, version int16) requestBody {
 	switch key {
 	case 0:
-		return &ProduceRequest{}
+		switch version {
+		case 2:
+			return &ProduceRequest{KafkaVersion: &KafkaVersion{Release: V0_10_0}}
+		case 1:
+			return &ProduceRequest{KafkaVersion: &KafkaVersion{Release: V0_9_0_0}}
+		case 0:
+			return &ProduceRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
+		}
 	case 1:
-		return &FetchRequest{}
+		switch version {
+		case 2:
+			return &FetchRequest{KafkaVersion: &KafkaVersion{Release: V0_10_0}}
+		case 1:
+			return &FetchRequest{KafkaVersion: &KafkaVersion{Release: V0_9_0_0}}
+		case 0:
+			return &FetchRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
+		}
 	case 2:
 		return &OffsetRequest{}
 	case 3:
 		return &MetadataRequest{}
 	case 8:
-		return &OffsetCommitRequest{Version: version}
+		switch version {
+		case 2:
+			return &OffsetCommitRequest{KafkaVersion: &KafkaVersion{Release: V0_9_0_0}}
+		case 1:
+			return &OffsetCommitRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_0}}
+		case 0:
+			return &OffsetCommitRequest{KafkaVersion: &KafkaVersion{Release: V0_8_1_0}}
+		}
 	case 9:
-		return &OffsetFetchRequest{}
+		switch version {
+		case 1:
+			return &OffsetFetchRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_0}}
+		case 0:
+			return &OffsetFetchRequest{KafkaVersion: &KafkaVersion{Release: V0_8_1_0}}
+		}
 	case 10:
 		return &ConsumerMetadataRequest{}
 	case 11:

--- a/request.go
+++ b/request.go
@@ -84,20 +84,20 @@ func allocateBody(key int16, version int16) requestBody {
 	case 0:
 		switch version {
 		case 2:
-			return &ProduceRequest{KafkaVersion: &KafkaVersion{Release: V0_10_0}}
+			return &ProduceRequest{KafkaVersion: V0_10_0}
 		case 1:
-			return &ProduceRequest{KafkaVersion: &KafkaVersion{Release: V0_9_0_0}}
+			return &ProduceRequest{KafkaVersion:  V0_9_0_0}
 		case 0:
-			return &ProduceRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
+			return &ProduceRequest{KafkaVersion: V0_8_2_2}
 		}
 	case 1:
 		switch version {
 		case 2:
-			return &FetchRequest{KafkaVersion: &KafkaVersion{Release: V0_10_0}}
+			return &FetchRequest{KafkaVersion: V0_10_0}
 		case 1:
-			return &FetchRequest{KafkaVersion: &KafkaVersion{Release: V0_9_0_0}}
+			return &FetchRequest{KafkaVersion: V0_9_0_0}
 		case 0:
-			return &FetchRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_2}}
+			return &FetchRequest{KafkaVersion: V0_8_2_2}
 		}
 	case 2:
 		return &OffsetRequest{}
@@ -106,18 +106,18 @@ func allocateBody(key int16, version int16) requestBody {
 	case 8:
 		switch version {
 		case 2:
-			return &OffsetCommitRequest{KafkaVersion: &KafkaVersion{Release: V0_9_0_0}}
+			return &OffsetCommitRequest{KafkaVersion: V0_9_0_0}
 		case 1:
-			return &OffsetCommitRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_0}}
+			return &OffsetCommitRequest{KafkaVersion: V0_8_2_0}
 		case 0:
-			return &OffsetCommitRequest{KafkaVersion: &KafkaVersion{Release: V0_8_1_0}}
+			return &OffsetCommitRequest{KafkaVersion: V0_8_1_0}
 		}
 	case 9:
 		switch version {
 		case 1:
-			return &OffsetFetchRequest{KafkaVersion: &KafkaVersion{Release: V0_8_2_0}}
+			return &OffsetFetchRequest{KafkaVersion: V0_8_2_0}
 		case 0:
-			return &OffsetFetchRequest{KafkaVersion: &KafkaVersion{Release: V0_8_1_0}}
+			return &OffsetFetchRequest{KafkaVersion: V0_8_1_0}
 		}
 	case 10:
 		return &ConsumerMetadataRequest{}

--- a/utils.go
+++ b/utils.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"net"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 type none struct{}
@@ -108,4 +110,34 @@ func newBufConn(conn net.Conn) *bufConn {
 
 func (bc *bufConn) Read(b []byte) (n int, err error) {
 	return bc.buf.Read(b)
+}
+
+type kVersion struct {
+	versionArr [4]int
+}
+
+func NewVersion(ver string) (*kVersion, error) {
+	x := strings.Split(ver, ".")
+	ordA, _ := strconv.Atoi(x[0])
+	ordB, _ := strconv.Atoi(x[1])
+	ordC, _ := strconv.Atoi(x[2])
+	ordD, _ := strconv.Atoi(x[3])
+
+	v := &kVersion{
+		versionArr: [4]int{ordA, ordB, ordC, ordD},
+	}
+	return v, nil
+}
+
+func (v *kVersion) GE(ver *kVersion) bool {
+	for k, ord := range v.versionArr {
+		if ord != 0 {
+			if ord >= ver.versionArr[k] {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+	return false
 }

--- a/utils.go
+++ b/utils.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"net"
 	"sort"
-	"strconv"
-	"strings"
 )
 
 type none struct{}
@@ -112,27 +110,21 @@ func (bc *bufConn) Read(b []byte) (n int, err error) {
 	return bc.buf.Read(b)
 }
 
-type kVersion struct {
-	versionArr [4]int
+type KafkaVersion struct {
+	release [4]int
 }
 
-func NewVersion(ver string) (*kVersion, error) {
-	x := strings.Split(ver, ".")
-	ordA, _ := strconv.Atoi(x[0])
-	ordB, _ := strconv.Atoi(x[1])
-	ordC, _ := strconv.Atoi(x[2])
-	ordD, _ := strconv.Atoi(x[3])
-
-	v := &kVersion{
-		versionArr: [4]int{ordA, ordB, ordC, ordD},
+func NewVersion(ordA int, ordB int, ordC int, ordD int) *KafkaVersion {
+	v := &KafkaVersion{
+		release: [4]int{ordA, ordB, ordC, ordD},
 	}
-	return v, nil
+	return v
 }
 
-func (v *kVersion) GE(ver *kVersion) bool {
-	for k, ord := range v.versionArr {
+func (v *KafkaVersion) GE(ver *KafkaVersion) bool {
+	for k, ord := range v.release {
 		if ord != 0 {
-			if ord >= ver.versionArr[k] {
+			if ord >= ver.release[k] {
 				return true
 			} else {
 				return false


### PR DESCRIPTION
@eapache @wvanbergen This is the PR I have been working on to address https://github.com/Shopify/sarama/issues/617. Can you guys start reviewing it please. I am originally from Python background so please ignore any coding horrors here.

Also checkout how different response versions are handled in `kafka-python` [here](https://github.com/dpkp/kafka-python/blob/master/kafka/protocol/fetch.py). For this PR, I am passing kafka version from request to response so that response knows how to decode itself. Also, please do leave comments on the way kafka version is assigned in test cases. It doesn't look right IMO.

Description:
- Tries to address https://github.com/Shopify/sarama/issues/617

Not implemented/missing/confused:
- Handling offsets to kafka vs zk.
- Config conflicts.

Issues:
- I am aware of at least five test cases that are failing on this branch. These are mostly `Decoded request does not match the encoded one`. Any pointers would be highly appreciated. Failing tests:
 - TestOffsetCommitRequestV0
 - TestOffsetCommitRequestV1
 - TestOffsetFetchRequest
 - TestPartitionOffsetManagerMarkOffsetWithRetention
 - TestProduceRequest

Gotchas:

I figured out that the BNF for FetchResponse v1 is actually 
```
v1 (supported in 0.9.0 or later) and v2 (supported in 0.10.0 or later)
FetchResponse => ThrottleTime [TopicName [Partition ErrorCode HighwaterMarkOffset MessageSetSize MessageSet]]
  ThrottleTime => int32
  TopicName => string
  Partition => int32
  ErrorCode => int16
  HighwaterMarkOffset => int64
  MessageSetSize => int32
```
instead of
```
v1 (supported in 0.9.0 or later) and v2 (supported in 0.10.0 or later)
FetchResponse => [TopicName [Partition ErrorCode HighwaterMarkOffset MessageSetSize MessageSet]] ThrottleTime
  TopicName => string
  Partition => int32
  ErrorCode => int16
  HighwaterMarkOffset => int64
  MessageSetSize => int32
  ThrottleTime => int32
```
I think there is an error in the kafka protocol wiki [here](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol).