### PR TITLE
Add a config option to store only minimal metadata

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,6 +72,12 @@ type Config struct {
 		// Defaults to 10 minutes. Set to 0 to disable. Similar to
 		// `topic.metadata.refresh.interval.ms` in the JVM version.
 		RefreshFrequency time.Duration
+
+		// Whether to maintain a full set of metadata for all topics, or just
+		// the minimal set that has been necessary so far. The full set is simpler
+		// and usually more convenient, but can take up a substantial amount of
+		// memory if you have many topics and partitions. Defaults to true.
+		Full bool
 	}
 
 	// Producer is the namespace for configuration related to producing messages,
@@ -263,6 +269,7 @@ func NewConfig() *Config {
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond
 	c.Metadata.RefreshFrequency = 10 * time.Minute
+	c.Metadata.Full = true
 
 	c.Producer.MaxMessageBytes = 1000000
 	c.Producer.RequiredAcks = WaitForLocal


### PR DESCRIPTION
Typically the default is just to fetch and store all topics, as it is
simpler and more convenient not to have to go to the network for every
new topic that is needed. However this can use a lot of memory for
clusters with many topics and partitions, so add a flag which can be
unset in order to just store the minimal topic information needed so
far.

As suggested in #931.

@chandradeepak does this solve your problem?