### PR TITLE
#1158 permits to disable offset autocommitment

### DIFF
--- a/config.go
+++ b/config.go
@@ -292,7 +292,7 @@ type Config struct {
 		// offsets. This currently requires the manual use of an OffsetManager
 		// but will eventually be automated.
 		Offsets struct {
-			// How frequently to commit updated offsets. Defaults to 1s.
+			// How frequently to commit updated offsets. Value 0 will disable autocommit offsets. Defaults to 1s.
 			CommitInterval time.Duration
 
 			// The initial offset to use if no offset was previously committed.
@@ -543,8 +543,8 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Consumer.MaxProcessingTime must be > 0")
 	case c.Consumer.Retry.Backoff < 0:
 		return ConfigurationError("Consumer.Retry.Backoff must be >= 0")
-	case c.Consumer.Offsets.CommitInterval <= 0:
-		return ConfigurationError("Consumer.Offsets.CommitInterval must be > 0")
+	case c.Consumer.Offsets.CommitInterval < 0:
+		return ConfigurationError("Consumer.Offsets.CommitInterval must be >= 0")
 	case c.Consumer.Offsets.Initial != OffsetOldest && c.Consumer.Offsets.Initial != OffsetNewest:
 		return ConfigurationError("Consumer.Offsets.Initial must be OffsetOldest or OffsetNewest")
 	case c.Consumer.Offsets.Retry.Max < 0:

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -58,7 +58,6 @@ func newOffsetManagerFromClient(group, memberID string, generation int32, client
 		client: client,
 		conf:   conf,
 		group:  group,
-		ticker: time.NewTicker(conf.Consumer.Offsets.CommitInterval),
 		poms:   make(map[string]map[int32]*partitionOffsetManager),
 
 		memberID:   memberID,
@@ -67,7 +66,10 @@ func newOffsetManagerFromClient(group, memberID string, generation int32, client
 		closing: make(chan none),
 		closed:  make(chan none),
 	}
-	go withRecover(om.mainLoop)
+	if conf.Consumer.Offsets.CommitInterval > 0 {
+		om.ticker = time.NewTicker(conf.Consumer.Offsets.CommitInterval)
+		go withRecover(om.mainLoop)
+	}
 
 	return om, nil
 }


### PR DESCRIPTION
If you want to be sure that your consumers doesn't take a same message in parallel at rebalance, you need to block the until the process of the message is done.

For that, configure a rebalance timeout  : `conf.Config.Consumer.Group.Rebalance.Timeout = 5 * time.Minute`
When you receive the message, mark offset : `consumer.MarkOffset(msg, "")`
When you finish your process for this message, commit offsets : `consumer.CommitOffsets()`

To avoid loosing message if your application reboot when your message is processing or this there is error in process, we don't want to commit before the process is done.

This workflow can work only if the autocommit is disabled. So with this new conf :
`conf.Consumer.Offsets.CommitInterval = 0`