### PR TITLE
Correcting two funcs comments

### DIFF
--- a/mocks/async_producer.go
+++ b/mocks/async_producer.go
@@ -147,7 +147,7 @@ func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndSucceed(cf ValueChecke
 	mp.expectations = append(mp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
 }
 
-// ExpectInputWithCheckerFunctionAndSucceed sets an expectation on the mock producer that a message
+// ExpectInputWithCheckerFunctionAndFail sets an expectation on the mock producer that a message
 // will be provided on the input channel. The mock producer will first call the given function to
 // check the message value. If an error is returned it will be made available on the Errors channel
 // otherwise the mock will handle the message as if it failed to produce successfully. This means

--- a/mocks/sync_producer.go
+++ b/mocks/sync_producer.go
@@ -123,7 +123,7 @@ func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndSucceed(cf ValueC
 	sp.expectations = append(sp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
 }
 
-// ExpectSendMessageAndFail sets an expectation on the mock producer that SendMessage will be
+// ExpectSendMessageWithCheckerFunctionAndFail sets an expectation on the mock producer that SendMessage will be
 // called. The mock producer will first call the given function to check the message value.
 // It will cascade the error of the function, if any, or handle the message as if it failed
 // to produce successfully, i.e. by returning the provided error.


### PR DESCRIPTION
This two funcs were with wrong names in their comments, just corrected this.