### PR TITLE
Consumer: reduce ticker allocations

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -441,20 +441,20 @@ func (child *partitionConsumer) HighWaterMarkOffset() int64 {
 
 func (child *partitionConsumer) responseFeeder() {
 	var msgs []*ConsumerMessage
-	msgSent := false
+	expiryTicker := time.NewTicker(child.conf.Consumer.MaxProcessingTime)
+	firstAttempt := true
 
 feederLoop:
 	for response := range child.feeder {
 		msgs, child.responseResult = child.parseResponse(response)
-		expiryTicker := time.NewTicker(child.conf.Consumer.MaxProcessingTime)
 
 		for i, msg := range msgs {
 		messageSelect:
 			select {
 			case child.messages <- msg:
-				msgSent = true
+				firstAttempt = true
 			case <-expiryTicker.C:
-				if !msgSent {
+				if !firstAttempt {
 					child.responseResult = errTimedOut
 					child.broker.acks.Done()
 					for _, msg = range msgs[i:] {
@@ -465,16 +465,16 @@ feederLoop:
 				} else {
 					// current message has not been sent, return to select
 					// statement
-					msgSent = false
+					firstAttempt = false
 					goto messageSelect
 				}
 			}
 		}
 
-		expiryTicker.Stop()
 		child.broker.acks.Done()
 	}
 
+	expiryTicker.Stop()
 	close(child.messages)
 	close(child.errors)
 }


### PR DESCRIPTION
A ticker is created after each response, **even when there is no messages in the response**, so when the consumer is idle the CPU is still high. The cost of ticker creation and destruction is expensive, when the number of fetch requests goes up, both the CPU and memory are consumed by the tickers. 

So I try to reuse the ticker, and did not change the existing behavior. Now the timeout is still low precision (between `MaxProcessingTime` and `2 * MaxProcessingTime`).

Before:
![image](https://user-images.githubusercontent.com/3659110/35332844-83973f46-0147-11e8-8e2d-c4f3e32c367b.png)
![image](https://user-images.githubusercontent.com/3659110/35332856-90cbd938-0147-11e8-85c3-b3404aa34fcf.png)

After:
![image](https://user-images.githubusercontent.com/3659110/35480381-ba5ddfdc-0447-11e8-9a8f-0888aad99999.png)

