### PR TITLE
Don't propagate zero timestamp to ProducerMessage

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -727,7 +727,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 		switch block.Err {
 		// Success
 		case ErrNoError:
-			if bp.parent.conf.Version.IsAtLeast(V0_10_0_0) {
+			if bp.parent.conf.Version.IsAtLeast(V0_10_0_0) && !block.Timestamp.IsZero() {
 				for _, msg := range msgs {
 					msg.Timestamp = block.Timestamp
 				}


### PR DESCRIPTION
Thank you for your response to #697. It makes much more sense to handle -1 timestamp in produce_response.go.
It would be nice to let ProducerMessage keep its timestamp, not overridden after being sent, so I made this pull request. Look forward to knowing your opinion. 