### PR TITLE
Fix download link in gh-pages

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -25,7 +25,7 @@
           <h2 class="hero-text">{{ site.github.project_tagline }}</h2>
           <div class="cta-buttons">
             <a href="http://godoc.org/github.com/Shopify/sarama" class="float">Documentation</a>
-            <a href="{{ site.github.zip_url }}" class="float">Download ZIP</a>
+            <a href="{{ site.github.repository_url }}/zipball/master" class="float">Download ZIP</a>
             <a href="{{ site.github.repository_url }}" class="float github">
               Github Repo
               <i class="icon-star" title="Stars"></i> <span id="starCount"></span>


### PR DESCRIPTION
The current download link in gh-pages is for downloading the zip of gh-pages branch, which should not be intended.