### PR TITLE
Fix input channel overflow

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -88,7 +88,7 @@ func NewAsyncProducerFromClient(client Client) (AsyncProducer, error) {
 		client:     client,
 		conf:       client.Config(),
 		errors:     make(chan *ProducerError),
-		input:      make(chan *ProducerMessage),
+  		input:      make(chan *ProducerMessage, 256),
 		successes:  make(chan *ProducerMessage),
 		retries:    make(chan *ProducerMessage),
 		brokers:    make(map[*Broker]chan<- *ProducerMessage),


### PR DESCRIPTION
This is a pretty straight forward fix for #1168 but it may be sub-optimal given it effectively means that in the worst case scenario the producer will accept `ChannelBufferSize * 2` for a given topic.  It may be more desirable to add another configuration option to set the shared channel buffer size independently of the topic channel buffer size.