### PR TITLE
Fix comment for mocks.NewConsumer

### DIFF
--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -20,7 +20,7 @@ type Consumer struct {
 
 // NewConsumer returns a new mock Consumer instance. The t argument should
 // be the *testing.T instance of your test method. An error will be written to it if
-// an expectation is violated. The config argument is currently unused and can be set to nil.
+// an expectation is violated. The config argument can be set to nil.
 func NewConsumer(t ErrorReporter, config *sarama.Config) *Consumer {
 	if config == nil {
 		config = sarama.NewConfig()


### PR DESCRIPTION
The config object is not unused and can in fact be set when calling the NewConsumer constructor.

This commit updates the function's description to reflect that.