### PR TITLE
Fix Racy call to Reset in feederLoop

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -420,10 +420,11 @@ feederLoop:
 		msgs, child.responseResult = child.parseResponse(response)
 
 		for i, msg := range msgs {
-			if !expiryTimer.Reset(child.conf.Consumer.MaxProcessingTime) {
+			if !expiryTimer.Stop() {
 				// expiryTimer was expired; clear out the waiting msg
 				<-expiryTimer.C
 			}
+			expiryTimer.Reset(child.conf.Consumer.MaxProcessingTime)
 
 			select {
 			case child.messages <- msg:


### PR DESCRIPTION
Checking Reset()'s active return value is racy according to [Golang docs](https://golang.org/pkg/time/#Timer.Reset). 

>Note that it is not possible to use Reset's return value correctly, as there is a race condition between draining the channel and the new timer expiring. Reset should always be used in concert with Stop, as described above. The return value exists to preserve compatibility with existing programs.

Docs advice to call Stop in order to reuse a timer. Should fix #732.