### PR TITLE
'Config.MetricRegistry=nil' to mute sarama metrics

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -109,6 +109,11 @@ func (b *Broker) Open(conf *Config) error {
 			b.requestRate = metrics.GetOrRegisterMeter("request-rate", conf.MetricRegistry)
 			b.outgoingByteRate = metrics.GetOrRegisterMeter("outgoing-byte-rate", conf.MetricRegistry)
 			b.responseRate = metrics.GetOrRegisterMeter("response-rate", conf.MetricRegistry)
+		} else {
+			b.incomingByteRate = metrics.NilMeter{}
+			b.requestRate = metrics.NilMeter{}
+			b.responseRate = metrics.NilMeter{}
+			b.outgoingByteRate = metrics.NilMeter{}
 		}
 		b.requestSize = getOrRegisterHistogram("request-size", conf.MetricRegistry)
 		b.requestLatency = getOrRegisterHistogram("request-latency-in-ms", conf.MetricRegistry)

--- a/broker.go
+++ b/broker.go
@@ -104,12 +104,14 @@ func (b *Broker) Open(conf *Config) error {
 		b.conf = conf
 
 		// Create or reuse the global metrics shared between brokers
-		b.incomingByteRate = metrics.GetOrRegisterMeter("incoming-byte-rate", conf.MetricRegistry)
-		b.requestRate = metrics.GetOrRegisterMeter("request-rate", conf.MetricRegistry)
+		if conf.MetricRegistry != nil {
+			b.incomingByteRate = metrics.GetOrRegisterMeter("incoming-byte-rate", conf.MetricRegistry)
+			b.requestRate = metrics.GetOrRegisterMeter("request-rate", conf.MetricRegistry)
+			b.outgoingByteRate = metrics.GetOrRegisterMeter("outgoing-byte-rate", conf.MetricRegistry)
+			b.responseRate = metrics.GetOrRegisterMeter("response-rate", conf.MetricRegistry)
+		}
 		b.requestSize = getOrRegisterHistogram("request-size", conf.MetricRegistry)
 		b.requestLatency = getOrRegisterHistogram("request-latency-in-ms", conf.MetricRegistry)
-		b.outgoingByteRate = metrics.GetOrRegisterMeter("outgoing-byte-rate", conf.MetricRegistry)
-		b.responseRate = metrics.GetOrRegisterMeter("response-rate", conf.MetricRegistry)
 		b.responseSize = getOrRegisterHistogram("response-size", conf.MetricRegistry)
 		// Do not gather metrics for seeded broker (only used during bootstrap) because they share
 		// the same id (-1) and are already exposed through the global metrics above

--- a/config.go
+++ b/config.go
@@ -269,8 +269,10 @@ type Config struct {
 	Version KafkaVersion
 	// The registry to define metrics into.
 	// Defaults to a local registry.
-	// If you want to disable metrics gathering, set "metrics.UseNilMetrics" to "true"
-	// prior to starting Sarama.
+	// If you want to disable metrics gathering for all of rcrowley/go-metrics
+	// managed metrics, set "metrics.UseNilMetrics" to "true" prior to
+	// starting Sarama.  If you want to disable only Sarama metrics gathering,
+	// set to nil prior to starting Sarama
 	// See Examples on how to use the metrics registry
 	MetricRegistry metrics.Registry
 }

--- a/metrics.go
+++ b/metrics.go
@@ -17,9 +17,13 @@ const (
 )
 
 func getOrRegisterHistogram(name string, r metrics.Registry) metrics.Histogram {
-	return r.GetOrRegister(name, func() metrics.Histogram {
-		return metrics.NewHistogram(metrics.NewExpDecaySample(metricsReservoirSize, metricsAlphaFactor))
-	}).(metrics.Histogram)
+	if r != nil {
+		return r.GetOrRegister(name, func() metrics.Histogram {
+			return metrics.NewHistogram(metrics.NewExpDecaySample(metricsReservoirSize, metricsAlphaFactor))
+		}).(metrics.Histogram)
+	} else {
+		return metrics.NilHistogram{}
+	}
 }
 
 func getMetricNameForBroker(name string, broker *Broker) string {
@@ -29,11 +33,19 @@ func getMetricNameForBroker(name string, broker *Broker) string {
 }
 
 func getOrRegisterBrokerMeter(name string, broker *Broker, r metrics.Registry) metrics.Meter {
-	return metrics.GetOrRegisterMeter(getMetricNameForBroker(name, broker), r)
+	if r != nil {
+		return metrics.GetOrRegisterMeter(getMetricNameForBroker(name, broker), r)
+	} else {
+		return metrics.NilMeter{}
+	}
 }
 
 func getOrRegisterBrokerHistogram(name string, broker *Broker, r metrics.Registry) metrics.Histogram {
-	return getOrRegisterHistogram(getMetricNameForBroker(name, broker), r)
+	if r != nil {
+		return getOrRegisterHistogram(getMetricNameForBroker(name, broker), r)
+	} else {
+		return metrics.NilHistogram{}
+	}
 }
 
 func getMetricNameForTopic(name string, topic string) string {
@@ -43,9 +55,17 @@ func getMetricNameForTopic(name string, topic string) string {
 }
 
 func getOrRegisterTopicMeter(name string, topic string, r metrics.Registry) metrics.Meter {
-	return metrics.GetOrRegisterMeter(getMetricNameForTopic(name, topic), r)
+	if r != nil {
+		return metrics.GetOrRegisterMeter(getMetricNameForTopic(name, topic), r)
+	} else {
+		return metrics.NilMeter{}
+	}
 }
 
 func getOrRegisterTopicHistogram(name string, topic string, r metrics.Registry) metrics.Histogram {
-	return getOrRegisterHistogram(getMetricNameForTopic(name, topic), r)
+	if r != nil {
+		return getOrRegisterHistogram(getMetricNameForTopic(name, topic), r)
+	} else {
+		return metrics.NilHistogram{}
+	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -27,6 +27,12 @@ func TestGetOrRegisterHistogram(t *testing.T) {
 	if sameHistogram != histogram {
 		t.Error("Unexpected different histogram", sameHistogram, histogram)
 	}
+
+	// Pulling from a nil registry should result in a nil metric type
+	nilHistogram := getOrRegisterHistogram("name", nil)
+	if nilHistogram != metrics.Histogram(metrics.NilHistogram{}) {
+		t.Error("Histogram from nil registry is not nil", nilHistogram)
+	}
 }
 
 func TestGetMetricNameForBroker(t *testing.T) {

--- a/produce_request.go
+++ b/produce_request.go
@@ -129,7 +129,9 @@ func (r *ProduceRequest) encode(pe packetEncoder) error {
 		}
 	}
 	if totalRecordCount > 0 {
-		metrics.GetOrRegisterMeter("record-send-rate", metricRegistry).Mark(totalRecordCount)
+		if metricRegistry != nil {
+			metrics.GetOrRegisterMeter("record-send-rate", metricRegistry).Mark(totalRecordCount)
+		}
 		getOrRegisterHistogram("records-per-request", metricRegistry).Update(totalRecordCount)
 	}
 


### PR DESCRIPTION
Histograms and Meters are very useful metrics to collect, but the current implemetation has two drawbacks:
1) They are also heavy in comparison to their Gauge and Counter peers, and the volume of data and the number of topics and brokers being addressed may warrant disabling them for throughput reasons.  
2) Entirely disabling rcrowlee/go-metrics is an awfully big hammer to use when just setting it to nil feels a lot more idiomatic.  

High level view of change is that all instances of metrics.GetOrRegister$FOO were guarded by a test for a nil registry, and if the registry was nil, return the corresponding metrics.Nil$FOO to preserve proper interface mechanics.  

Seem OK: 
- 'go test' passed
- 'go vet' doesn't complain about anything besides printf format strings
- Have consumed a couple hundred thousand non-synthetic messages through it so far