### PR TITLE
Adjust paritioning / hash behavior to comply with java lib

### DIFF
--- a/partitioner.go
+++ b/partitioner.go
@@ -123,10 +123,7 @@ func (p *hashPartitioner) Partition(message *ProducerMessage, numPartitions int3
 	if err != nil {
 		return -1, err
 	}
-	partition := int32(p.hasher.Sum32()) % numPartitions
-	if partition < 0 {
-		partition = -partition
-	}
+	partition :=  (int32(p.hasher.Sum32()) & 0x7fffffff) % numPartitions
 	return partition, nil
 }
 

--- a/partitioner.go
+++ b/partitioner.go
@@ -123,7 +123,7 @@ func (p *hashPartitioner) Partition(message *ProducerMessage, numPartitions int3
 	if err != nil {
 		return -1, err
 	}
-	partition :=  (int32(p.hasher.Sum32()) & 0x7fffffff) % numPartitions
+	partition := (int32(p.hasher.Sum32()) & 0x7fffffff) % numPartitions
 	return partition, nil
 }
 


### PR DESCRIPTION
So we had a problem here with java and go services working together. Even though they are using the same hash function, the behavior afterwards is slightly different.

While java is doing this:
`Abs(Hash) % numPartitions`

Sarama was doing this: 
`Abs(Hash % numPartitions`

I updated that according to how the java lib is doing it : 

https://github.com/apache/kafka/blob/fa1d0383902260576132e09bdf9efcc2784b55b4/clients/src/main/java/org/apache/kafka/clients/producer/internals/DefaultPartitioner.java#L69

https://github.com/apache/kafka/blob/fa1d0383902260576132e09bdf9efcc2784b55b4/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L821