### PR TITLE
pre-allocate decoding errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -37,6 +37,11 @@ var ErrShuttingDown = errors.New("kafka: message received by producer in process
 // ErrMessageTooLarge is returned when the next message to consume is larger than the configured Consumer.Fetch.Max
 var ErrMessageTooLarge = errors.New("kafka: message is larger than Consumer.Fetch.Max")
 
+var ErrInvalidArrayLength = PacketDecodingError{"invalid array length"}
+var ErrInvalidByteSliceLength = PacketDecodingError{"invalid byteslice length"}
+var ErrInvalidStringLength = PacketDecodingError{"invalid string length"}
+var ErrInvalidSubsetSize = PacketDecodingError{"invalid subset size"}
+
 // PacketEncodingError is returned from a failure while encoding a Kafka packet. This can happen, for example,
 // if you try to encode a string over 2^15 characters in length, since Kafka's encoding rules do not permit that.
 type PacketEncodingError struct {

--- a/errors.go
+++ b/errors.go
@@ -37,11 +37,6 @@ var ErrShuttingDown = errors.New("kafka: message received by producer in process
 // ErrMessageTooLarge is returned when the next message to consume is larger than the configured Consumer.Fetch.Max
 var ErrMessageTooLarge = errors.New("kafka: message is larger than Consumer.Fetch.Max")
 
-var ErrInvalidArrayLength = PacketDecodingError{"invalid array length"}
-var ErrInvalidByteSliceLength = PacketDecodingError{"invalid byteslice length"}
-var ErrInvalidStringLength = PacketDecodingError{"invalid string length"}
-var ErrInvalidSubsetSize = PacketDecodingError{"invalid subset size"}
-
 // PacketEncodingError is returned from a failure while encoding a Kafka packet. This can happen, for example,
 // if you try to encode a string over 2^15 characters in length, since Kafka's encoding rules do not permit that.
 type PacketEncodingError struct {

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -5,6 +5,11 @@ import (
 	"math"
 )
 
+var errInvalidArrayLength = PacketDecodingError{"invalid array length"}
+var errInvalidByteSliceLength = PacketDecodingError{"invalid byteslice length"}
+var errInvalidStringLength = PacketDecodingError{"invalid string length"}
+var errInvalidSubsetSize = PacketDecodingError{"invalid subset size"}
+
 type realDecoder struct {
 	raw   []byte
 	off   int
@@ -64,7 +69,7 @@ func (rd *realDecoder) getArrayLength() (int, error) {
 		rd.off = len(rd.raw)
 		return -1, ErrInsufficientData
 	} else if tmp > 2*math.MaxUint16 {
-		return -1, ErrInvalidArrayLength
+		return -1, errInvalidArrayLength
 	}
 	return tmp, nil
 }
@@ -82,7 +87,7 @@ func (rd *realDecoder) getBytes() ([]byte, error) {
 
 	switch {
 	case n < -1:
-		return nil, ErrInvalidByteSliceLength
+		return nil, errInvalidByteSliceLength
 	case n == -1:
 		return nil, nil
 	case n == 0:
@@ -108,7 +113,7 @@ func (rd *realDecoder) getString() (string, error) {
 
 	switch {
 	case n < -1:
-		return "", ErrInvalidStringLength
+		return "", errInvalidStringLength
 	case n == -1:
 		return "", nil
 	case n == 0:
@@ -141,7 +146,7 @@ func (rd *realDecoder) getInt32Array() ([]int32, error) {
 	}
 
 	if n < 0 {
-		return nil, ErrInvalidArrayLength
+		return nil, errInvalidArrayLength
 	}
 
 	ret := make([]int32, n)
@@ -170,7 +175,7 @@ func (rd *realDecoder) getInt64Array() ([]int64, error) {
 	}
 
 	if n < 0 {
-		return nil, ErrInvalidArrayLength
+		return nil, errInvalidArrayLength
 	}
 
 	ret := make([]int64, n)
@@ -194,7 +199,7 @@ func (rd *realDecoder) getStringArray() ([]string, error) {
 	}
 
 	if n < 0 {
-		return nil, ErrInvalidArrayLength
+		return nil, errInvalidArrayLength
 	}
 
 	ret := make([]string, n)
@@ -216,7 +221,7 @@ func (rd *realDecoder) remaining() int {
 
 func (rd *realDecoder) getSubset(length int) (packetDecoder, error) {
 	if length < 0 {
-		return nil, ErrInvalidSubsetSize
+		return nil, errInvalidSubsetSize
 	} else if length > rd.remaining() {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -64,7 +64,7 @@ func (rd *realDecoder) getArrayLength() (int, error) {
 		rd.off = len(rd.raw)
 		return -1, ErrInsufficientData
 	} else if tmp > 2*math.MaxUint16 {
-		return -1, PacketDecodingError{"invalid array length"}
+		return -1, ErrInvalidArrayLength
 	}
 	return tmp, nil
 }
@@ -82,7 +82,7 @@ func (rd *realDecoder) getBytes() ([]byte, error) {
 
 	switch {
 	case n < -1:
-		return nil, PacketDecodingError{"invalid byteslice length"}
+		return nil, ErrInvalidByteSliceLength
 	case n == -1:
 		return nil, nil
 	case n == 0:
@@ -108,7 +108,7 @@ func (rd *realDecoder) getString() (string, error) {
 
 	switch {
 	case n < -1:
-		return "", PacketDecodingError{"invalid string length"}
+		return "", ErrInvalidStringLength
 	case n == -1:
 		return "", nil
 	case n == 0:
@@ -141,7 +141,7 @@ func (rd *realDecoder) getInt32Array() ([]int32, error) {
 	}
 
 	if n < 0 {
-		return nil, PacketDecodingError{"invalid array length"}
+		return nil, ErrInvalidArrayLength
 	}
 
 	ret := make([]int32, n)
@@ -170,7 +170,7 @@ func (rd *realDecoder) getInt64Array() ([]int64, error) {
 	}
 
 	if n < 0 {
-		return nil, PacketDecodingError{"invalid array length"}
+		return nil, ErrInvalidArrayLength
 	}
 
 	ret := make([]int64, n)
@@ -194,7 +194,7 @@ func (rd *realDecoder) getStringArray() ([]string, error) {
 	}
 
 	if n < 0 {
-		return nil, PacketDecodingError{"invalid array length"}
+		return nil, ErrInvalidArrayLength
 	}
 
 	ret := make([]string, n)
@@ -216,7 +216,7 @@ func (rd *realDecoder) remaining() int {
 
 func (rd *realDecoder) getSubset(length int) (packetDecoder, error) {
 	if length < 0 {
-		return nil, PacketDecodingError{"invalid subset size"}
+		return nil, ErrInvalidSubsetSize
 	} else if length > rd.remaining() {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData


### PR DESCRIPTION
I saw that the dynamic creation of errors was contributing a lot to the heap profile (see below)
I haven't tested extensively yet, but this should fix it


```
(pprof) top30 -cum
62951786 of 63347642 total (99.38%)
Dropped 41 nodes (cum <= 316738)
      flat  flat%   sum%        cum   cum%
  57502851 90.77% 90.77%   63347642   100%  [metric_tank]
         0     0% 90.77%   35258445 55.66%  github.com/Shopify/sarama.(*realDecoder).getInt64Array
   3922373  6.19% 96.97%    3922373  6.19%  regexp/syntax.(*compiler).quest
    680349  1.07% 98.04%     680349  1.07%  crypto/x509/pkix.(*Name).FillFromRDNSequence
    444790   0.7% 98.74%     504731   0.8%  crypto/x509/pkix.Name.ToRDNSequence
         0     0% 98.74%     491660  0.78%  github.com/Shopify/sarama.(*OffsetFetchRequest).decode
    401423  0.63% 99.38%     401423  0.63%  regexp/syntax.(*parser).factor
(pprof) list getInt64Array
Total: 63347642
ROUTINE ======================== github.com/Shopify/sarama.(*realDecoder).getInt64Array in /home/dieter/go/src/github.com/Shopify/sarama/real_decoder.go
         0   35258445 (flat, cum) 55.66% of Total
         .          .    153:}
         .          .    154:
         .          .    155:func (rd *realDecoder) getInt64Array() ([]int64, error) {
         .          .    156:	if rd.remaining() < 4 {
         .          .    157:		rd.off = len(rd.raw)
         .      10923    158:		return nil, ErrInsufficientData
         .          .    159:	}
         .          .    160:	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
         .          .    161:	rd.off += 4
         .          .    162:
         .          .    163:	if rd.remaining() < 8*n {
         .    1773176    164:		rd.off = len(rd.raw)
         .          .    165:		return nil, ErrInsufficientData
         .          .    166:	}
         .          .    167:
         .          .    168:	if n == 0 {
         .    1180404    169:		return nil, nil
         .          .    170:	}
         .          .    171:
         .          .    172:	if n < 0 {
         .   32293942    173:		return nil, PacketDecodingError{"invalid array length"}
         .          .    174:	}
         .          .    175:
         .          .    176:	ret := make([]int64, n)
         .          .    177:	for i := range ret {
         .          .    178:		ret[i] = int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
(pprof) 
```


