### PR TITLE
Unblock consumer when receiving invalid FetchResponse (response did not contain all the expected topic/partition blocks)

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -528,7 +528,7 @@ func (child *partitionConsumer) parseRecords(batch *RecordBatch) ([]*ConsumerMes
 		child.offset = offset + 1
 	}
 	if len(messages) == 0 {
-		return nil, ErrIncompleteResponse
+		child.offset += 1
 	}
 	return messages, nil
 }


### PR DESCRIPTION
Increment offsets to avoid consumer blocking. The issue is described here https://github.com/Shopify/sarama/issues/1087