### PR TITLE
Permit setting version on mock produce response

### DIFF
--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -639,6 +639,7 @@ func TestAsyncProducerFlusherRetryCondition(t *testing.T) {
 
 	leader.SetHandlerByMap(map[string]MockResponse{
 		"ProduceRequest": NewMockProduceResponse(t).
+			SetVersion(0).
 			SetError("my_topic", 0, ErrNoError),
 	})
 

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -384,12 +384,18 @@ func (mr *MockOffsetCommitResponse) getError(group, topic string, partition int3
 
 // MockProduceResponse is a `ProduceResponse` builder.
 type MockProduceResponse struct {
+	version      int16
 	errors map[string]map[int32]KError
 	t      TestReporter
 }
 
 func NewMockProduceResponse(t TestReporter) *MockProduceResponse {
 	return &MockProduceResponse{t: t}
+}
+
+func (mr *MockProduceResponse) SetVersion(version int16) *MockProduceResponse {
+	mr.version = version
+	return mr
 }
 
 func (mr *MockProduceResponse) SetError(topic string, partition int32, kerror KError) *MockProduceResponse {
@@ -407,7 +413,9 @@ func (mr *MockProduceResponse) SetError(topic string, partition int32, kerror KE
 
 func (mr *MockProduceResponse) For(reqBody versionedDecoder) encoder {
 	req := reqBody.(*ProduceRequest)
-	res := &ProduceResponse{}
+	res := &ProduceResponse{
+		Version: mr.version,
+	}
 	for topic, partitions := range req.records {
 		for partition := range partitions {
 			res.AddTopicPartition(topic, partition, mr.getError(topic, partition))

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -384,9 +384,9 @@ func (mr *MockOffsetCommitResponse) getError(group, topic string, partition int3
 
 // MockProduceResponse is a `ProduceResponse` builder.
 type MockProduceResponse struct {
-	version      int16
-	errors map[string]map[int32]KError
-	t      TestReporter
+	version int16
+	errors  map[string]map[int32]KError
+	t       TestReporter
 }
 
 func NewMockProduceResponse(t TestReporter) *MockProduceResponse {


### PR DESCRIPTION
This allows setting the version of the message data struct for
MockProduceResponse. This change is very similar to what was already
done in pull request #939

In order to mock a "produce" request for Kafka version 0.10.2.0 you
would use the following:

    leader.SetHandlerByMap(map[string]MockResponse{
    	"ProduceRequest": NewMockProduceResponse(t).
    		SetVersion(2).
    		SetError("my_topic", 0, ErrNoError),
    })