### PR TITLE
add block.LastStableOffset check ,only block.LastStableOffset >0 mean…

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -547,7 +547,7 @@ func (child *partitionConsumer) parseRecords(block *FetchResponseBlock) ([]*Cons
 			incomplete = true
 		}
 
-		if child.offset > block.LastStableOffset {
+		if block.LastStableOffset > 0 && child.offset > block.LastStableOffset {
 			// We reached the end of closed transactions
 			break
 		}


### PR DESCRIPTION
When spending 0.11 kafka, block.LastStableOffset has been -1, so each time you get the data can only be parsed one. Cause serious consumer congestion
