### PR TITLE
Add lz4 compression

### DIFF
--- a/config.go
+++ b/config.go
@@ -375,9 +375,7 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Producer.Retry.Backoff must be >= 0")
 	}
 
-	if c.Producer.Compression == CompressionLZ4 && (c.Version == V0_8_2_0 || c.Version == V0_8_2_1 ||
-		c.Version == V0_8_2_2 || c.Version == V0_9_0_0 ||
-		c.Version == V0_9_0_1) {
+	if c.Producer.Compression == CompressionLZ4 && !c.Version.IsAtLeast(V0_10_0_0) {
 		return ConfigurationError("lz4 compression requires Version >= V0_10_0_0")
 	}
 

--- a/config.go
+++ b/config.go
@@ -375,6 +375,12 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Producer.Retry.Backoff must be >= 0")
 	}
 
+	if c.Producer.Compression == CompressionLZ4 && (c.Version == V0_8_2_0 || c.Version == V0_8_2_1 ||
+		c.Version == V0_8_2_2 || c.Version == V0_9_0_0 ||
+		c.Version == V0_9_0_1) {
+		return ConfigurationError("lz4 compression requires Version >= V0_10_0_0")
+	}
+
 	// validate the Consumer values
 	switch {
 	case c.Consumer.Fetch.Min <= 0:

--- a/config_test.go
+++ b/config_test.go
@@ -33,6 +33,18 @@ func TestEmptyClientIDConfigValidates(t *testing.T) {
 	}
 }
 
+func TestLZ4ConfigValidation(t *testing.T) {
+	config := NewConfig()
+	config.Producer.Compression = CompressionLZ4
+	if err := config.Validate(); string(err.(ConfigurationError)) != "lz4 compression requires Version >= V0_10_0_0" {
+		t.Error("Expected invalid lz4/kakfa version error, got ", err)
+	}
+	config.Version = V0_10_0_0
+	if err := config.Validate(); err != nil {
+		t.Error("Expected lz4 to work, got ", err)
+	}
+}
+
 // This example shows how to integrate with an existing registry as well as publishing metrics
 // on the standard output
 func ExampleConfig_metrics() {

--- a/message.go
+++ b/message.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/eapache/go-xerial-snappy"
+	"github.com/pierrec/lz4"
 )
 
 // CompressionCodec represents the various compression codecs recognized by Kafka in messages.
@@ -20,6 +21,7 @@ const (
 	CompressionNone   CompressionCodec = 0
 	CompressionGZIP   CompressionCodec = 1
 	CompressionSnappy CompressionCodec = 2
+	CompressionLZ4    CompressionCodec = 3
 )
 
 type Message struct {
@@ -74,6 +76,18 @@ func (m *Message) encode(pe packetEncoder) error {
 			tmp := snappy.Encode(m.Value)
 			m.compressedCache = tmp
 			payload = m.compressedCache
+		case CompressionLZ4:
+			var buf bytes.Buffer
+			writer := lz4.NewWriter(&buf)
+			if _, err = writer.Write(m.Value); err != nil {
+				return err
+			}
+			if err = writer.Close(); err != nil {
+				return err
+			}
+			m.compressedCache = buf.Bytes()
+			payload = m.compressedCache
+
 		default:
 			return PacketEncodingError{fmt.Sprintf("unsupported compression codec (%d)", m.Codec)}
 		}
@@ -148,6 +162,18 @@ func (m *Message) decode(pd packetDecoder) (err error) {
 		if err := m.decodeSet(); err != nil {
 			return err
 		}
+	case CompressionLZ4:
+		if m.Value == nil {
+			break
+		}
+		reader := lz4.NewReader(bytes.NewReader(m.Value))
+		if m.Value, err = ioutil.ReadAll(reader); err != nil {
+			return err
+		}
+		if err := m.decodeSet(); err != nil {
+			return err
+		}
+
 	default:
 		return PacketDecodingError{fmt.Sprintf("invalid compression specified (%d)", m.Codec)}
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 var (
 	emptyMessage = []byte{
@@ -20,6 +23,19 @@ var (
 		0x1f, 0x8b,
 		0x08,
 		0, 0, 9, 110, 136, 0, 255, 1, 0, 0, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	emptyLZ4Message = []byte{
+		132, 219, 238, 101, // CRC
+		0x01,                          // version byte
+		0x03,                          // attribute flags: lz4
+		0, 0, 1, 88, 141, 205, 89, 56, // timestamp
+		0xFF, 0xFF, 0xFF, 0xFF, // key
+		0x00, 0x00, 0x00, 0x0f, // len
+		0x04, 0x22, 0x4D, 0x18, // LZ4 magic number
+		100,                  // LZ4 flags: version 01, block indepedant, content checksum
+		112, 185, 0, 0, 0, 0, // LZ4 data
+		5, 93, 204, 2, // LZ4 checksum
+	}
 
 	emptyBulkSnappyMessage = []byte{
 		180, 47, 53, 209, //CRC
@@ -64,6 +80,12 @@ func TestMessageEncoding(t *testing.T) {
 	message.Value = []byte{}
 	message.Codec = CompressionGZIP
 	testEncodable(t, "empty gzip", &message, emptyGzipMessage)
+
+	message.Value = []byte{}
+	message.Codec = CompressionLZ4
+	message.Timestamp = time.Unix(1479847795, 0)
+	message.Version = 1
+	testEncodable(t, "empty lz4", &message, emptyLZ4Message)
 }
 
 func TestMessageDecoding(t *testing.T) {


### PR DESCRIPTION
This patch may cause issues with kafka < 0.10.0 as it doesn't handle "broken" framing.
It should thus only be used with 0.10+.