### PR TITLE
Add SASL handshake negotiation

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -514,6 +514,53 @@ func (b *Broker) responseReceiver() {
 	close(b.done)
 }
 
+func (b *Broker) sendAndReceiveSASLPlainHandshake() error {
+	rb := &SaslHandshakeRequest{"PLAIN"}
+	req := &request{correlationID: b.correlationID, clientID: b.conf.ClientID, body: rb}
+	buf, err := encode(req)
+	if err != nil {
+		return err
+	}
+
+	err = b.conn.SetWriteDeadline(time.Now().Add(b.conf.Net.WriteTimeout))
+	if err != nil {
+		return err
+	}
+
+	bytes, err := b.conn.Write(buf)
+	b.updateOutgoingCommunicationMetrics(bytes)
+	if err != nil {
+		Logger.Printf("Failed to send SASL handshake %s: %s\n", b.addr, err.Error())
+		return err
+	}
+	b.correlationID++
+	//wait for the response
+	header := make([]byte, 8) // response header
+	n, err := io.ReadFull(b.conn, header)
+	b.updateIncomingCommunicationMetrics(n)
+	length := binary.BigEndian.Uint32(header[:4])
+	payload := make([]byte, length-4)
+	n, err = io.ReadFull(b.conn, payload)
+	if err != nil {
+		Logger.Printf("Failed to read SASL handshake payload : %s\n", err.Error())
+		return err
+	}
+	b.updateIncomingCommunicationMetrics(n)
+	res := &SaslHandshakeResponse{}
+	err = versionedDecode(payload, res, 0)
+	if err != nil {
+		Logger.Printf("Failed to parse SASL handshake : %s\n", err.Error())
+		return err
+	}
+	if res.Err != ErrNoError {
+		Logger.Printf("Invalid SASL Mechanism : %s\n", err.Error())
+		return res.Err
+	}
+	Logger.Print("Successful SASL handshake")
+	return nil
+
+}
+
 // Kafka 0.10.0 plans to support SASL Plain and Kerberos as per PR #812 (KIP-43)/(JIRA KAFKA-3149)
 // Some hosted kafka services such as IBM Message Hub already offer SASL/PLAIN auth with Kafka 0.9
 //
@@ -533,6 +580,11 @@ func (b *Broker) responseReceiver() {
 // When credentials are invalid, Kafka closes the connection. This does not seem to be the ideal way
 // of responding to bad credentials but thats how its being done today.
 func (b *Broker) sendAndReceiveSASLPlainAuth() error {
+	handshakeErr := b.sendAndReceiveSASLPlainHandshake()
+	if handshakeErr != nil {
+		Logger.Printf("Error while performing SASL handshake %s\n", b.addr)
+		return handshakeErr
+	}
 	length := 1 + len(b.conf.Net.SASL.User) + 1 + len(b.conf.Net.SASL.Password)
 	authBytes := make([]byte, length+4) //4 byte length header + auth data
 	binary.BigEndian.PutUint32(authBytes, uint32(length))


### PR DESCRIPTION
Here is a description of the problem I found :
##### Versions

Sarama Version: 482c471fbf73dc2ac66945187f811581f008c24a
Kafka Version: 0.10.0.1
Go Version:  go1.7 darwin/amd64
##### Configuration

Kafka configuration 

```
listeners=SASL_PLAINTEXT://:9091,SASL_SSL://:9093
advertised.listeners=SASL_PLAINTEXT://:9091,SASL_SSL://:9093
ssl.keystore.location=/opt/kafka/ssl/keystore/kafka.keystore.jks
ssl.keystore.password=XXXXXXXXXXX
ssl.key.password=XXXXXXXXXXX
ssl.truststore.location=/opt/kafka/ssl/truststore/kafka.truststore.jks
ssl.truststore.password=XXXXXXXXXXX
ssl.client.auth=required
security.inter.broker.protocol=SASL_SSL                                           
sasl.enabled.mechanisms=PLAIN                                                     
sasl.mechanism.inter.broker.protocol=PLAIN
```

Sarama configuration

``` go
config.Net.SASL.Enable = true
config.Net.SASL.User = username
config.Net.SASL.Password = password
```
##### Problem Description

Using tcp-proxy ang golang I have the following frames : 

```
Connection #001 Opened :9091 >>> 167.114.245.179:9091
Connection #001 >>> 34 bytes sent
Connection #001 0000001e69616d746865636c69656e740069616d746865636c69656e7400746f746f
Connection #001 Closed (34 bytes sent, 0 bytes recieved)
```

Using tcp-proxy and python we have the following frames : 

```
Connection #005 >>> 44 bytes sent
Connection #005 00000028001100000000000100176b61666b612d707974686f6e2d70726f64756365722d310005504c41494e
Connection #005 <<< 21 bytes received
Connection #005 00000011000000010000000000010005504c41494e
Connection #005 >>> 34 bytes sent
Connection #005 0000001e69616d746865636c69656e740069616d746865636c69656e7400746f746f
Connection #005 <<< 4 bytes received
Connection #005 00000000
```

With SASL plain authentication activated, sarama sends the username/password but does not send the SASL handshake to start the SASL negotiation. As a result, Kafka closes the connection.
This patch add the SASL handshake negotiation.
