### PR TITLE
Permit protocol ordering in JoinGroup requests

### DIFF
--- a/join_group_request_test.go
+++ b/join_group_request_test.go
@@ -23,19 +23,35 @@ var (
 )
 
 func TestJoinGroupRequest(t *testing.T) {
-	var request *JoinGroupRequest
-
-	request = new(JoinGroupRequest)
+	request := new(JoinGroupRequest)
 	request.GroupId = "TestGroup"
 	request.SessionTimeout = 100
 	request.ProtocolType = "consumer"
 	testRequest(t, "no protocols", request, joinGroupRequestNoProtocols)
+}
 
-	request = new(JoinGroupRequest)
+func TestJoinGroupRequestOneProtocol(t *testing.T) {
+	request := new(JoinGroupRequest)
 	request.GroupId = "TestGroup"
 	request.SessionTimeout = 100
 	request.MemberId = "OneProtocol"
 	request.ProtocolType = "consumer"
 	request.AddGroupProtocol("one", []byte{0x01, 0x02, 0x03})
-	testRequest(t, "one protocol", request, joinGroupRequestOneProtocol)
+	packet := testRequestEncode(t, "one protocol", request, joinGroupRequestOneProtocol)
+	request.GroupProtocols = make(map[string][]byte)
+	request.GroupProtocols["one"] = []byte{0x01, 0x02, 0x03}
+	testRequestDecode(t, "one protocol", request, packet)
+}
+
+func TestJoinGroupRequestDeprecatedEncode(t *testing.T) {
+	request := new(JoinGroupRequest)
+	request.GroupId = "TestGroup"
+	request.SessionTimeout = 100
+	request.MemberId = "OneProtocol"
+	request.ProtocolType = "consumer"
+	request.GroupProtocols = make(map[string][]byte)
+	request.GroupProtocols["one"] = []byte{0x01, 0x02, 0x03}
+	packet := testRequestEncode(t, "one protocol", request, joinGroupRequestOneProtocol)
+	request.AddGroupProtocol("one", []byte{0x01, 0x02, 0x03})
+	testRequestDecode(t, "one protocol", request, packet)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -50,7 +50,11 @@ func testVersionDecodable(t *testing.T, name string, out versionedDecoder, in []
 }
 
 func testRequest(t *testing.T, name string, rb protocolBody, expected []byte) {
-	// Encoder request
+	packet := testRequestEncode(t, name, rb, expected)
+	testRequestDecode(t, name, rb, packet)
+}
+
+func testRequestEncode(t *testing.T, name string, rb protocolBody, expected []byte) []byte {
 	req := &request{correlationID: 123, clientID: "foo", body: rb}
 	packet, err := encode(req, nil)
 	headerSize := 14 + len("foo")
@@ -59,7 +63,10 @@ func testRequest(t *testing.T, name string, rb protocolBody, expected []byte) {
 	} else if !bytes.Equal(packet[headerSize:], expected) {
 		t.Error("Encoding", name, "failed\ngot ", packet[headerSize:], "\nwant", expected)
 	}
-	// Decoder request
+	return packet
+}
+
+func testRequestDecode(t *testing.T, name string, rb protocolBody, packet []byte) {
 	decoded, n, err := decodeRequest(bytes.NewReader(packet))
 	if err != nil {
 		t.Error("Failed to decode request", err)


### PR DESCRIPTION
The kafka protocol for JoinGroupRequest allows you to specify priority
on group protocols for seamless rollout of new protocols while a
consumer group is running. The old map was not supporting that use case.

Add an array field (OrderedGroupProtocols) and deprecate the map.

Fixes #812.

@DanielMorsing @wvanbergen