### PR TITLE
Added support for Metadata Request/Response up to v5

### DIFF
--- a/metadata_request.go
+++ b/metadata_request.go
@@ -1,12 +1,13 @@
 package sarama
 
 type MetadataRequest struct {
-	Version int16
-	Topics  []string
+	Version                int16
+	Topics                 []string
+	AllowAutoTopicCreation bool
 }
 
 func (r *MetadataRequest) encode(pe packetEncoder) error {
-	if r.Version < 0 || r.Version > 1 {
+	if r.Version < 0 || r.Version > 5 {
 		return PacketEncodingError{"invalid or unsupported MetadataRequest version field"}
 	}
 	if r.Version == 0 || r.Topics != nil || len(r.Topics) > 0 {
@@ -23,6 +24,9 @@ func (r *MetadataRequest) encode(pe packetEncoder) error {
 		}
 	} else {
 		pe.putInt32(-1)
+	}
+	if r.Version > 3 {
+		pe.putBool(r.AllowAutoTopicCreation)
 	}
 	return nil
 }
@@ -49,9 +53,15 @@ func (r *MetadataRequest) decode(pd packetDecoder, version int16) error {
 			}
 			r.Topics[i] = topic
 		}
-		return nil
 	}
-
+	if r.Version > 3 {
+		autoCreation, err := pd.getBool()
+		if err != nil {
+			return err
+		}
+		r.AllowAutoTopicCreation = autoCreation
+	}
+	return nil
 }
 
 func (r *MetadataRequest) key() int16 {
@@ -66,6 +76,12 @@ func (r *MetadataRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
 	case 1:
 		return V0_10_0_0
+	case 2:
+		return V0_10_1_0
+	case 3, 4:
+		return V0_11_0_0
+	case 5:
+		return V1_0_0_0
 	default:
 		return MinVersion
 	}

--- a/metadata_request_test.go
+++ b/metadata_request_test.go
@@ -18,6 +18,9 @@ var (
 
 	metadataRequestNoTopicsV1 = []byte{
 		0xff, 0xff, 0xff, 0xff}
+
+	metadataRequestAutoCreateV4   = append(metadataRequestOneTopicV0, byte(1))
+	metadataRequestNoAutoCreateV4 = append(metadataRequestOneTopicV0, byte(0))
 )
 
 func TestMetadataRequestV0(t *testing.T) {
@@ -41,4 +44,33 @@ func TestMetadataRequestV1(t *testing.T) {
 
 	request.Topics = []string{"foo", "bar", "baz"}
 	testRequest(t, "three topics", request, metadataRequestThreeTopicsV0)
+}
+
+func TestMetadataRequestV2(t *testing.T) {
+	request := new(MetadataRequest)
+	request.Version = 2
+	testRequest(t, "no topics", request, metadataRequestNoTopicsV1)
+
+	request.Topics = []string{"topic1"}
+	testRequest(t, "one topic", request, metadataRequestOneTopicV0)
+}
+
+func TestMetadataRequestV3(t *testing.T) {
+	request := new(MetadataRequest)
+	request.Version = 3
+	testRequest(t, "no topics", request, metadataRequestNoTopicsV1)
+
+	request.Topics = []string{"topic1"}
+	testRequest(t, "one topic", request, metadataRequestOneTopicV0)
+}
+
+func TestMetadataRequestV4(t *testing.T) {
+	request := new(MetadataRequest)
+	request.Version = 4
+	request.Topics = []string{"topic1"}
+	request.AllowAutoTopicCreation = true
+	testRequest(t, "one topic", request, metadataRequestAutoCreateV4)
+
+	request.AllowAutoTopicCreation = false
+	testRequest(t, "one topic", request, metadataRequestNoAutoCreateV4)
 }


### PR DESCRIPTION
Request:
- v4 added the `allow_auto_topic_creation` boolean field

Response:
- v2 added the `cluster_id` field
- v3 added the `throttle_time_ms` field
- v5 added the `offline_replicas` field for each partition metadata