### PR TITLE
Stop test if client.Coordinator fails somehow

### DIFF
--- a/functional_client_test.go
+++ b/functional_client_test.go
@@ -78,7 +78,7 @@ func TestFuncClientCoordinator(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		broker, err := client.Coordinator(fmt.Sprintf("another_new_consumer_group_%d", i))
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		if connected, err := broker.Connected(); !connected || err != nil {


### PR DESCRIPTION
When working on #771, the tests failed one time with:
```
=== RUN   TestFuncClientCoordinator
--- FAIL: TestFuncClientCoordinator (1.60s)
	functional_client_test.go:81: kafka server: Offset's topic has not yet been created.
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8666d]

goroutine 1223 [running]:
panic(0x37c3e0, 0xc4200120c0)
	/usr/local/Cellar/go/1.7/libexec/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc4209a6180)
	/usr/local/Cellar/go/1.7/libexec/src/testing/testing.go:579 +0x25d
panic(0x37c3e0, 0xc4200120c0)
	/usr/local/Cellar/go/1.7/libexec/src/runtime/panic.go:458 +0x243
github.com/Shopify/sarama.(*Broker).Connected(0x0, 0xc42098bf00, 0x0, 0x0)
	/Users/slaunay/work/open-source/sarama/src/github.com/Shopify/sarama/broker.go:152 +0x3d
github.com/Shopify/sarama.TestFuncClientCoordinator(0xc4209a6180)
	/Users/slaunay/work/open-source/sarama/src/github.com/Shopify/sarama/functional_client_test.go:84 +0x21d
testing.tRunner(0xc4209a6180, 0x4181c8)
	/usr/local/Cellar/go/1.7/libexec/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
	/usr/local/Cellar/go/1.7/libexec/src/testing/testing.go:646 +0x2ec
```

The brokers being unresponsive (see #771), `client.Coordinator` would fail but the test would continue leading to a nil pointer dereference:
```go
func (b *Broker) Connected() (bool, error) {
    b.lock.Lock() // <== here
    defer b.lock.Unlock()
    return b.conn != nil, b.connErr
}
```

Code change:
- use `t.Fatal` instead of `t.Error` to stop the test right away