### PR TITLE
FIX: Remove dupeAndSort in Replicas and InSyncReplicas 

### DIFF
--- a/client.go
+++ b/client.go
@@ -297,7 +297,7 @@ func (client *client) Replicas(topic string, partitionID int32) ([]int32, error)
 	if metadata.Err == ErrReplicaNotAvailable {
 		return nil, metadata.Err
 	}
-	return dupeAndSort(metadata.Replicas), nil
+	return metadata.Replicas, nil
 }
 
 func (client *client) InSyncReplicas(topic string, partitionID int32) ([]int32, error) {
@@ -322,7 +322,7 @@ func (client *client) InSyncReplicas(topic string, partitionID int32) ([]int32, 
 	if metadata.Err == ErrReplicaNotAvailable {
 		return nil, metadata.Err
 	}
-	return dupeAndSort(metadata.Isr), nil
+	return metadata.Isr, nil
 }
 
 func (client *client) Leader(topic string, partitionID int32) (*Broker, error) {

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@ package sarama
 import (
 	"bufio"
 	"net"
-	"sort"
 )
 
 type none struct{}
@@ -21,16 +20,6 @@ func (slice int32Slice) Less(i, j int) bool {
 
 func (slice int32Slice) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
-}
-
-func dupeAndSort(input []int32) []int32 {
-	ret := make([]int32, 0, len(input))
-	for _, val := range input {
-		ret = append(ret, val)
-	}
-
-	sort.Sort(int32Slice(ret))
-	return ret
 }
 
 func withRecover(fn func()) {


### PR DESCRIPTION
It shouldn't sort the replicas and isr while the order is meaningful to Kafka(preferred leader)