### PR TITLE
Reuse compression objects

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -1,0 +1,75 @@
+package sarama
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"sync"
+
+	"github.com/eapache/go-xerial-snappy"
+	"github.com/pierrec/lz4"
+)
+
+var (
+	lz4WriterPool = sync.Pool{
+		New: func() interface{} {
+			return lz4.NewWriter(nil)
+		},
+	}
+
+	gzipWriterPool = sync.Pool{
+		New: func() interface{} {
+			return gzip.NewWriter(nil)
+		},
+	}
+)
+
+func compress(cc CompressionCodec, level int, data []byte) ([]byte, error) {
+	switch cc {
+	case CompressionNone:
+		return data, nil
+	case CompressionGZIP:
+		var (
+			err    error
+			buf    bytes.Buffer
+			writer *gzip.Writer
+		)
+		if level != CompressionLevelDefault {
+			writer, err = gzip.NewWriterLevel(&buf, level)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			writer = gzipWriterPool.Get().(*gzip.Writer)
+			defer gzipWriterPool.Put(writer)
+			writer.Reset(&buf)
+		}
+		if _, err := writer.Write(data); err != nil {
+			return nil, err
+		}
+		if err := writer.Close(); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case CompressionSnappy:
+		return snappy.Encode(data), nil
+	case CompressionLZ4:
+		writer := lz4WriterPool.Get().(*lz4.Writer)
+		defer lz4WriterPool.Put(writer)
+
+		var buf bytes.Buffer
+		writer.Reset(&buf)
+
+		if _, err := writer.Write(data); err != nil {
+			return nil, err
+		}
+		if err := writer.Close(); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	case CompressionZSTD:
+		return zstdCompressLevel(nil, data, level)
+	default:
+		return nil, PacketEncodingError{fmt.Sprintf("unsupported compression codec (%d)", cc)}
+	}
+}

--- a/decompress.go
+++ b/decompress.go
@@ -1,0 +1,63 @@
+package sarama
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"sync"
+
+	"github.com/eapache/go-xerial-snappy"
+	"github.com/pierrec/lz4"
+)
+
+var (
+	lz4Pool = sync.Pool{
+		New: func() interface{} {
+			return lz4.NewReader(nil)
+		},
+	}
+
+	gzipPool sync.Pool
+)
+
+func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
+	switch cc {
+	case CompressionNone:
+		return data, nil
+	case CompressionGZIP:
+		var (
+			err        error
+			reader     *gzip.Reader
+			readerIntf = gzipPool.Get()
+		)
+		if readerIntf != nil {
+			reader = readerIntf.(*gzip.Reader)
+		} else {
+			reader, err = gzip.NewReader(bytes.NewReader(data))
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		defer gzipPool.Put(reader)
+
+		if err := reader.Reset(bytes.NewReader(data)); err != nil {
+			return nil, err
+		}
+
+		return ioutil.ReadAll(reader)
+	case CompressionSnappy:
+		return snappy.Decode(data)
+	case CompressionLZ4:
+		reader := lz4Pool.Get().(*lz4.Reader)
+		defer lz4Pool.Put(reader)
+
+		reader.Reset(bytes.NewReader(data))
+		return ioutil.ReadAll(reader)
+	case CompressionZSTD:
+		return zstdDecompress(nil, data)
+	default:
+		return nil, PacketDecodingError{fmt.Sprintf("invalid compression specified (%d)", cc)}
+	}
+}

--- a/decompress.go
+++ b/decompress.go
@@ -12,13 +12,13 @@ import (
 )
 
 var (
-	lz4Pool = sync.Pool{
+	lz4ReaderPool = sync.Pool{
 		New: func() interface{} {
 			return lz4.NewReader(nil)
 		},
 	}
 
-	gzipPool sync.Pool
+	gzipReaderPool sync.Pool
 )
 
 func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
@@ -29,7 +29,7 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 		var (
 			err        error
 			reader     *gzip.Reader
-			readerIntf = gzipPool.Get()
+			readerIntf = gzipReaderPool.Get()
 		)
 		if readerIntf != nil {
 			reader = readerIntf.(*gzip.Reader)
@@ -40,7 +40,7 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 			}
 		}
 
-		defer gzipPool.Put(reader)
+		defer gzipReaderPool.Put(reader)
 
 		if err := reader.Reset(bytes.NewReader(data)); err != nil {
 			return nil, err
@@ -50,8 +50,8 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 	case CompressionSnappy:
 		return snappy.Decode(data)
 	case CompressionLZ4:
-		reader := lz4Pool.Get().(*lz4.Reader)
-		defer lz4Pool.Put(reader)
+		reader := lz4ReaderPool.Get().(*lz4.Reader)
+		defer lz4ReaderPool.Put(reader)
 
 		reader.Reset(bytes.NewReader(data))
 		return ioutil.ReadAll(reader)


### PR DESCRIPTION
Reusing lz4/gzip reader and writer objects via sync.Pool greatly reduces CPU usage (saves allocations and creates much less garbage).