### PR TITLE
Added support for Metadata Request/Response v1

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -18,6 +18,7 @@ import (
 type Broker struct {
 	id   int32
 	addr string
+	rack *string
 
 	conf          *Config
 	correlationID int32
@@ -592,7 +593,7 @@ func (b *Broker) sendAndReceive(req protocolBody, res versionedDecoder) error {
 	}
 }
 
-func (b *Broker) decode(pd packetDecoder) (err error) {
+func (b *Broker) decode(pd packetDecoder, version int16) (err error) {
 	b.id, err = pd.getInt32()
 	if err != nil {
 		return err
@@ -606,6 +607,13 @@ func (b *Broker) decode(pd packetDecoder) (err error) {
 	port, err := pd.getInt32()
 	if err != nil {
 		return err
+	}
+
+	if version >= 1 {
+		b.rack, err = pd.getNullableString()
+		if err != nil {
+			return err
+		}
 	}
 
 	b.addr = net.JoinHostPort(host, fmt.Sprint(port))

--- a/broker.go
+++ b/broker.go
@@ -624,7 +624,7 @@ func (b *Broker) decode(pd packetDecoder, version int16) (err error) {
 	return nil
 }
 
-func (b *Broker) encode(pe packetEncoder) (err error) {
+func (b *Broker) encode(pe packetEncoder, version int16) (err error) {
 
 	host, portstr, err := net.SplitHostPort(b.addr)
 	if err != nil {
@@ -643,6 +643,13 @@ func (b *Broker) encode(pe packetEncoder) (err error) {
 	}
 
 	pe.putInt32(int32(port))
+
+	if version >= 1 {
+		err = pe.putNullableString(b.rack)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/find_coordinator_response.go
+++ b/find_coordinator_response.go
@@ -36,7 +36,7 @@ func (f *FindCoordinatorResponse) decode(pd packetDecoder, version int16) (err e
 	}
 
 	coordinator := new(Broker)
-	if err := coordinator.decode(pd); err != nil {
+	if err := coordinator.decode(pd, 0); err != nil {
 		return err
 	}
 	if coordinator.addr == ":0" {
@@ -60,7 +60,7 @@ func (f *FindCoordinatorResponse) encode(pe packetEncoder) error {
 		}
 	}
 
-	if err := f.Coordinator.encode(pe); err != nil {
+	if err := f.Coordinator.encode(pe, 0); err != nil {
 		return err
 	}
 

--- a/metadata_request.go
+++ b/metadata_request.go
@@ -1,42 +1,57 @@
 package sarama
 
 type MetadataRequest struct {
-	Topics []string
+	Version int16
+	Topics  []string
 }
 
 func (r *MetadataRequest) encode(pe packetEncoder) error {
-	err := pe.putArrayLength(len(r.Topics))
-	if err != nil {
-		return err
+	if r.Version < 0 || r.Version > 1 {
+		return PacketEncodingError{"invalid or unsupported MetadataRequest version field"}
 	}
-
-	for i := range r.Topics {
-		err = pe.putString(r.Topics[i])
+	if r.Version == 0 || r.Topics != nil || len(r.Topics) > 0 {
+		err := pe.putArrayLength(len(r.Topics))
 		if err != nil {
 			return err
 		}
+
+		for i := range r.Topics {
+			err = pe.putString(r.Topics[i])
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		pe.putInt32(-1)
 	}
 	return nil
 }
 
 func (r *MetadataRequest) decode(pd packetDecoder, version int16) error {
-	topicCount, err := pd.getArrayLength()
+	r.Version = version
+	size, err := pd.getInt32()
 	if err != nil {
 		return err
 	}
-	if topicCount == 0 {
+	if size < 0 {
+		return nil
+	} else {
+		topicCount := size
+		if topicCount == 0 {
+			return nil
+		}
+
+		r.Topics = make([]string, topicCount)
+		for i := range r.Topics {
+			topic, err := pd.getString()
+			if err != nil {
+				return err
+			}
+			r.Topics[i] = topic
+		}
 		return nil
 	}
 
-	r.Topics = make([]string, topicCount)
-	for i := range r.Topics {
-		topic, err := pd.getString()
-		if err != nil {
-			return err
-		}
-		r.Topics[i] = topic
-	}
-	return nil
 }
 
 func (r *MetadataRequest) key() int16 {
@@ -44,9 +59,14 @@ func (r *MetadataRequest) key() int16 {
 }
 
 func (r *MetadataRequest) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *MetadataRequest) requiredVersion() KafkaVersion {
-	return MinVersion
+	switch r.Version {
+	case 1:
+		return V0_10_0_0
+	default:
+		return MinVersion
+	}
 }

--- a/metadata_request_test.go
+++ b/metadata_request_test.go
@@ -3,27 +3,42 @@ package sarama
 import "testing"
 
 var (
-	metadataRequestNoTopics = []byte{
+	metadataRequestNoTopicsV0 = []byte{
 		0x00, 0x00, 0x00, 0x00}
 
-	metadataRequestOneTopic = []byte{
+	metadataRequestOneTopicV0 = []byte{
 		0x00, 0x00, 0x00, 0x01,
 		0x00, 0x06, 't', 'o', 'p', 'i', 'c', '1'}
 
-	metadataRequestThreeTopics = []byte{
+	metadataRequestThreeTopicsV0 = []byte{
 		0x00, 0x00, 0x00, 0x03,
 		0x00, 0x03, 'f', 'o', 'o',
 		0x00, 0x03, 'b', 'a', 'r',
 		0x00, 0x03, 'b', 'a', 'z'}
+
+	metadataRequestNoTopicsV1 = []byte{
+		0xff, 0xff, 0xff, 0xff}
 )
 
-func TestMetadataRequest(t *testing.T) {
+func TestMetadataRequestV0(t *testing.T) {
 	request := new(MetadataRequest)
-	testRequest(t, "no topics", request, metadataRequestNoTopics)
+	testRequest(t, "no topics", request, metadataRequestNoTopicsV0)
 
 	request.Topics = []string{"topic1"}
-	testRequest(t, "one topic", request, metadataRequestOneTopic)
+	testRequest(t, "one topic", request, metadataRequestOneTopicV0)
 
 	request.Topics = []string{"foo", "bar", "baz"}
-	testRequest(t, "three topics", request, metadataRequestThreeTopics)
+	testRequest(t, "three topics", request, metadataRequestThreeTopicsV0)
+}
+
+func TestMetadataRequestV1(t *testing.T) {
+	request := new(MetadataRequest)
+	request.Version = 1
+	testRequest(t, "no topics", request, metadataRequestNoTopicsV1)
+
+	request.Topics = []string{"topic1"}
+	testRequest(t, "one topic", request, metadataRequestOneTopicV0)
+
+	request.Topics = []string{"foo", "bar", "baz"}
+	testRequest(t, "three topics", request, metadataRequestThreeTopicsV0)
 }

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -179,7 +179,7 @@ func (r *MetadataResponse) encode(pe packetEncoder) error {
 		return err
 	}
 	for _, broker := range r.Brokers {
-		err = broker.encode(pe)
+		err = broker.encode(pe, r.Version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
V1 enables to discover the cluster controller which is required to send CreateTopics, DeleteTopics and CreatePartitions requests

So far we've just added the v1 request/response "definition" just enough so v1 requests can be sent using `Broker.GetMetadata()` to find the controller.

`Client` is still using v0 metadata and also it would be nice to add a `Controller` field to `Broker.` We can do that in another PR.

Co-authored-by: Adrian Preston <prestona@uk.ibm.com>
Co-authored-by: Mickael Maison <mickael.maison@gmail.com>