### PR TITLE
Add ListTopics func to ClusterAdmin interface

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -192,6 +192,9 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 		topicDetails := TopicDetail{
 			NumPartitions: int32(len(topic.Partitions)),
 		}
+		if len(topic.Partitions) > 0 {
+			topicDetails.ReplicationFactor = int16(len(topic.Partitions[0].Replicas))
+		}
 		topicsDetailsMap[topic.Name] = topicDetails
 
 		// we populate the resources we want to describe from the MetadataResponse

--- a/admin.go
+++ b/admin.go
@@ -176,6 +176,7 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 	if err != nil {
 		return nil, err
 	}
+	b.Open(ca.client.Config())
 
 	metadataReq := &MetadataRequest{}
 	metadataResp, err := b.GetMetadata(metadataReq)

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -631,16 +631,32 @@ func (mr *MockDescribeConfigsResponse) For(reqBody versionedDecoder) encoder {
 	req := reqBody.(*DescribeConfigsRequest)
 	res := &DescribeConfigsResponse{}
 
-	var configEntries []*ConfigEntry
-	configEntries = append(configEntries, &ConfigEntry{Name: "my_topic",
-		Value:     "my_topic",
-		ReadOnly:  true,
-		Default:   true,
-		Sensitive: false,
-	})
-
 	for _, r := range req.Resources {
-		res.Resources = append(res.Resources, &ResourceResponse{Name: r.Name, Configs: configEntries})
+		var configEntries []*ConfigEntry
+		switch r.Type {
+		case TopicResource:
+			configEntries = append(configEntries,
+				&ConfigEntry{Name: "max.message.bytes",
+					Value:     "1000000",
+					ReadOnly:  false,
+					Default:   true,
+					Sensitive: false,
+				}, &ConfigEntry{Name: "retention.ms",
+					Value:     "5000",
+					ReadOnly:  false,
+					Default:   false,
+					Sensitive: false,
+				}, &ConfigEntry{Name: "password",
+					Value:     "12345",
+					ReadOnly:  false,
+					Default:   false,
+					Sensitive: true,
+				})
+			res.Resources = append(res.Resources, &ResourceResponse{
+				Name:    r.Name,
+				Configs: configEntries,
+			})
+		}
 	}
 	return res
 }


### PR DESCRIPTION
Currently the Sarama ClusterAdmin client (added under https://github.com/Shopify/sarama/pull/1055) didn't have anything analogous to the Java client's [AdminClient#listTopics()](https://kafka.apache.org/10/javadoc/org/apache/kafka/clients/admin/AdminClient.html#listTopics--) command.

This PR is to add one which will return an up-to-date map of all topics in the cluster and any non-default topic configuration that they have.