### PR TITLE
fix encoding of MetadataResponse with version >= 2

### DIFF
--- a/metadata_response.go
+++ b/metadata_response.go
@@ -207,6 +207,10 @@ func (r *MetadataResponse) decode(pd packetDecoder, version int16) (err error) {
 }
 
 func (r *MetadataResponse) encode(pe packetEncoder) error {
+	if r.Version >= 3 {
+		pe.putInt32(r.ThrottleTimeMs)
+	}
+
 	err := pe.putArrayLength(len(r.Brokers))
 	if err != nil {
 		return err
@@ -216,6 +220,10 @@ func (r *MetadataResponse) encode(pe packetEncoder) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if r.Version >= 2 {
+		pe.putNullableString(r.ClusterID)
 	}
 
 	if r.Version >= 1 {


### PR DESCRIPTION
ThrottleTimeMs and ClusterID have been added to decode(), but apparently
encode() was forgotten. This causes errors in tests, if versions >= 2 are used.