### PR TITLE
consumer: set BlockTimestamp when consuming V2 messages (Records)

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -520,13 +520,14 @@ func (child *partitionConsumer) parseRecords(batch *RecordBatch) ([]*ConsumerMes
 			continue
 		}
 		messages = append(messages, &ConsumerMessage{
-			Topic:     child.topic,
-			Partition: child.partition,
-			Key:       rec.Key,
-			Value:     rec.Value,
-			Offset:    offset,
-			Timestamp: batch.FirstTimestamp.Add(rec.TimestampDelta),
-			Headers:   rec.Headers,
+			Topic:          child.topic,
+			Partition:      child.partition,
+			Key:            rec.Key,
+			Value:          rec.Value,
+			Offset:         offset,
+			Timestamp:      batch.FirstTimestamp.Add(rec.TimestampDelta),
+			BlockTimestamp: batch.MaxTimestamp,
+			Headers:        rec.Headers,
 		})
 		child.offset = offset + 1
 	}


### PR DESCRIPTION
record.MaxTimestamp is set to "log append time" when using
message.timestamp.type=LogAppendTime

see https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java#L85

Signed-off-by: Etienne Champetier <champetier.etienne@gmail.com>