### PR TITLE
Bump some versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
 - 1.5.4
-- 1.6.2
+- 1.6.3
+- 1.7.1
 
 env:
   global:
@@ -13,7 +14,7 @@ env:
   matrix:
   - KAFKA_VERSION=0.8.2.2
   - KAFKA_VERSION=0.9.0.1
-  - KAFKA_VERSION=0.10.0.0
+  - KAFKA_VERSION=0.10.0.1
 
 before_install:
 - export REPOSITORY_ROOT=${TRAVIS_BUILD_DIR}

--- a/utils.go
+++ b/utils.go
@@ -146,5 +146,6 @@ var (
 	V0_9_0_0   = newKafkaVersion(0, 9, 0, 0)
 	V0_9_0_1   = newKafkaVersion(0, 9, 0, 1)
 	V0_10_0_0  = newKafkaVersion(0, 10, 0, 0)
+	V0_10_0_1  = newKafkaVersion(0, 10, 0, 1)
 	minVersion = V0_8_2_0
 )


### PR DESCRIPTION
Add go 1.7 to CI, bump 1.6 CI point release, bump kafka 0.10 CI point version,
add kafka 0.10.0.1 to the pre-defined version set.