### PR TITLE
Add support for Kafka 2.1.0 and fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 - make test
 - make vet
 - make errcheck
-- if [ "$TRAVIS_GO_VERSION" = "1.11" ]; then make fmt; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.11* ]]; then make fmt; fi
 
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.9.x
 - 1.10.x
 - 1.11.x
 
@@ -12,9 +11,9 @@ env:
   - KAFKA_HOSTNAME=localhost
   - DEBUG=true
   matrix:
-  - KAFKA_VERSION=1.0.0
-  - KAFKA_VERSION=1.1.0
-  - KAFKA_VERSION=2.0.0
+  - KAFKA_VERSION=1.1.1
+  - KAFKA_VERSION=2.0.1
+  - KAFKA_VERSION=2.1.0
 
 before_install:
 - export REPOSITORY_ROOT=${TRAVIS_BUILD_DIR}

--- a/utils.go
+++ b/utils.go
@@ -155,7 +155,9 @@ var (
 	V0_11_0_2 = newKafkaVersion(0, 11, 0, 2)
 	V1_0_0_0  = newKafkaVersion(1, 0, 0, 0)
 	V1_1_0_0  = newKafkaVersion(1, 1, 0, 0)
+	V1_1_1_0  = newKafkaVersion(1, 1, 1, 0)
 	V2_0_0_0  = newKafkaVersion(2, 0, 0, 0)
+	V2_0_1_0  = newKafkaVersion(2, 0, 1, 0)
 	V2_1_0_0  = newKafkaVersion(2, 1, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
@@ -175,7 +177,9 @@ var (
 		V0_11_0_2,
 		V1_0_0_0,
 		V1_1_0_0,
+		V1_1_1_0,
 		V2_0_0_0,
+		V2_0_1_0,
 		V2_1_0_0,
 	}
 	MinVersion = V0_8_2_0
@@ -210,7 +214,7 @@ func scanKafkaVersion(s string, pattern string, format string, v [3]*uint) error
 func (v KafkaVersion) String() string {
 	if v.version[0] == 0 {
 		return fmt.Sprintf("0.%d.%d.%d", v.version[1], v.version[2], v.version[3])
-	} else {
-		return fmt.Sprintf("%d.%d.%d", v.version[0], v.version[1], v.version[2])
 	}
+
+	return fmt.Sprintf("%d.%d.%d", v.version[0], v.version[1], v.version[2])
 }

--- a/utils.go
+++ b/utils.go
@@ -156,6 +156,7 @@ var (
 	V1_0_0_0  = newKafkaVersion(1, 0, 0, 0)
 	V1_1_0_0  = newKafkaVersion(1, 1, 0, 0)
 	V2_0_0_0  = newKafkaVersion(2, 0, 0, 0)
+	V2_1_0_0  = newKafkaVersion(2, 1, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -175,9 +176,10 @@ var (
 		V1_0_0_0,
 		V1_1_0_0,
 		V2_0_0_0,
+		V2_1_0_0,
 	}
 	MinVersion = V0_8_2_0
-	MaxVersion = V2_0_0_0
+	MaxVersion = V2_1_0_0
 )
 
 func ParseKafkaVersion(s string) (KafkaVersion, error) {

--- a/vagrant/install_cluster.sh
+++ b/vagrant/install_cluster.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-TOXIPROXY_VERSION=2.0.0
+TOXIPROXY_VERSION=2.1.3
 
 mkdir -p ${KAFKA_INSTALL_ROOT}
 if [ ! -f ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz ]; then
-    wget --quiet http://apache.mirror.gtcomm.net/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz -O ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz
+    wget --quiet https://www-us.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz -O ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz
 fi
 if [ ! -f ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION} ]; then
     wget --quiet https://github.com/Shopify/toxiproxy/releases/download/v${TOXIPROXY_VERSION}/toxiproxy-server-linux-amd64 -O ${KAFKA_INSTALL_ROOT}/toxiproxy-${TOXIPROXY_VERSION}


### PR DESCRIPTION
Old download URLs for kafka return 404 so I updated them with a new mirror. 

Also fix `make fmt` condition to match all patch versions of Golang—instead of only matching 1.11.0 (`make fmt` would never run since we're already on 1.11.2).

Last but not least, add new version definitions and support for recently released Kafka 2.1.0.

@varun06 @muirrn could you please 👀this PR?