### PR TITLE
try fixing a PartitionConsumer's race condition

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -421,12 +421,6 @@ func (child *partitionConsumer) AsyncClose() {
 func (child *partitionConsumer) Close() error {
 	child.AsyncClose()
 
-	go withRecover(func() {
-		for range child.messages {
-			// drain
-		}
-	})
-
 	var errors ConsumerErrors
 	for err := range child.errors {
 		errors = append(errors, err)

--- a/consumer.go
+++ b/consumer.go
@@ -448,14 +448,22 @@ feederLoop:
 		for i, msg := range msgs {
 		messageSelect:
 			select {
+			case <-child.dying:
+				child.broker.acks.Done()
+				continue feederLoop
 			case child.messages <- msg:
 				firstAttempt = true
 			case <-expiryTicker.C:
 				if !firstAttempt {
 					child.responseResult = errTimedOut
 					child.broker.acks.Done()
+				remainingLoop:
 					for _, msg = range msgs[i:] {
-						child.messages <- msg
+						select {
+						case child.messages <- msg:
+						case <-child.dying:
+							break remainingLoop
+						}
 					}
 					child.broker.input <- child
 					continue feederLoop

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -807,8 +807,28 @@ func TestConsumerInterleavedClose(t *testing.T) {
 	assertMessageOffset(t, <-c0.Messages(), 1001)
 	assertMessageOffset(t, <-c0.Messages(), 1002)
 
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for range c0.Messages() {
+			// drain
+		}
+	}()
+	go func() {
+		defer wg.Done()
+
+		for range c1.Messages() {
+			// drain
+		}
+	}()
+
 	safeClose(t, c1)
 	safeClose(t, c0)
+	wg.Wait()
+
 	safeClose(t, master)
 	broker0.Close()
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -807,28 +807,8 @@ func TestConsumerInterleavedClose(t *testing.T) {
 	assertMessageOffset(t, <-c0.Messages(), 1001)
 	assertMessageOffset(t, <-c0.Messages(), 1002)
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-
-		for range c0.Messages() {
-			// drain
-		}
-	}()
-	go func() {
-		defer wg.Done()
-
-		for range c1.Messages() {
-			// drain
-		}
-	}()
-
 	safeClose(t, c1)
 	safeClose(t, c0)
-	wg.Wait()
-
 	safeClose(t, master)
 	broker0.Close()
 }


### PR DESCRIPTION
When closing a `PartitionConsumer`, a race condition will happen if draining the channel `messages` . This causes user's consuming routine gets partial messages, which can lead to confusion.

This problem is related to https://github.com/bsm/sarama-cluster/issues/255