### PR TITLE
Adding Dockerfile for easily bringing up tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.6
+
+RUN mkdir -p /go/src/github.com/Shopify/sarama
+
+COPY . /go/src/github.com/Shopify/sarama
+
+RUN cd /go/src/github.com/Shopify/sarama && \
+	go-wrapper download
+
+# Build our tools
+RUN go build /go/src/github.com/Shopify/sarama/tools/kafka-console-producer/kafka-console-producer.go && \
+	mv kafka-console-producer /go/bin/
+
+RUN cd /go/src/github.com/Shopify/sarama && \
+	go build tools/kafka-console-consumer/kafka-console-consumer.go && \
+	mv kafka-console-consumer /go/bin/
+
+RUN cd /go/src/github.com/Shopify/sarama && \
+	go build tools/kafka-console-partitionconsumer/kafka-console-partitionconsumer.go && \
+	mv kafka-console-partitionconsumer /go/bin/
+
+WORKDIR /go/bin


### PR DESCRIPTION
This provides an easy way to run the producer and consumer using docker containers.

The following examples use kafka in a docker image as the broker, and therefore
have a link to the kafka container to use as the hostname.  This will work the same
as long as kafka is reachable by the docker container.

Example build:
    docker build -t sarama .

Example producer:
    docker run --rm --link kafka:kafka sarama kafka-console-producer -topic test -brokers kafka:9092 -value "test 1 2"

Example consumer
    docker run --rm --link kafka:kafka sarama kafka-console-consumer -topic test -offset oldest -brokers kafka:9092

Reported by: Tyler Ruppert <tylerruppert@gmail.com>
Signed-off-by: Tyler Ruppert <tylerruppert@gmail.com>