### PR TITLE
remove rack from FindCoordinatorResponse

### DIFF
--- a/find_coordinator_response.go
+++ b/find_coordinator_response.go
@@ -38,7 +38,9 @@ func (f *FindCoordinatorResponse) decode(pd packetDecoder, version int16) (err e
 	}
 
 	coordinator := new(Broker)
-	if err := coordinator.decode(pd, version); err != nil {
+	// The version is hardcoded to 0, as version 1 of the Broker-decode
+	// contains the rack-field which is not present in the FindCoordinatorResponse.
+	if err := coordinator.decode(pd, 0); err != nil {
 		return err
 	}
 	if coordinator.addr == ":0" {
@@ -66,7 +68,7 @@ func (f *FindCoordinatorResponse) encode(pe packetEncoder) error {
 	if coordinator == nil {
 		coordinator = NoNode
 	}
-	if err := coordinator.encode(pe, f.Version); err != nil {
+	if err := coordinator.encode(pe, 0); err != nil {
 		return err
 	}
 	return nil

--- a/find_coordinator_response_test.go
+++ b/find_coordinator_response_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestFindCoordinatorResponse(t *testing.T) {
 	errMsg := "kaboom"
-	brokerRack := "foo"
 
 	for _, tc := range []struct {
 		desc     string
@@ -38,7 +37,6 @@ func TestFindCoordinatorResponse(t *testing.T) {
 			Coordinator: &Broker{
 				id:   7,
 				addr: "host:9092",
-				rack: &brokerRack,
 			},
 		},
 		encoded: []byte{
@@ -48,7 +46,6 @@ func TestFindCoordinatorResponse(t *testing.T) {
 			0, 0, 0, 7, // Coordinator.ID
 			0, 4, 'h', 'o', 's', 't', // Coordinator.Host
 			0, 0, 35, 132, // Coordinator.Port
-			0, 3, 'f', 'o', 'o', // Coordinator.Rack
 		},
 	}, {
 		desc: "version 0 - error",
@@ -79,7 +76,6 @@ func TestFindCoordinatorResponse(t *testing.T) {
 			255, 255, 255, 255, // Coordinator.ID: -1
 			0, 0, // Coordinator.Host: ""
 			255, 255, 255, 255, // Coordinator.Port: -1
-			255, 255, // Coordinator.Rack: empty
 		},
 	}} {
 		testResponse(t, tc.desc, tc.response, tc.encoded)


### PR DESCRIPTION
#1050 introduced the `Rack`-field to the [`FindCoordinatorResponse`](https://kafka.apache.org/protocol#The_Messages_FindCoordinator), however this is only part of the [`MetadataResponse`](https://kafka.apache.org/protocol#The_Messages_Metadata). As we now have a shared method for decoding/encoding the broker for both these messages we can work around this (as was pre-#1050) by hard coding the version of the coordinator-decode to 0.

Ultimately I guess we should separate the decoding of the broker for these two messages, but maybe we should leave that for another day.

This removes the rack from the `FindCoordinatorResponse` and hardcodes the `Broker` `decode`/`encode` version to 0 and adds a comment for that.

cc @horkhe 