### PR TITLE
Ignore fmt package when doing errcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ test:
 vet:
 	go vet ./...
 
+# See https://github.com/kisielk/errcheck/pull/141 for details on ignorepkg
 errcheck:
-	errcheck github.com/Shopify/sarama/...
+	errcheck -ignorepkg fmt github.com/Shopify/sarama/...
 
 fmt:
 	@if [ -n "$$(go fmt ./...)" ]; then echo 'Please run go fmt on your code.' && exit 1; fi


### PR DESCRIPTION
[This errcheck PR](https://github.com/kisielk/errcheck/pull/141) removed `fmt.Fprintf` from default exclude list and that makes CI sad, e.g. https://travis-ci.org/Shopify/sarama/jobs/385690067.

This PR brings back old behavior of errcheck.