### PR TITLE
Reuse objects in consume flow

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -275,7 +275,7 @@ func (b *Broker) Produce(request *ProduceRequest) (*ProduceResponse, error) {
 }
 
 func (b *Broker) Fetch(request *FetchRequest) (*FetchResponse, error) {
-	response := new(FetchResponse)
+	response := acquireFetchResponse()
 
 	err := b.sendAndReceive(request, response)
 

--- a/consumer.go
+++ b/consumer.go
@@ -19,6 +19,42 @@ type ConsumerMessage struct {
 	Headers        []*RecordHeader // only set if kafka is version 0.11+
 }
 
+var consumerMessagePool = &sync.Pool{
+	New: func() interface{} {
+		return &ConsumerMessage{
+			Headers: make([]*RecordHeader, 0, 16),
+		}
+	},
+}
+
+func acquireConsumerMessage() *ConsumerMessage {
+	return consumerMessagePool.Get().(*ConsumerMessage)
+}
+
+// ReleaseConsumerMessage returns a ConsumerMessage instance to sync.Pool.
+func ReleaseConsumerMessage(m *ConsumerMessage) {
+	if m.Headers == nil {
+		m.Headers = make([]*RecordHeader, 0, 16)
+	} else {
+		for i := 0; i < len(m.Headers); i++ {
+			if m.Headers[i] != nil {
+				releaseRecordHeader(m.Headers[i])
+			}
+			m.Headers[i] = nil
+		}
+		m.Headers = m.Headers[:0]
+	}
+
+	m.Key = nil
+	m.Value = nil
+	m.Topic = ""
+	m.Partition = 0
+	m.Offset = 0
+	m.Timestamp = time.Time{}
+	m.BlockTimestamp = time.Time{}
+	consumerMessagePool.Put(m)
+}
+
 // ConsumerError is what is provided to the user when an error occurs.
 // It wraps an error and includes the topic and partition.
 type ConsumerError struct {
@@ -494,15 +530,15 @@ func (child *partitionConsumer) parseMessages(msgSet *MessageSet) ([]*ConsumerMe
 			if offset < child.offset {
 				continue
 			}
-			messages = append(messages, &ConsumerMessage{
-				Topic:          child.topic,
-				Partition:      child.partition,
-				Key:            msg.Msg.Key,
-				Value:          msg.Msg.Value,
-				Offset:         offset,
-				Timestamp:      msg.Msg.Timestamp,
-				BlockTimestamp: msgBlock.Msg.Timestamp,
-			})
+			m := acquireConsumerMessage()
+			m.Topic = child.topic
+			m.Partition = child.partition
+			m.Key = msg.Msg.Key
+			m.Value = msg.Msg.Value
+			m.Offset = offset
+			m.Timestamp = msg.Msg.Timestamp
+			m.BlockTimestamp = msgBlock.Msg.Timestamp
+			messages = append(messages, m)
 			child.offset = offset + 1
 		}
 	}
@@ -519,15 +555,15 @@ func (child *partitionConsumer) parseRecords(batch *RecordBatch) ([]*ConsumerMes
 		if offset < child.offset {
 			continue
 		}
-		messages = append(messages, &ConsumerMessage{
-			Topic:     child.topic,
-			Partition: child.partition,
-			Key:       rec.Key,
-			Value:     rec.Value,
-			Offset:    offset,
-			Timestamp: batch.FirstTimestamp.Add(rec.TimestampDelta),
-			Headers:   rec.Headers,
-		})
+		m := acquireConsumerMessage()
+		m.Topic = child.topic
+		m.Partition = child.partition
+		m.Key = rec.Key
+		m.Value = rec.Value
+		m.Offset = offset
+		m.Timestamp = batch.FirstTimestamp.Add(rec.TimestampDelta)
+		m.Headers = append(m.Headers, rec.Headers...)
+		messages = append(messages, m)
 		child.offset = offset + 1
 	}
 	if len(messages) == 0 {
@@ -703,6 +739,7 @@ func (bc *brokerConsumer) subscriptionConsumer() {
 		}
 		bc.acks.Wait()
 		bc.handleResponses()
+		releaseFetchResponse(response)
 	}
 }
 


### PR DESCRIPTION
As mentioned in issue https://github.com/Shopify/sarama/issues/1131 , consumer allocs many objects which can be reused.

This PR reuses objects in the whole consume flow using `sync.Pool` and can significantly reduce gc frequency. 

Users should call `ReleaseConsumerMessage` after they finished all jobs with the `ConsumerMessage`.