### PR TITLE
Consumer: reduce timer allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Improvements:
    ([#634](https://github.com/Shopify/sarama/pull/634)).
  - Pre-allocate decoding errors, greatly reducing heap usage and GC time against
    misbehaving brokers ([#690](https://github.com/Shopify/sarama/pull/690)).
+ - Re-use consumer expiry timers, removing one allocation per consumed message
+   ([#707](https://github.com/Shopify/sarama/pull/707)).
 
 Bug Fixes:
  - Actually default the client ID to "sarama" like we say we do


### PR DESCRIPTION
Rather than allocating a new timer with `time.After` on every message we
consume, allocate one for the `responseFeeder` and just keep resetting it.
Thanks to @Tevic for suggesting this approach.

Fixes #707 cc @Dieterbe.