### PR TITLE
add missing metadata and assignment methods in describegroups

### DIFF
--- a/describe_groups_response.go
+++ b/describe_groups_response.go
@@ -172,3 +172,15 @@ func (gmd *GroupMemberDescription) decode(pd packetDecoder) (err error) {
 
 	return nil
 }
+
+func (r *GroupMemberDescription) GetMemberAssignment() (*ConsumerGroupMemberAssignment, error) {
+	assignment := new(ConsumerGroupMemberAssignment)
+	err := decode(r.MemberAssignment, assignment)
+	return assignment, err
+}
+
+func (r *GroupMemberDescription) GetMemberMetadata() (*ConsumerGroupMemberMetadata, error) {
+	assignment := new(ConsumerGroupMemberMetadata)
+	err := decode(r.MemberMetadata, assignment)
+	return assignment, err
+}

--- a/describe_groups_response.go
+++ b/describe_groups_response.go
@@ -173,14 +173,14 @@ func (gmd *GroupMemberDescription) decode(pd packetDecoder) (err error) {
 	return nil
 }
 
-func (r *GroupMemberDescription) GetMemberAssignment() (*ConsumerGroupMemberAssignment, error) {
+func (gmd *GroupMemberDescription) GetMemberAssignment() (*ConsumerGroupMemberAssignment, error) {
 	assignment := new(ConsumerGroupMemberAssignment)
-	err := decode(r.MemberAssignment, assignment)
+	err := decode(gmd.MemberAssignment, assignment)
 	return assignment, err
 }
 
-func (r *GroupMemberDescription) GetMemberMetadata() (*ConsumerGroupMemberMetadata, error) {
-	assignment := new(ConsumerGroupMemberMetadata)
-	err := decode(r.MemberMetadata, assignment)
-	return assignment, err
+func (gmd *GroupMemberDescription) GetMemberMetadata() (*ConsumerGroupMemberMetadata, error) {
+	metadata := new(ConsumerGroupMemberMetadata)
+	err := decode(gmd.MemberMetadata, metadata)
+	return metadata, err
 }


### PR DESCRIPTION
The code did already exists in sync_group_response.go, but added them also in describe_groups_response.go.
Now you can read the MemberAssignment and MemberMetadata also (before it was raw bytes, and not that easy to get the actual structs)