### PR TITLE
Do not modify ProducerMessage.MetaData

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -145,8 +145,9 @@ type ProducerMessage struct {
 	// least version 0.10.0.
 	Timestamp time.Time
 
-	retries int
-	flags   flagSet
+	retries     int
+	flags       flagSet
+	expectation chan *ProducerError
 }
 
 const producerMessageOverhead = 26 // the metadata overhead of CRC, flags, etc.


### PR DESCRIPTION
In SyncProducer, do not modify ProducerMessage.MetaData during the whole process of publishing the message to Kafka. 
MetaData could be used in a user-defined Partitioner. The original design saves the MetaData and reuse the field as a signal channel to wait for completion of publish. It's better to add a non-exeported field for this purpose in the ProducerMessage struct.