### PR TITLE
Optional replica id in offset request

### DIFF
--- a/offset_request.go
+++ b/offset_request.go
@@ -27,12 +27,20 @@ func (b *offsetRequestBlock) decode(pd packetDecoder, version int16) (err error)
 }
 
 type OffsetRequest struct {
-	Version int16
-	blocks  map[string]map[int32]*offsetRequestBlock
+	Version        int16
+	replicaID      *int32
+	storeReplicaID int32
+	blocks         map[string]map[int32]*offsetRequestBlock
 }
 
 func (r *OffsetRequest) encode(pe packetEncoder) error {
-	pe.putInt32(-1) // replica ID is always -1 for clients
+	if r.replicaID == nil {
+		// default replica ID is always -1 for clients
+		pe.putInt32(-1)
+	} else {
+		pe.putInt32(*r.replicaID)
+	}
+
 	err := pe.putArrayLength(len(r.blocks))
 	if err != nil {
 		return err
@@ -111,6 +119,11 @@ func (r *OffsetRequest) requiredVersion() KafkaVersion {
 	default:
 		return MinVersion
 	}
+}
+
+func (r *OffsetRequest) SetReplicaID(id int32) {
+	r.storeReplicaID = id
+	r.replicaID = &r.storeReplicaID
 }
 
 func (r *OffsetRequest) AddBlock(topic string, partitionID int32, time int64, maxOffsets int32) {

--- a/offset_request.go
+++ b/offset_request.go
@@ -67,10 +67,14 @@ func (r *OffsetRequest) encode(pe packetEncoder) error {
 func (r *OffsetRequest) decode(pd packetDecoder, version int16) error {
 	r.Version = version
 
-	// Ignore replica ID
-	if _, err := pd.getInt32(); err != nil {
+	replicaID, err := pd.getInt32()
+	if err != nil {
 		return err
 	}
+	if replicaID >= 0 {
+		r.SetReplicaID(replicaID)
+	}
+
 	blockCount, err := pd.getArrayLength()
 	if err != nil {
 		return err

--- a/offset_request.go
+++ b/offset_request.go
@@ -130,6 +130,13 @@ func (r *OffsetRequest) SetReplicaID(id int32) {
 	r.replicaID = &r.storeReplicaID
 }
 
+func (r *OffsetRequest) ReplicaID() int32 {
+	if r.replicaID == nil {
+		return -1
+	}
+	return r.storeReplicaID
+}
+
 func (r *OffsetRequest) AddBlock(topic string, partitionID int32, time int64, maxOffsets int32) {
 	if r.blocks == nil {
 		r.blocks = make(map[string]map[int32]*offsetRequestBlock)

--- a/offset_request_test.go
+++ b/offset_request_test.go
@@ -23,6 +23,10 @@ var (
 		0x00, 0x00, 0x00, 0x01,
 		0x00, 0x00, 0x00, 0x04,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}
+
+	offsetRequestReplicaID = []byte{
+		0x00, 0x00, 0x00, 0x2a,
+		0x00, 0x00, 0x00, 0x00}
 )
 
 func TestOffsetRequest(t *testing.T) {
@@ -40,4 +44,10 @@ func TestOffsetRequestV1(t *testing.T) {
 
 	request.AddBlock("bar", 4, 1, 2) // Last argument is ignored for V1
 	testRequest(t, "one block", request, offsetRequestOneBlockV1)
+}
+
+func TestOffsetRequestReplicaID(t *testing.T) {
+	request := new(OffsetRequest)
+	request.SetReplicaID(42)
+	testRequestEncode(t, "with replica ID", request, offsetRequestReplicaID)
 }

--- a/offset_request_test.go
+++ b/offset_request_test.go
@@ -48,6 +48,12 @@ func TestOffsetRequestV1(t *testing.T) {
 
 func TestOffsetRequestReplicaID(t *testing.T) {
 	request := new(OffsetRequest)
-	request.SetReplicaID(42)
+	replicaID := int32(42)
+	request.SetReplicaID(replicaID)
+
+	if found := request.ReplicaID(); found != replicaID {
+		t.Errorf("replicaID: expected %v, found %v", replicaID, found)
+	}
+
 	testRequest(t, "with replica ID", request, offsetRequestReplicaID)
 }

--- a/offset_request_test.go
+++ b/offset_request_test.go
@@ -49,5 +49,5 @@ func TestOffsetRequestV1(t *testing.T) {
 func TestOffsetRequestReplicaID(t *testing.T) {
 	request := new(OffsetRequest)
 	request.SetReplicaID(42)
-	testRequestEncode(t, "with replica ID", request, offsetRequestReplicaID)
+	testRequest(t, "with replica ID", request, offsetRequestReplicaID)
 }


### PR DESCRIPTION
This change adds `SetReplicaID` to the OffsetRequest structure. If `SetReplicaID` has not been used on an instance of `OffsetRequest`, `-1` will be used when serializing the request.