### PR TITLE
Fix block on control messages

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -579,10 +579,6 @@ func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*Consu
 
 	messages := []*ConsumerMessage{}
 	for _, records := range block.RecordsSet {
-		if control, err := records.isControl(); err != nil || control {
-			continue
-		}
-
 		switch records.recordsType {
 		case legacyRecords:
 			messageSetMessages, err := child.parseMessages(records.MsgSet)
@@ -595,6 +591,9 @@ func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*Consu
 			recordBatchMessages, err := child.parseRecords(records.RecordBatch)
 			if err != nil {
 				return nil, err
+			}
+			if control, err := records.isControl(); err != nil || control {
+				continue
 			}
 
 			messages = append(messages, recordBatchMessages...)


### PR DESCRIPTION
Move the skip for those block to after the point where we've
parsed/incremented the offset so we don't get stuck on a response
containing *only* control messages.

Should fix #1106. @FrancoisPoinsot can you please confirm?