### PR TITLE
Restrict client metadata update more

### DIFF
--- a/client.go
+++ b/client.go
@@ -612,6 +612,9 @@ func (client *client) backgroundMetadataUpdater() {
 				if specificTopics, err := client.Topics(); err != nil {
 					Logger.Println("Client background metadata topic load:", err)
 					break
+				} else if len(specificTopics) == 0 {
+					Logger.Println("Client background metadata update: no specific topics to update")
+					break
 				} else {
 					topics = specificTopics
 				}


### PR DESCRIPTION
If Metadata.Full is set to false, and no topics have ever been
requested, the first background refresh would load them all because go's
varags don't distinguish between nothing and an explicitly splatted
empty array.

Just break instead.

@chandradeepak this *might* fix https://github.com/Shopify/sarama/issues/931#issuecomment-325829238? I'm just guessing.