### PR TITLE
Fix CustomHasher

### DIFF
--- a/partitioner.go
+++ b/partitioner.go
@@ -82,16 +82,15 @@ func (p *roundRobinPartitioner) RequiresConsistency() bool {
 	return false
 }
 
-type hasherFunc func() hash.Hash32
-
 type hashPartitioner struct {
 	random Partitioner
 	hasher hash.Hash32
 }
 
-// NewCustomHashPartitioner is a wrapper around NewHashPartitioner,
-// allowing the use of custom hasher
-func NewCustomHashPartitioner(hasher hasherFunc) PartitionerConstructor {
+// NewCustomHashPartitioner is a wrapper around NewHashPartitioner, allowing the use of custom hasher.
+// The argument is a function providing the instance, implementing the hash.Hash32 interface. This is to ensure that
+// each partition dispatcher gets its own hasher, to avoid concurrency issues by sharing an instance.
+func NewCustomHashPartitioner(hasher func() hash.Hash32) PartitionerConstructor {
 	return func(topic string) Partitioner {
 		p := new(hashPartitioner)
 		p.random = NewRandomPartitioner(topic)

--- a/partitioner_test.go
+++ b/partitioner_test.go
@@ -73,7 +73,7 @@ func TestRoundRobinPartitioner(t *testing.T) {
 
 func TestNewHashPartitionerWithHasher(t *testing.T) {
 	// use the current default hasher fnv.New32a()
-	partitioner := NewCustomHashPartitioner(fnv.New32a())("mytopic")
+	partitioner := NewCustomHashPartitioner(fnv.New32a)("mytopic")
 
 	choice, err := partitioner.Partition(&ProducerMessage{}, 1)
 	if err != nil {
@@ -104,7 +104,7 @@ func TestNewHashPartitionerWithHasher(t *testing.T) {
 
 func TestHashPartitionerWithHasherMinInt32(t *testing.T) {
 	// use the current default hasher fnv.New32a()
-	partitioner := NewCustomHashPartitioner(fnv.New32a())("mytopic")
+	partitioner := NewCustomHashPartitioner(fnv.New32a)("mytopic")
 
 	msg := ProducerMessage{}
 	// "1468509572224" generates 2147483648 (uint32) result from Sum32 function


### PR DESCRIPTION
I had to realise that even though now the same hashing algorithm was used across services to determine the partition, the problem that messages published under the same key on log compact topics still ended up on different partitions. Unfortunately I found out that I made a huge mistake by passing an already instantiated hasher. Thus the proposed fix: pass a callback so the hasher is instantiated just before needed (thanks to the [wiki page](https://github.com/Shopify/sarama/wiki/Producer-implementation#message-flow) for helping my understanding of the publisher's flow).