### PR TITLE
FIX: Remove dupeAndSort in Replicas and InSyncReplicas

### DIFF
--- a/client.go
+++ b/client.go
@@ -297,7 +297,7 @@ func (client *client) Replicas(topic string, partitionID int32) ([]int32, error)
 	if metadata.Err == ErrReplicaNotAvailable {
 		return nil, metadata.Err
 	}
-	return dupeAndSort(metadata.Replicas), nil
+	return dupInt32Slice(metadata.Replicas), nil
 }
 
 func (client *client) InSyncReplicas(topic string, partitionID int32) ([]int32, error) {
@@ -322,7 +322,7 @@ func (client *client) InSyncReplicas(topic string, partitionID int32) ([]int32, 
 	if metadata.Err == ErrReplicaNotAvailable {
 		return nil, metadata.Err
 	}
-	return dupeAndSort(metadata.Isr), nil
+	return dupInt32Slice(metadata.Isr), nil
 }
 
 func (client *client) Leader(topic string, partitionID int32) (*Broker, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -188,12 +188,12 @@ func TestClientMetadata(t *testing.T) {
 	replicas, err = client.Replicas("my_topic", 0)
 	if err != nil {
 		t.Error(err)
-	} else if replicas[0] != 1 {
-		t.Error("Incorrect (or unsorted) replica")
-	} else if replicas[1] != 3 {
-		t.Error("Incorrect (or unsorted) replica")
+	} else if replicas[0] != 3 {
+		t.Error("Incorrect (or sorted) replica")
+	} else if replicas[1] != 1 {
+		t.Error("Incorrect (or sorted) replica")
 	} else if replicas[2] != 5 {
-		t.Error("Incorrect (or unsorted) replica")
+		t.Error("Incorrect (or sorted) replica")
 	}
 
 	isr, err = client.InSyncReplicas("my_topic", 0)
@@ -201,10 +201,10 @@ func TestClientMetadata(t *testing.T) {
 		t.Error(err)
 	} else if len(isr) != 2 {
 		t.Error("Client returned incorrect ISRs for partition:", isr)
-	} else if isr[0] != 1 {
-		t.Error("Incorrect (or unsorted) ISR:", isr)
-	} else if isr[1] != 5 {
-		t.Error("Incorrect (or unsorted) ISR:", isr)
+	} else if isr[0] != 5 {
+		t.Error("Incorrect (or sorted) ISR:", isr)
+	} else if isr[1] != 1 {
+		t.Error("Incorrect (or sorted) ISR:", isr)
 	}
 
 	leader.Close()

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@ package sarama
 import (
 	"bufio"
 	"net"
-	"sort"
 )
 
 type none struct{}
@@ -23,13 +22,11 @@ func (slice int32Slice) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func dupeAndSort(input []int32) []int32 {
+func dupInt32Slice(input []int32) []int32 {
 	ret := make([]int32, 0, len(input))
 	for _, val := range input {
 		ret = append(ret, val)
 	}
-
-	sort.Sort(int32Slice(ret))
 	return ret
 }
 


### PR DESCRIPTION
It shouldn't sort the replicas and isr while the order is meaningful to Kafka(preferred leader)