### PR TITLE
Tweak documentation of Close/AsyncClose methods

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -17,17 +17,16 @@ import (
 // scope.
 type AsyncProducer interface {
 
-	// AsyncClose triggers a shutdown of the producer, flushing any messages it may
-	// have buffered. The shutdown has completed when both the Errors and Successes
-	// channels have been closed. When calling AsyncClose, you *must* continue to
-	// read from those channels in order to drain the results of any messages in
-	// flight.
+	// AsyncClose triggers a shutdown of the producer. The shutdown has completed
+	// when both the Errors and Successes channels have been closed. When calling
+	// AsyncClose, you *must* continue to read from those channels in order to
+	// drain the results of any messages in flight.
 	AsyncClose()
 
-	// Close shuts down the producer and flushes any messages it may have buffered.
-	// You must call this function before a producer object passes out of scope, as
-	// it may otherwise leak memory. You must call this before calling Close on the
-	// underlying client.
+	// Close shuts down the producer and waits for any buffered messages to be
+	// flushed. You must call this function before a producer object passes out of
+	// scope, as it may otherwise leak memory. You must call this before calling
+	// Close on the underlying client.
 	Close() error
 
 	// Input is the input channel for the user to write messages to that they

--- a/sync_producer.go
+++ b/sync_producer.go
@@ -25,10 +25,10 @@ type SyncProducer interface {
 	// SendMessages will return an error.
 	SendMessages(msgs []*ProducerMessage) error
 
-	// Close shuts down the producer and flushes any messages it may have buffered.
-	// You must call this function before a producer object passes out of scope, as
-	// it may otherwise leak memory. You must call this before calling Close on the
-	// underlying client.
+	// Close shuts down the producer and waits for any buffered messages to be
+	// flushed. You must call this function before a producer object passes out of
+	// scope, as it may otherwise leak memory. You must call this before calling
+	// Close on the underlying client.
 	Close() error
 }
 


### PR DESCRIPTION
AsyncClose has nothing to do with flushes at all.

Close *waits* for messages to be flushed, but does not *trigger* a flush
itself.

Clarifications as suggested in #834.

@agis- @wvanbergen 