### PR TITLE
Expose request latency metric

### DIFF
--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	toxiproxy "github.com/Shopify/toxiproxy/client"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -98,6 +99,13 @@ func TestFuncProducingToInvalidTopic(t *testing.T) {
 func testProducingMessages(t *testing.T, config *Config) {
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
+
+	// Configure some latency in order to properly validate the request latency metric
+	for _, proxy := range Proxies {
+		if _, err := proxy.AddToxic("", "latency", "", 1, toxiproxy.Attributes{"latency": 10}); err != nil {
+			t.Fatal("Unable to configure latency toxicity", err)
+		}
+	}
 
 	config.Producer.Return.Successes = true
 	config.Consumer.Return.Errors = true
@@ -193,16 +201,25 @@ func validateMetrics(t *testing.T, client Client) {
 	noResponse := client.Config().Producer.RequiredAcks == NoResponse
 	compressionEnabled := client.Config().Producer.Compression != CompressionNone
 
+	// We are adding 10ms of latency to all requests with toxiproxy
+	minRequestLatencyInMs := 10
+	if noResponse {
+		// but when we do not wait for a response it can be less than 1ms
+		minRequestLatencyInMs = 0
+	}
+
 	// We read at least 1 byte from the broker
 	metricValidators.registerForAllBrokers(broker, minCountMeterValidator("incoming-byte-rate", 1))
 	// in at least 3 global requests (1 for metadata request, 1 for offset request and N for produce request)
 	metricValidators.register(minCountMeterValidator("request-rate", 3))
 	metricValidators.register(minCountHistogramValidator("request-size", 3))
 	metricValidators.register(minValHistogramValidator("request-size", 1))
+	metricValidators.register(minValHistogramValidator("request-latency-in-ms", minRequestLatencyInMs))
 	// and at least 2 requests to the registered broker (offset + produces)
 	metricValidators.registerForBroker(broker, minCountMeterValidator("request-rate", 2))
 	metricValidators.registerForBroker(broker, minCountHistogramValidator("request-size", 2))
 	metricValidators.registerForBroker(broker, minValHistogramValidator("request-size", 1))
+	metricValidators.registerForBroker(broker, minValHistogramValidator("request-latency-in-ms", minRequestLatencyInMs))
 
 	// We send at least 1 batch
 	metricValidators.registerForGlobalAndTopic("test_1", minCountHistogramValidator("batch-size", 1))

--- a/sarama.go
+++ b/sarama.go
@@ -25,22 +25,24 @@ Metrics are exposed through https://github.com/rcrowley/go-metrics library in a 
 
 Broker related metrics:
 
-	+-------------------------------------------+------------+---------------------------------------------------------------+
-	| Name                                      | Type       | Description                                                   |
-	+-------------------------------------------+------------+---------------------------------------------------------------+
-	| incoming-byte-rate                        | meter      | Bytes/second read off all brokers                             |
-	| incoming-byte-rate-for-broker-<broker-id> | meter      | Bytes/second read off a given broker                          |
-	| outgoing-byte-rate                        | meter      | Bytes/second written off all brokers                          |
-	| outgoing-byte-rate-for-broker-<broker-id> | meter      | Bytes/second written off a given broker                       |
-	| request-rate                              | meter      | Requests/second sent to all brokers                           |
-	| request-rate-for-broker-<broker-id>       | meter      | Requests/second sent to a given broker                        |
-	| request-size                              | histogram  | Distribution of the request size in bytes for all brokers     |
-	| request-size-for-broker-<broker-id>       | histogram  | Distribution of the request size in bytes for a given broker  |
-	| response-rate                             | meter      | Responses/second received from all brokers                    |
-	| response-rate-for-broker-<broker-id>      | meter      | Responses/second received from a given broker                 |
-	| response-size                             | histogram  | Distribution of the response size in bytes for all brokers    |
-	| response-size-for-broker-<broker-id>      | histogram  | Distribution of the response size in bytes for a given broker |
-	+-------------------------------------------+------------+---------------------------------------------------------------+
+	+----------------------------------------------+------------+---------------------------------------------------------------+
+	| Name                                         | Type       | Description                                                   |
+	+----------------------------------------------+------------+---------------------------------------------------------------+
+	| incoming-byte-rate                           | meter      | Bytes/second read off all brokers                             |
+	| incoming-byte-rate-for-broker-<broker-id>    | meter      | Bytes/second read off a given broker                          |
+	| outgoing-byte-rate                           | meter      | Bytes/second written off all brokers                          |
+	| outgoing-byte-rate-for-broker-<broker-id>    | meter      | Bytes/second written off a given broker                       |
+	| request-rate                                 | meter      | Requests/second sent to all brokers                           |
+	| request-rate-for-broker-<broker-id>          | meter      | Requests/second sent to a given broker                        |
+	| request-size                                 | histogram  | Distribution of the request size in bytes for all brokers     |
+	| request-size-for-broker-<broker-id>          | histogram  | Distribution of the request size in bytes for a given broker  |
+	| request-latency-in-ms                        | histogram  | Distribution of the request latency in ms for all brokers     |
+	| request-latency-in-ms-for-broker-<broker-id> | histogram  | Distribution of the request latency in ms for a given broker  |
+	| response-rate                                | meter      | Responses/second received from all brokers                    |
+	| response-rate-for-broker-<broker-id>         | meter      | Responses/second received from a given broker                 |
+	| response-size                                | histogram  | Distribution of the response size in bytes for all brokers    |
+	| response-size-for-broker-<broker-id>         | histogram  | Distribution of the response size in bytes for a given broker |
+	+----------------------------------------------+------------+---------------------------------------------------------------+
 
 Note that we do not gather specific metrics for seed brokers but they are part of the "all brokers" metrics.
 


### PR DESCRIPTION
The Java client exposes two metrics about request latency (`request-latency-avg` as the average request latency in ms and `request-latency-max` as the maximum request latency in ms).
This metric is extremely valuable when optimizing the communication between a remote producer and a Kafka cluster through TCP tuning, typically when the socket buffers are too small on either side to reach the bandwidth-delay product of the connection.

Code change:
- new `request-latency-in-ms` histogram metric (global and per registered broker)
- addng 10ms latency to brokers in producer functional tests for validation
- updating documentation
