### PR TITLE
Producer: block in `Close` without `Return.Errors`

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -210,6 +210,8 @@ func (p *asyncProducer) Close() error {
 		for event := range p.errors {
 			errors = append(errors, event)
 		}
+	} else {
+		<-p.errors
 	}
 
 	if len(errors) > 0 {


### PR DESCRIPTION
If neither `Return.Errors` nor `Return.Successes` was set then `Close` wouldn't
actually block at all. This is arguably correct given the send-it-into-the-void-
and-pray configuration but it was still surprising.

It turns out to be a very minimal change to block anyway (since the `Errors`
channel is still present and closed at the appropriate moment) so just do that.
Also add a test for this configuration, since it's not one I remember to think
about on the regular.

@hchargois after poking around the code a bit I decided it was simpler to just fix this the way you suggested. Let me know if this works for you.

Closes #784.