### PR TITLE
Expose Encode in encode_decode.go

### DIFF
--- a/encoder_decoder.go
+++ b/encoder_decoder.go
@@ -8,6 +8,10 @@ type encoder interface {
 	encode(pe packetEncoder) error
 }
 
+func Encode(e encoder) ([]byte, error) {
+	return encode(e)
+}
+
 // Encode takes an Encoder and turns it into bytes.
 func encode(e encoder) ([]byte, error) {
 	if e == nil {


### PR DESCRIPTION
Hi,

I would like to expose a public `Encode` interface to allow low level clients to do something like below. Basically low level clients would like to create their own Producer based on sarama low level components.

When producing message to Kafka:
1) Create a sarama.MessageSet, add sarama.MessageBlock
2) Call this new `sarama.Encode` against the MessageSet in 1) to generate encoded payload
3) Add the encoded payload to sarama.ProduceRequest
4) Call broker.Produce(req) against req in 3) to produce the message to Kafka

For now, sarama.encode in encoder_decoder.go doesn't expose to clients.
