### PR TITLE
Go back to hash/crc32

### DIFF
--- a/crc32_field.go
+++ b/crc32_field.go
@@ -2,8 +2,7 @@ package sarama
 
 import (
 	"encoding/binary"
-
-	"github.com/klauspost/crc32"
+	"hash/crc32"
 )
 
 // crc32Field implements the pushEncoder and pushDecoder interfaces for calculating CRC32s.


### PR DESCRIPTION
As of Go 1.7, hash/crc32 has all the same optimizations. This means anyone on
an older Go version will see a performance hit, but anyone who cares about
performance should really be updating to Go 1.7 anyway.