### PR TITLE
Forbid empty ClientID and use 'sarama' as default

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,8 @@ type Client interface {
 }
 
 const (
+	// Default ClientID
+	DefaultClientID = "sarama"
 	// OffsetNewest stands for the log head offset, i.e. the offset that will be
 	// assigned to the next message that will be produced to the partition. You
 	// can send this to a client's GetOffset method to get this offset, or when

--- a/client.go
+++ b/client.go
@@ -67,8 +67,6 @@ type Client interface {
 }
 
 const (
-	// Default ClientID
-	DefaultClientID = "sarama"
 	// OffsetNewest stands for the log head offset, i.e. the offset that will be
 	// assigned to the next message that will be produced to the partition. You
 	// can send this to a client's GetOffset method to get this offset, or when

--- a/config.go
+++ b/config.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const defaultClientID = "sarama"
+
 var validID *regexp.Regexp = regexp.MustCompile(`\A[A-Za-z0-9._-]+\z`)
 
 // Config is used to pass multiple configuration options to Sarama's constructors.
@@ -258,7 +260,7 @@ func NewConfig() *Config {
 
 	c.ChannelBufferSize = 256
 
-	c.ClientID = DefaultClientID
+	c.ClientID = defaultClientID
 
 	return c
 }
@@ -299,7 +301,7 @@ func (c *Config) Validate() error {
 	if c.Consumer.Offsets.Retention%time.Millisecond != 0 {
 		Logger.Println("Consumer.Offsets.Retention only supports millisecond precision; nanoseconds will be truncated.")
 	}
-	if c.ClientID == DefaultClientID {
+	if c.ClientID == defaultClientID {
 		Logger.Println("ClientID is the default of 'sarama', you should consider setting it to something application-specific.")
 	}
 

--- a/config.go
+++ b/config.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-var validID *regexp.Regexp = regexp.MustCompile(`\A[A-Za-z0-9._-]*\z`)
+var validID *regexp.Regexp = regexp.MustCompile(`\A[A-Za-z0-9._-]+\z`)
 
 // Config is used to pass multiple configuration options to Sarama's constructors.
 type Config struct {
@@ -258,6 +258,8 @@ func NewConfig() *Config {
 
 	c.ChannelBufferSize = 256
 
+	c.ClientID = DefaultClientID
+
 	return c
 }
 
@@ -297,7 +299,7 @@ func (c *Config) Validate() error {
 	if c.Consumer.Offsets.Retention%time.Millisecond != 0 {
 		Logger.Println("Consumer.Offsets.Retention only supports millisecond precision; nanoseconds will be truncated.")
 	}
-	if c.ClientID == "sarama" {
+	if c.ClientID == DefaultClientID {
 		Logger.Println("ClientID is the default of 'sarama', you should consider setting it to something application-specific.")
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -9,9 +9,17 @@ func TestDefaultConfigValidates(t *testing.T) {
 	}
 }
 
-func TestClientIDValidates(t *testing.T) {
+func TestInvalidClientIDConfigValidates(t *testing.T) {
 	config := NewConfig()
 	config.ClientID = "foo:bar"
+	if err := config.Validate(); string(err.(ConfigurationError)) != "ClientID is invalid" {
+		t.Error("Expected invalid ClientID, got ", err)
+	}
+}
+
+func TestEmptyClientIDConfigValidates(t *testing.T) {
+	config := NewConfig()
+	config.ClientID = ""
 	if err := config.Validate(); string(err.(ConfigurationError)) != "ClientID is invalid" {
 		t.Error("Expected invalid ClientID, got ", err)
 	}


### PR DESCRIPTION
Documentation states that `"sarama"` is the default ClientID but the empty string actually is used.

This is a not a problem for connecting to the brokers but it creates issues when settings policies against the tools binaries (e.g. `kafka-console-producer`) like:
```
bin/kafka-configs.sh  --zookeeper localhost:2181 --describe --entity-name ""  --entity-type clients
Error while executing topic command Path must not end with / character
java.lang.IllegalArgumentException: Path must not end with / character
	at org.apache.zookeeper.common.PathUtils.validatePath(PathUtils.java:58)
	at org.apache.zookeeper.ZooKeeper.getData(ZooKeeper.java:1137)
	at org.apache.zookeeper.ZooKeeper.getData(ZooKeeper.java:1184)
	at org.I0Itec.zkclient.ZkConnection.readData(ZkConnection.java:119)
	at org.I0Itec.zkclient.ZkClient$12.call(ZkClient.java:1094)
	at org.I0Itec.zkclient.ZkClient$12.call(ZkClient.java:1090)
	at org.I0Itec.zkclient.ZkClient.retryUntilConnected(ZkClient.java:985)
	at org.I0Itec.zkclient.ZkClient.readData(ZkClient.java:1090)
	at org.I0Itec.zkclient.ZkClient.readData(ZkClient.java:1085)
	at org.I0Itec.zkclient.ZkClient.readData(ZkClient.java:1074)
	at kafka.admin.AdminUtils$.fetchEntityConfig(AdminUtils.scala:353)
	at kafka.admin.ConfigCommand$$anonfun$describeConfig$1.apply(ConfigCommand.scala:108)
	at kafka.admin.ConfigCommand$$anonfun$describeConfig$1.apply(ConfigCommand.scala:107)
	at scala.collection.immutable.List.foreach(List.scala:318)
	at kafka.admin.ConfigCommand$.describeConfig(ConfigCommand.scala:107)
	at kafka.admin.ConfigCommand$.main(ConfigCommand.scala:57)
	at kafka.admin.ConfigCommand.main(ConfigCommand.scala)
```

Fix uses `"sarama"` as the default ClientID following the documentation and also forbids the empty string (test case provided).