### PR TITLE
Fix metadata requests on later versions

### DIFF
--- a/metadata_request.go
+++ b/metadata_request.go
@@ -10,7 +10,7 @@ func (r *MetadataRequest) encode(pe packetEncoder) error {
 	if r.Version < 0 || r.Version > 5 {
 		return PacketEncodingError{"invalid or unsupported MetadataRequest version field"}
 	}
-	if r.Version == 0 || r.Topics != nil || len(r.Topics) > 0 {
+	if r.Version == 0 || len(r.Topics) > 0 {
 		err := pe.putArrayLength(len(r.Topics))
 		if err != nil {
 			return err


### PR DESCRIPTION
If the set of Topics is an empty array, we don't need to put it in the
request or we'll just get an empty set of data back which is useless.
As far as I can tell the nil check was for safety, but len(nil) is
already safe and the boolean logic was wrong anyway.

Thanks to @Preylien for figuring this one out.

Fixes #1130.