### PR TITLE
re-partition messages on retry

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -300,7 +300,7 @@ func (p *asyncProducer) newTopicProducer(topic string) chan<- *ProducerMessage {
 
 func (tp *topicProducer) dispatch() {
 	for msg := range tp.input {
-		if msg.retries == 0 {
+		if msg.retries == 0 || (msg.flags == 0 && !tp.partitioner.RequiresConsistency()) {
 			if err := tp.partitionMessage(msg); err != nil {
 				tp.parent.returnError(msg, err)
 				continue

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -580,12 +580,12 @@ func TestAsyncProducerRetryWithReferenceOpen(t *testing.T) {
 	// send another message on partition 0 to trigger the EOF and retry
 	producer.Input() <- &ProducerMessage{Topic: "my_topic", Key: nil, Value: StringEncoder(TestMessage)}
 
-	// tell partition 0 to go to that broker again
+	// tell both partitions to go to that broker again
 	seedBroker.Returns(metadataResponse)
 
-	// succeed this time
+	// succeed on retry to partition 1
 	prodSuccess = new(ProduceResponse)
-	prodSuccess.AddTopicPartition("my_topic", 0, ErrNoError)
+	prodSuccess.AddTopicPartition("my_topic", 1, ErrNoError)
 	leader.Returns(prodSuccess)
 	expectResults(t, producer, 1, 0)
 


### PR DESCRIPTION
If our partitioner doesn't require consistency, it's safe to do retries
on a different partition, and doing so can greatly improve availability
in the case of broker failures; Since we'll only try on partitions that
are known to have an active leader, we can route messages to a partition
homed on a healthy broker.

This is technically a behavior change, but it seems like a "safe" one in that `RequiresConsistency() == false` partitioners never had any strong guarantees on where messages would route in the case of failure.

I'm happy to write a test and/or hide this behavior behind a config flag if that'd be desired. But I think that the gain in availability when publishing is well-worth implementing this behavior in some form, so I'm opening this to start the discussion.