### PR TITLE
client: fix returning the wrong error

### DIFF
--- a/client.go
+++ b/client.go
@@ -290,7 +290,7 @@ func (client *client) Leader(topic string, partitionID int32) (*Broker, error) {
 	leader, err := client.cachedLeader(topic, partitionID)
 
 	if leader == nil {
-		err := client.RefreshMetadata(topic)
+		err = client.RefreshMetadata(topic)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
err goes out of scope at the end of the if-block

Bug found with ineffassign.