### PR TITLE
Support ProduceResponse v1 and v2 encoding

### DIFF
--- a/produce_response.go
+++ b/produce_response.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type ProduceResponseBlock struct {
 	Err    KError
@@ -27,6 +30,23 @@ func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err erro
 		} else if millis != -1 {
 			b.Timestamp = time.Unix(millis/1000, (millis%1000)*int64(time.Millisecond))
 		}
+	}
+
+	return nil
+}
+
+func (b *ProduceResponseBlock) encode(pe packetEncoder, version int16) (err error) {
+	pe.putInt16(int16(b.Err))
+	pe.putInt64(b.Offset)
+
+	if version >= 2 {
+		timestamp := int64(-1)
+		if !b.Timestamp.Before(time.Unix(0, 0)) {
+			timestamp = b.Timestamp.UnixNano() / int64(time.Millisecond)
+		} else if !b.Timestamp.IsZero() {
+			return PacketEncodingError{fmt.Sprintf("invalid timestamp (%v)", b.Timestamp)}
+		}
+		pe.putInt64(timestamp)
 	}
 
 	return nil
@@ -103,8 +123,10 @@ func (r *ProduceResponse) encode(pe packetEncoder) error {
 		}
 		for id, prb := range partitions {
 			pe.putInt32(id)
-			pe.putInt16(int16(prb.Err))
-			pe.putInt64(prb.Offset)
+			err = prb.encode(pe, r.Version)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if r.Version >= 1 {

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -1,67 +1,128 @@
 package sarama
 
-import "testing"
-
-var (
-	produceResponseNoBlocks = []byte{
-		0x00, 0x00, 0x00, 0x00}
-
-	produceResponseManyBlocks = []byte{
-		0x00, 0x00, 0x00, 0x02,
-
-		0x00, 0x03, 'f', 'o', 'o',
-		0x00, 0x00, 0x00, 0x00,
-
-		0x00, 0x03, 'b', 'a', 'r',
-		0x00, 0x00, 0x00, 0x02,
-
-		0x00, 0x00, 0x00, 0x01,
-		0x00, 0x00,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF,
-
-		0x00, 0x00, 0x00, 0x02,
-		0x00, 0x02,
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+import (
+	"fmt"
+	"testing"
+	"time"
 )
 
-func TestProduceResponse(t *testing.T) {
+var (
+	produceResponseNoBlocksV0 = []byte{
+		0x00, 0x00, 0x00, 0x00}
+
+	produceResponseManyBlocksVersions = [][]byte{
+		{
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x03, 'f', 'o', 'o',
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x00, 0x00, 0x01, // Partition 1
+			0x00, 0x02, // ErrInvalidMessage
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, // Offset 255
+		}, {
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x03, 'f', 'o', 'o',
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x00, 0x00, 0x01, // Partition 1
+			0x00, 0x02, // ErrInvalidMessage
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, // Offset 255
+
+			0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
+		}, {
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x03, 'f', 'o', 'o',
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x00, 0x00, 0x01, // Partition 1
+			0x00, 0x02, // ErrInvalidMessage
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, // Offset 255
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8, // Timestamp January 1st 0001 at 00:00:01,000 UTC (LogAppendTime was used)
+
+			0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
+		},
+	}
+)
+
+func TestProduceResponseDecode(t *testing.T) {
 	response := ProduceResponse{}
 
-	testVersionDecodable(t, "no blocks", &response, produceResponseNoBlocks, 0)
+	testVersionDecodable(t, "no blocks", &response, produceResponseNoBlocksV0, 0)
 	if len(response.Blocks) != 0 {
 		t.Error("Decoding produced", len(response.Blocks), "topics where there were none")
 	}
 
-	testVersionDecodable(t, "many blocks", &response, produceResponseManyBlocks, 0)
-	if len(response.Blocks) != 2 {
-		t.Error("Decoding produced", len(response.Blocks), "topics where there were 2")
-	}
-	if len(response.Blocks["foo"]) != 0 {
-		t.Error("Decoding produced", len(response.Blocks["foo"]), "partitions for 'foo' where there were none")
-	}
-	if len(response.Blocks["bar"]) != 2 {
-		t.Error("Decoding produced", len(response.Blocks["bar"]), "partitions for 'bar' where there were two")
-	}
-	block := response.GetBlock("bar", 1)
-	if block == nil {
-		t.Error("Decoding did not produce a block for bar/1")
-	} else {
-		if block.Err != ErrNoError {
-			t.Error("Decoding failed for bar/1/Err, got:", int16(block.Err))
+	for v, produceResponseManyBlocks := range produceResponseManyBlocksVersions {
+		t.Logf("Decoding produceResponseManyBlocks version %d", v)
+		testVersionDecodable(t, "many blocks", &response, produceResponseManyBlocks, int16(v))
+		if len(response.Blocks) != 1 {
+			t.Error("Decoding produced", len(response.Blocks), "topics where there was 1")
 		}
-		if block.Offset != 0xFF {
-			t.Error("Decoding failed for bar/1/Offset, got:", block.Offset)
+		if len(response.Blocks["foo"]) != 1 {
+			t.Error("Decoding produced", len(response.Blocks["foo"]), "partitions for 'foo' where there was one")
+		}
+		block := response.GetBlock("foo", 1)
+		if block == nil {
+			t.Error("Decoding did not produce a block for foo/1")
+		} else {
+			if block.Err != ErrInvalidMessage {
+				t.Error("Decoding failed for foo/2/Err, got:", int16(block.Err))
+			}
+			if block.Offset != 255 {
+				t.Error("Decoding failed for foo/1/Offset, got:", block.Offset)
+			}
+			if v >= 2 {
+				if block.Timestamp != time.Unix(1, 0) {
+					t.Error("Decoding failed for foo/2/Timestamp, got:", block.Timestamp)
+				}
+			}
+		}
+		if v >= 1 {
+			if expected := 100 * time.Millisecond; response.ThrottleTime != expected {
+				t.Error("Failed decoding produced throttle time, expected:", expected, ", got:", response.ThrottleTime)
+			}
 		}
 	}
-	block = response.GetBlock("bar", 2)
-	if block == nil {
-		t.Error("Decoding did not produce a block for bar/2")
-	} else {
-		if block.Err != ErrInvalidMessage {
-			t.Error("Decoding failed for bar/2/Err, got:", int16(block.Err))
-		}
-		if block.Offset != 0 {
-			t.Error("Decoding failed for bar/2/Offset, got:", block.Offset)
-		}
+}
+
+func TestProduceResponseEncode(t *testing.T) {
+	response := ProduceResponse{}
+	response.Blocks = make(map[string]map[int32]*ProduceResponseBlock)
+	testEncodable(t, "empty", &response, produceResponseNoBlocksV0)
+
+	response.Blocks["foo"] = make(map[int32]*ProduceResponseBlock)
+	response.Blocks["foo"][1] = &ProduceResponseBlock{
+		Err:       ErrInvalidMessage,
+		Offset:    255,
+		Timestamp: time.Unix(1, 0),
+	}
+	response.ThrottleTime = 100 * time.Millisecond
+	for v, produceResponseManyBlocks := range produceResponseManyBlocksVersions {
+		response.Version = int16(v)
+		testEncodable(t, fmt.Sprintf("many blocks version %d", v), &response, produceResponseManyBlocks)
+	}
+}
+
+func TestProduceResponseEncodeInvalidTimestamp(t *testing.T) {
+	response := ProduceResponse{}
+	response.Version = 2
+	response.Blocks = make(map[string]map[int32]*ProduceResponseBlock)
+	response.Blocks["t"] = make(map[int32]*ProduceResponseBlock)
+	response.Blocks["t"][0] = &ProduceResponseBlock{
+		Err:    ErrNoError,
+		Offset: 0,
+		// Use a timestamp before Unix time
+		Timestamp: time.Unix(0, 0).Add(-1 * time.Millisecond),
+	}
+	response.ThrottleTime = 100 * time.Millisecond
+	_, err := encode(&response, nil)
+	if err == nil {
+		t.Error("Expecting error, got nil")
+	}
+	if _, ok := err.(PacketEncodingError); !ok {
+		t.Error("Expecting PacketEncodingError, got:", err)
 	}
 }


### PR DESCRIPTION
I have been running into an issue when using v1.13.0 of Sarama for unit testing a producer with the `MockBroker` abstraction.

When using an `AsyncProducer` with `config.version` >= `V0_9_0_0` decoding produce responses from a `MockBroker` fails with: `insufficient data to decode packet, more bytes expected`.

### Example to reproduce error

Example of application that fails when sending a `V0_10_0_0` `ProduceRequest` as it expects the same version in the `ProduceResponse`:
```go
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/Shopify/sarama"
)

func main() {
	sarama.Logger = log.New(os.Stdout, "[SARAMA]", log.LstdFlags|log.Lmicroseconds)
	reporter := reporter{}
	seedBroker := sarama.NewMockBroker(reporter, 1)
	leader := sarama.NewMockBroker(reporter, 2)

	metadataResponse := new(sarama.MetadataResponse)
	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
	metadataResponse.AddTopicPartition("topic", 0, leader.BrokerID(), nil, nil, sarama.ErrNoError)
	seedBroker.Returns(metadataResponse)

	prodSuccess := new(sarama.ProduceResponse)
	// We are using V0_10_0_0 so the response version should match the request version
	prodSuccess.Version = 2
	prodSuccess.AddTopicPartition("topic", 0, sarama.ErrNoError)
	leader.Returns(prodSuccess)

	config := sarama.NewConfig()
	config.Metadata.Retry.Max = 0
	config.Producer.Retry.Max = 0
	config.Producer.Return.Successes = true
	config.Version = sarama.V0_10_0_0

	producer, err := sarama.NewAsyncProducer([]string{seedBroker.Addr()}, config)
	if err != nil {
		log.Fatal(err)
	}

	producer.Input() <- &sarama.ProducerMessage{
		Topic: "topic",
		Value: sarama.StringEncoder("value"),
	}

	select {
	case <-producer.Successes():
		log.Println("Success")
	case err := <-producer.Errors():
		log.Println("Error", err)
	}

	producer.Close()
	leader.Close()
	seedBroker.Close()
}

type reporter struct{}

func (r reporter) Error(args ...interface{}) {
	log.Print(args...)
}
func (r reporter) Errorf(format string, args ...interface{}) {
	log.Printf(format, args...)
}
func (r reporter) Fatal(args ...interface{}) {
	log.Fatal(args...)
}
func (r reporter) Fatalf(format string, args ...interface{}) {
	log.Fatalf(format, args...)
}
```

### Logs

The application fails with:
```
[SARAMA]2017/10/18 15:57:30.136867 *** mockbroker/1 listening on 127.0.0.1:55595
[SARAMA]2017/10/18 15:57:30.137777 *** mockbroker/2 listening on 127.0.0.1:55596
[SARAMA]2017/10/18 15:57:30.137819 Initializing new client
[SARAMA]2017/10/18 15:57:30.137826 ClientID is the default of 'sarama', you should consider setting it to something application-specific.
[SARAMA]2017/10/18 15:57:30.137866 ClientID is the default of 'sarama', you should consider setting it to something application-specific.
[SARAMA]2017/10/18 15:57:30.137874 client/metadata fetching metadata for all topics from broker 127.0.0.1:55595
[SARAMA]2017/10/18 15:57:30.138172 Connected to broker at 127.0.0.1:55595 (unregistered)
[SARAMA]2017/10/18 15:57:30.138253 *** mockbroker/1/0: connection opened
[SARAMA]2017/10/18 15:57:30.138375 *** mockbroker/1/0: served &{0 sarama 0xc420110020} -> &{[0xc4200d6000] [0xc42007cc30]}
[SARAMA]2017/10/18 15:57:30.138493 client/brokers registered new broker #2 at 127.0.0.1:55596
[SARAMA]2017/10/18 15:57:30.138535 Successfully initialized new client
[SARAMA]2017/10/18 15:57:30.138645 ClientID is the default of 'sarama', you should consider setting it to something application-specific.
[SARAMA]2017/10/18 15:57:30.138739 producer/broker/2 starting up
[SARAMA]2017/10/18 15:57:30.138760 producer/broker/2 state change to [open] on topic/0
[SARAMA]2017/10/18 15:57:30.138925 Connected to broker at 127.0.0.1:55596 (registered as #2)
[SARAMA]2017/10/18 15:57:30.138986 *** mockbroker/2/0: connection opened
[SARAMA]2017/10/18 15:57:30.139205 *** mockbroker/2/0: served &{0 sarama 0xc420140400} -> &{map[topic:map[0:0xc42007ccc0]] 2 0s}
[SARAMA]2017/10/18 15:57:30.139299 producer/broker/2 state change to [closing] because kafka: insufficient data to decode packet, more bytes expected
[SARAMA]2017/10/18 15:57:30.139331 Closed connection to broker 127.0.0.1:55596
2017/10/18 15:57:30 Error kafka: Failed to produce message to topic topic: kafka: insufficient data to decode packet, more bytes expected
[SARAMA]2017/10/18 15:57:30.139371 Producer shutting down.
[SARAMA]2017/10/18 15:57:30.139379 Closing Client
[SARAMA]2017/10/18 15:57:30.139414 producer/broker/2 shut down
[SARAMA]2017/10/18 15:57:30.139433 Closed connection to broker 127.0.0.1:55595
[SARAMA]2017/10/18 15:57:30.139385 *** mockbroker/2/0: invalid request: err=EOF, (*sarama.request)(<nil>)
[SARAMA]2017/10/18 15:57:30.139443 *** mockbroker/2/0: connection closed, err=<nil>
[SARAMA]2017/10/18 15:57:30.139466 *** mockbroker/2: listener closed, err=accept tcp 127.0.0.1:55596: use of closed network connection
[SARAMA]2017/10/18 15:57:30.139484 *** mockbroker/1/0: invalid request: err=EOF, (*sarama.request)(<nil>)
[SARAMA]2017/10/18 15:57:30.139492 *** mockbroker/1/0: connection closed, err=<nil>
[SARAMA]2017/10/18 15:57:30.139510 *** mockbroker/1: listener closed, err=accept tcp 127.0.0.1:55595: use of closed network connection
```

### Code change

- sort Blocks by increasing order prior to encoding to ensure deterministic payload to simplify unit tests
- encode `ProduceResponse` `ThrottleTime` when version >= 1
- encode `ProduceResponseBlock` `Timestamp` when version >= 2
- add unit tests for `ProduceResponse `decoding (version 1 and 2)
- add unit tests for `ProduceResponse` encoding