### PR TITLE
Use a local registry for metrics

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 func ExampleBroker() {
@@ -74,8 +72,6 @@ func TestSimpleBrokerCommunication(t *testing.T) {
 		broker.id = 0
 		conf := NewConfig()
 		conf.Version = V0_10_0_0
-		// Use a new registry every time to prevent side effect caused by the global one
-		conf.MetricRegistry = metrics.NewRegistry()
 		err := broker.Open(conf)
 		if err != nil {
 			t.Fatal(err)

--- a/config.go
+++ b/config.go
@@ -236,7 +236,7 @@ type Config struct {
 	// running may lead to random breakage.
 	Version KafkaVersion
 	// The registry to define metrics into.
-	// Defaults to metrics.DefaultRegistry.
+	// Defaults to a local registry.
 	// If you want to disable metrics gathering, set "metrics.UseNilMetrics" to "true"
 	// prior to starting Sarama.
 	// See Examples on how to use the metrics registry
@@ -276,7 +276,7 @@ func NewConfig() *Config {
 	c.ClientID = defaultClientID
 	c.ChannelBufferSize = 256
 	c.Version = minVersion
-	c.MetricRegistry = metrics.DefaultRegistry
+	c.MetricRegistry = metrics.NewRegistry()
 
 	return c
 }

--- a/config_test.go
+++ b/config_test.go
@@ -12,8 +12,8 @@ func TestDefaultConfigValidates(t *testing.T) {
 	if err := config.Validate(); err != nil {
 		t.Error(err)
 	}
-	if config.MetricRegistry != metrics.DefaultRegistry {
-		t.Error("Expected metrics.DefaultRegistry, got ", config.MetricRegistry)
+	if config.MetricRegistry == nil {
+		t.Error("Expected non nil metrics.MetricRegistry, got nil")
 	}
 }
 
@@ -42,7 +42,7 @@ func ExampleConfig_metrics() {
 	appGauge.Update(1)
 
 	config := NewConfig()
-	// Use a prefix registry instead of the default global one
+	// Use a prefix registry instead of the default local one
 	config.MetricRegistry = metrics.NewPrefixedChildRegistry(appMetricRegistry, "sarama.")
 
 	// Simulate a metric created by sarama without starting a broker

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -99,9 +99,6 @@ func testProducingMessages(t *testing.T, config *Config) {
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
 
-	// Use a dedicated registry to prevent side effect caused by the global one
-	config.MetricRegistry = metrics.NewRegistry()
-
 	config.Producer.Return.Successes = true
 	config.Consumer.Return.Errors = true
 

--- a/sarama.go
+++ b/sarama.go
@@ -21,7 +21,7 @@ the producers and the consumer. The Request/Response objects and properties are 
 exactly with the protocol fields documented by Kafka at
 https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol
 
-Metrics are exposed through https://github.com/rcrowley/go-metrics library.
+Metrics are exposed through https://github.com/rcrowley/go-metrics library in a local registry.
 
 Broker related metrics:
 


### PR DESCRIPTION
- use a new dedicated registry per config instead of using the default global registry provided by go-metrics
- update documentation and unit tests