### PR TITLE
Removing unnecessary attribution

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -30,9 +30,9 @@ type ErrorReporter interface {
 type ValueChecker func(val []byte) error
 
 var (
-	errProduceSuccess              error = nil
-	errOutOfExpectations                 = errors.New("No more expectations set on mock")
-	errPartitionConsumerNotStarted       = errors.New("The partition consumer was never started")
+	errProduceSuccess              error
+	errOutOfExpectations           = errors.New("No more expectations set on mock")
+	errPartitionConsumerNotStarted = errors.New("The partition consumer was never started")
 )
 
 const AnyOffset int64 = -1000


### PR DESCRIPTION
Nil is already the default value for error vars, so removing it