### PR TITLE
Update logo to not use HTTP, but also allows HTTPS

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -11,7 +11,7 @@
       <header class="hero-header">
         <div class="pagewidth">
           <div class="logo--ie">
-            <img src="http://shopify.github.io/images/shopify-open-source-sub.svg" alt="Shopify Open Source" class="logo">
+            <img src="//shopify.github.io/images/shopify-open-source-sub.svg" alt="Shopify Open Source" class="logo">
             <span class="breadcrumb"><a href="http://shopify.github.io">Open Source</a> > {{ site.github.project_title }}</span>
           </div>
           <div class="repo-lang {{ site.github.language | downcase }}">


### PR DESCRIPTION
If you access `https://shopify.github.io/sarama/` (note HTTPS), the page loads the icon via HTTP, breaking the seal. This PR makes it so it'll pick either HTTP or HTTPS, like the javascripts files at the bottom of the page.