### PR TITLE
Sasl plain handshake

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -118,11 +118,6 @@ func (b *Broker) Open(conf *Config) error {
 		}
 
 		if conf.Net.SASL.Enable {
-			b.connErr = b.sendAndReceiveSASLPlainHandshake()
-			if b.connErr != nil {
-				Logger.Printf("Error while performing SASL handshake %s\n", b.addr)
-				return
-			}
 			b.connErr = b.sendAndReceiveSASLPlainAuth()
 			if b.connErr != nil {
 				err = b.conn.Close()
@@ -563,7 +558,6 @@ func (b *Broker) sendAndReceiveSASLPlainHandshake() error {
 	}
 	Logger.Print("Successful SASL handshake")
 	return nil
-
 }
 
 // Kafka 0.10.0 plans to support SASL Plain and Kerberos as per PR #812 (KIP-43)/(JIRA KAFKA-3149)
@@ -585,7 +579,6 @@ func (b *Broker) sendAndReceiveSASLPlainHandshake() error {
 // When credentials are invalid, Kafka closes the connection. This does not seem to be the ideal way
 // of responding to bad credentials but thats how its being done today.
 func (b *Broker) sendAndReceiveSASLPlainAuth() error {
-
 	handshakeErr := b.sendAndReceiveSASLPlainHandshake()
 	if handshakeErr != nil {
 		Logger.Printf("Error while performing SASL handshake %s\n", b.addr)

--- a/broker.go
+++ b/broker.go
@@ -118,6 +118,11 @@ func (b *Broker) Open(conf *Config) error {
 		}
 
 		if conf.Net.SASL.Enable {
+			b.connErr = b.sendAndReceiveSASLPlainHandshake()
+			if b.connErr != nil {
+				Logger.Printf("Error while performing SASL handshake %s\n", b.addr)
+				return
+			}
 			b.connErr = b.sendAndReceiveSASLPlainAuth()
 			if b.connErr != nil {
 				err = b.conn.Close()
@@ -514,6 +519,53 @@ func (b *Broker) responseReceiver() {
 	close(b.done)
 }
 
+func (b *Broker) sendAndReceiveSASLPlainHandshake() error {
+	rb := &SaslHandshakeRequest{"PLAIN"}
+	req := &request{correlationID: b.correlationID, clientID: b.conf.ClientID, body: rb}
+	buf, err := encode(req)
+	if err != nil {
+		return err
+	}
+
+	err = b.conn.SetWriteDeadline(time.Now().Add(b.conf.Net.WriteTimeout))
+	if err != nil {
+		return err
+	}
+
+	bytes, err := b.conn.Write(buf)
+	b.updateOutgoingCommunicationMetrics(bytes)
+	if err != nil {
+		Logger.Printf("Failed to send SASL handshake %s: %s\n", b.addr, err.Error())
+		return err
+	}
+	b.correlationID++
+	//wait for the response
+	header := make([]byte, 8) // response header
+	n, err := io.ReadFull(b.conn, header)
+	b.updateIncomingCommunicationMetrics(n)
+	length := binary.BigEndian.Uint32(header[:4])
+	payload := make([]byte, length-4)
+	n, err = io.ReadFull(b.conn, payload)
+	if err != nil {
+		Logger.Printf("Failed to read SASL handshake payload : %s\n", err.Error())
+		return err
+	}
+	b.updateIncomingCommunicationMetrics(n)
+	res := &SaslHandshakeResponse{}
+	err = versionedDecode(payload, res, 0)
+	if err != nil {
+		Logger.Printf("Failed to parse SASL handshake : %s\n", err.Error())
+		return err
+	}
+	if res.Err != ErrNoError {
+		Logger.Printf("Invalid SASL Mechanism : %s\n", err.Error())
+		return res.Err
+	}
+	Logger.Print("Successful SASL handshake")
+	return nil
+
+}
+
 // Kafka 0.10.0 plans to support SASL Plain and Kerberos as per PR #812 (KIP-43)/(JIRA KAFKA-3149)
 // Some hosted kafka services such as IBM Message Hub already offer SASL/PLAIN auth with Kafka 0.9
 //
@@ -533,6 +585,12 @@ func (b *Broker) responseReceiver() {
 // When credentials are invalid, Kafka closes the connection. This does not seem to be the ideal way
 // of responding to bad credentials but thats how its being done today.
 func (b *Broker) sendAndReceiveSASLPlainAuth() error {
+
+	handshakeErr := b.sendAndReceiveSASLPlainHandshake()
+	if handshakeErr != nil {
+		Logger.Printf("Error while performing SASL handshake %s\n", b.addr)
+		return handshakeErr
+	}
 	length := 1 + len(b.conf.Net.SASL.User) + 1 + len(b.conf.Net.SASL.Password)
 	authBytes := make([]byte, length+4) //4 byte length header + auth data
 	binary.BigEndian.PutUint32(authBytes, uint32(length))


### PR DESCRIPTION
This PR contains #748 + a bug fix.
#748 calls sendAndReceiveSASLPlainHandshake two times leading to a runtime error:

```
INFO[0008] client/metadata fetching metadata for all topics from broker ***:9093
INFO[0008] Successful SASL handshake
fatal error: runtime: out of memory
```

After removing the call in `Open`, everything works fine:
```
INFO[0002] client/metadata fetching metadata for all topics from broker ***:9093
INFO[0002] Successful SASL handshake
INFO[0002] SASL authentication successful with broker ***:9093:4 - [0 0 0 0]
INFO[0002] Connected to broker at ***:9093 (unregistered)
INFO[0002] client/brokers registered new broker #2 at ***:9093
INFO[0002] client/brokers registered new broker #5 at ***:9093
INFO[0002] client/brokers registered new broker #7 at ***:9093
INFO[0002] client/brokers registered new broker #1 at ***:9093
INFO[0002] client/brokers registered new broker #3 at ***:9093
INFO[0002] Successfully initialized new client
```