### PR TITLE
Fix segmentation fault on SASL failed

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -566,7 +566,7 @@ func (b *Broker) sendAndReceiveSASLPlainHandshake() error {
 		return err
 	}
 	if res.Err != ErrNoError {
-		Logger.Printf("Invalid SASL Mechanism : %s\n", err.Error())
+		Logger.Printf("Invalid SASL Mechanism : %s\n", res.Err.Error())
 		return res.Err
 	}
 	Logger.Print("Successful SASL handshake")


### PR DESCRIPTION
A segmentation violation occurs when initializing producer using SASL fails.