### PR TITLE
send errTimedOut to partition consumer

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -652,6 +652,7 @@ func (bc *brokerConsumer) handleResponses() {
 		case errTimedOut:
 			Logger.Printf("consumer/broker/%d abandoned subscription to %s/%d because consuming was taking too long\n",
 				bc.broker.ID(), child.topic, child.partition)
+			child.sendError(errTimedOut)
 			delete(bc.subscriptions, child)
 		case ErrOffsetOutOfRange:
 			// there's no point in retrying this it will just fail the same way again


### PR DESCRIPTION
At the moment , when errTimeout happens, usually that means the client take too long to respond message , the behavior is silently stop consuming messages , which in my case it might happen , and that's not a good behavior,  instead of doing that, it will be better to dispatch the error message to the correct partition consumer, so it can take some appropriate actions.  

just one line changes, so it is quite straightforward. 