### PR TITLE
Add client.Isr to determine in-sync replicas

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,8 +38,10 @@ type Client interface {
 	// Replicas returns the set of all replica IDs for the given partition.
 	Replicas(topic string, partitionID int32) ([]int32, error)
 
-	// Isr returns the set of in-sync replica IDs for the given partition.
-	Isr(topic string, partitionID int32) ([]int32, error)
+	// InSyncReplicas returns the set of all in-sync replica IDs for the given
+	// partition. In-sync replicas are replicas which are fully caught up with
+	// the partition leader.
+	InSyncReplicas(topic string, partitionID int32) ([]int32, error)
 
 	// RefreshMetadata takes a list of topics and queries the cluster to refresh the
 	// available metadata for those topics. If no topics are provided, it will refresh
@@ -298,7 +300,7 @@ func (client *client) Replicas(topic string, partitionID int32) ([]int32, error)
 	return dupeAndSort(metadata.Replicas), nil
 }
 
-func (client *client) Isr(topic string, partitionID int32) ([]int32, error) {
+func (client *client) InSyncReplicas(topic string, partitionID int32) ([]int32, error) {
 	if client.Closed() {
 		return nil, ErrClosedClient
 	}

--- a/client.go
+++ b/client.go
@@ -38,6 +38,9 @@ type Client interface {
 	// Replicas returns the set of all replica IDs for the given partition.
 	Replicas(topic string, partitionID int32) ([]int32, error)
 
+	// Isr returns the set of in-sync replica IDs for the given partition.
+	Isr(topic string, partitionID int32) ([]int32, error)
+
 	// RefreshMetadata takes a list of topics and queries the cluster to refresh the
 	// available metadata for those topics. If no topics are provided, it will refresh
 	// metadata for all topics.

--- a/client.go
+++ b/client.go
@@ -295,6 +295,31 @@ func (client *client) Replicas(topic string, partitionID int32) ([]int32, error)
 	return dupeAndSort(metadata.Replicas), nil
 }
 
+func (client *client) Isr(topic string, partitionID int32) ([]int32, error) {
+	if client.Closed() {
+		return nil, ErrClosedClient
+	}
+
+	metadata := client.cachedMetadata(topic, partitionID)
+
+	if metadata == nil {
+		err := client.RefreshMetadata(topic)
+		if err != nil {
+			return nil, err
+		}
+		metadata = client.cachedMetadata(topic, partitionID)
+	}
+
+	if metadata == nil {
+		return nil, ErrUnknownTopicOrPartition
+	}
+
+	if metadata.Err == ErrReplicaNotAvailable {
+		return nil, metadata.Err
+	}
+	return dupeAndSort(metadata.Isr), nil
+}
+
 func (client *client) Leader(topic string, partitionID int32) (*Broker, error) {
 	if client.Closed() {
 		return nil, ErrClosedClient

--- a/client_test.go
+++ b/client_test.go
@@ -196,7 +196,7 @@ func TestClientMetadata(t *testing.T) {
 		t.Error("Incorrect (or unsorted) replica")
 	}
 
-	isr, err = client.Isr("my_topic", 0)
+	isr, err = client.InSyncReplicas("my_topic", 0)
 	if err != nil {
 		t.Error(err)
 	} else if len(isr) != 2 {

--- a/client_test.go
+++ b/client_test.go
@@ -196,6 +196,17 @@ func TestClientMetadata(t *testing.T) {
 		t.Error("Incorrect (or unsorted) replica")
 	}
 
+	isr, err = client.Isr("my_topic", 0)
+	if err != nil {
+		t.Error(err)
+	} else if len(isr) != 2 {
+		t.Error("Client returned incorrect ISRs for partition:", isr)
+	} else if isr[0] != 1 {
+		t.Error("Incorrect (or unsorted) ISR:", isr)
+	} else if isr[1] != 5 {
+		t.Error("Incorrect (or unsorted) ISR:", isr)
+	}
+
 	leader.Close()
 	seedBroker.Close()
 	safeClose(t, client)


### PR DESCRIPTION
This restores the commit from @funkygao in PR #566, with an additional commit to expose the function on the `Client` interface and add some basic tests around its functionality.

The PR was previously closed with the suggestion that Zookeeper should be used directly, because, at the time, it was possible to receive stale information from Kafka. If I'm reading the [linked issue](https://issues.apache.org/jira/browse/KAFKA-1367?jql=text%20~%20%22ISR%20out%20of%20sync%22) correctly, that issue has been resolved since Kafka 0.9, so I'd like this patch to be reconsidered now.

I personally want this so that I can then add ISR support to the excellent [kt](https://github.com/fgeller/kt), which is the workhorse of a fair amount of the Kafka automation tooling I use.