### PR TITLE
Fix HashPartitioner's negative result

### DIFF
--- a/partitioner.go
+++ b/partitioner.go
@@ -112,10 +112,11 @@ func (p *hashPartitioner) Partition(message *ProducerMessage, numPartitions int3
 		return -1, err
 	}
 	hash := int32(p.hasher.Sum32())
-	if hash < 0 {
-		hash = -hash
+	partition := hash % numPartitions
+	if partition < 0 {
+		partition = -partition
 	}
-	return hash % numPartitions, nil
+	return partition, nil
 }
 
 func (p *hashPartitioner) RequiresConsistency() bool {

--- a/partitioner_test.go
+++ b/partitioner_test.go
@@ -100,6 +100,23 @@ func TestHashPartitioner(t *testing.T) {
 	}
 }
 
+func TestHashPartitionerMinInt32(t *testing.T) {
+	partitioner := NewHashPartitioner("mytopic")
+
+	msg := ProducerMessage{}
+	// "1468509572224" generates 2147483648 (uint32) result from Sum32 function
+	// which is -2147483648 or int32's min value
+	msg.Key = StringEncoder("1468509572224")
+
+	choice, err := partitioner.Partition(&msg, 50)
+	if err != nil {
+		t.Error(partitioner, err)
+	}
+	if choice < 0 || choice >= 50 {
+		t.Error("Returned partition", choice, "outside of range for nil key.")
+	}
+}
+
 func TestManualPartitioner(t *testing.T) {
 	partitioner := NewManualPartitioner("mytopic")
 


### PR DESCRIPTION
Issue: I have found that for some Key, the Partition function of HashPartitioner return negative value. After I investigate the issue, I have found that if the fnv's Sum32 function returns 2147483648, which is -2147483648 in int32 and the negative of this will still be -2147483648 causing the negative result returned.

Reproduce: this issue can be reproduced by using "1468509572224" as message's key.

Change: 
- partitioner.go: Apply modulo before checking the negative value to ensure the positive result.
- partitioner_test.go: Add TestHashPartitionerMinInt32 to test the error case.

Please feel free to suggest the better way to fix this issue.