### PR TITLE
Fix compression timestamps

### DIFF
--- a/produce_set.go
+++ b/produce_set.go
@@ -101,7 +101,7 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 				}
 				if ps.parent.conf.Version.IsAtLeast(V0_10_0_0) {
 					compMsg.Version = 1
-					compMsg.Timestamp = time.Now()
+					compMsg.Timestamp = set.setToSend.Messages[0].Msg.Timestamp
 				}
 				req.AddMessage(topic, partition, compMsg)
 			}


### PR DESCRIPTION
The wrapper message has to use the "new" format if the compressed messages use it as well.
This will fix #757 #758 