### PR TITLE
Do not choke on MessageSet without version

### DIFF
--- a/message_set.go
+++ b/message_set.go
@@ -66,6 +66,10 @@ func (ms *MessageSet) decode(pd packetDecoder) (err error) {
 	for pd.remaining() > 0 {
 		magic, err := magicValue(pd)
 		if err != nil {
+			if err == ErrInsufficientData {
+				ms.PartialTrailingMessage = true
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
If we end un unlucky and MessageSet buffer is truncated right before
we can read magic value, we just return `ErrInsufficientData`, even
if some messages were previously successfully parsed.

This propagates all the way up to `partitionConsumer`, where we zero
parsed messages, which results in `ErrMessageTooLarge` returned
to the consumer.

This commit fixes the issue by setting `PartialTrailingMessage` to `true`
on `MessageSet`, making it possible to read successfully parsed messages.