### PR TITLE
Do not reset ProducerMessage timestamp when it's CreateTime

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -727,7 +727,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 		switch block.Err {
 		// Success
 		case ErrNoError:
-			if bp.parent.conf.Version.IsAtLeast(V0_10_0_0) {
+			if bp.parent.conf.Version.IsAtLeast(V0_10_0_0) && block.Timestamp.Unix() >= 0 {
 				for _, msg := range msgs {
 					msg.Timestamp = block.Timestamp
 				}


### PR DESCRIPTION
ProduceResponse doesn't always guarantee a valid timestamp. When broker is set to "CreateTime", the field will be -1.

[http://kafka.apache.org/protocol.html](http://kafka.apache.org/protocol.html)
> If CreateTime is used for the topic, the timestamp will be -1.
