### PR TITLE
exported Broker's rack setting

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -208,6 +208,17 @@ func (b *Broker) Addr() string {
 	return b.addr
 }
 
+// Rack returns the broker's rack as retrieved from Kafka's metadata or the
+// empty string if it is not known.  The returned value corresponds to the
+// broker's broker.rack configuration setting.  Requires protocol version to be
+// at least v0.10.0.0.
+func (b *Broker) Rack() string {
+	if b.rack == nil {
+		return ""
+	}
+	return *b.rack
+}
+
 func (b *Broker) GetMetadata(request *MetadataRequest) (*MetadataResponse, error) {
 	response := new(MetadataResponse)
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -51,9 +51,19 @@ func TestBrokerAccessors(t *testing.T) {
 		t.Error("New broker didn't have the correct address")
 	}
 
+	if broker.Rack() != "" {
+		t.Error("New broker didn't have an unknown rack.")
+	}
+
 	broker.id = 34
 	if broker.ID() != 34 {
 		t.Error("Manually setting broker ID did not take effect.")
+	}
+
+	rack := "dc1"
+	broker.rack = &rack
+	if broker.Rack() != rack {
+		t.Error("Manually setting broker rack did not take effect.")
 	}
 }
 


### PR DESCRIPTION
This change enables library clients to use the sarama Client to implement
rack-aware features.