### PR TITLE
Implement SASL/OAUTHBEARER support

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -936,7 +936,7 @@ func (b *Broker) sendAndReceiveSASLOAuth(tokenProvider AccessTokenProvider, exte
 }
 
 // Build SASL/OAUTHBEARER initial client response as described by RFC-7628
-// https://tools.ietf.org/html/rfc7628.
+// https://tools.ietf.org/html/rfc7628
 func buildClientInitialResponse(bearerToken string, extensions map[string]string) ([]byte, error) {
 
 	if _, ok := extensions[SASLExtKeyAuth]; ok {

--- a/broker.go
+++ b/broker.go
@@ -959,15 +959,13 @@ func (b *Broker) sendSASLOAuthBearerClientResponse(bearerToken string) (int, err
 
 func (b *Broker) receiveSASLOAuthBearerServerResponse() (int, error) {
 
-	var (
-		bytesRead      int
-		err            error
-		totalBytesRead int
-	)
+	var totalBytesRead int
 
 	header := make([]byte, 8)
 
-	if bytesRead, err = io.ReadFull(b.conn, header); err != nil {
+	bytesRead, err := io.ReadFull(b.conn, header)
+
+	if err != nil {
 		return 0, err
 	}
 
@@ -976,7 +974,9 @@ func (b *Broker) receiveSASLOAuthBearerServerResponse() (int, error) {
 	length := binary.BigEndian.Uint32(header[:4])
 	payload := make([]byte, length-4)
 
-	if bytesRead, err = io.ReadFull(b.conn, payload); err != nil {
+	bytesRead, err = io.ReadFull(b.conn, payload)
+
+	if err != nil {
 		return bytesRead, err
 	}
 

--- a/broker.go
+++ b/broker.go
@@ -915,8 +915,6 @@ func (b *Broker) sendAndReceiveSASLOAuth(tokenProvider AccessTokenProvider) erro
 		return err
 	}
 
-	Logger.Printf("Correlation ID %d ", b.correlationID)
-
 	b.updateOutgoingCommunicationMetrics(bytesWritten)
 
 	b.correlationID++
@@ -997,6 +995,10 @@ func (b *Broker) receiveSASLOAuthBearerServerResponse(correlationID int32) (int,
 	res := &SaslAuthenticateResponse{}
 
 	if err := versionedDecode(buf, res, 0); err != nil {
+		return bytesRead, err
+	}
+
+	if err != nil {
 		return bytesRead, err
 	}
 

--- a/broker.go
+++ b/broker.go
@@ -937,7 +937,7 @@ func (b *Broker) sendAndReceiveSASLOAuth(tokenProvider AccessTokenProvider, exte
 }
 
 // Build SASL/OAUTHBEARER initial client response as described by RFC-7628
-// https://tools.ietf.org/html/rfc7628
+// https://tools.ietf.org/html/rfc7628.
 func buildClientInitialResponse(bearerToken string, extensions map[string]string) ([]byte, error) {
 
 	if _, ok := extensions[SASLExtKeyAuth]; ok {

--- a/broker.go
+++ b/broker.go
@@ -944,9 +944,13 @@ func buildClientInitialResponse(bearerToken string, extensions map[string]string
 		return []byte{}, fmt.Errorf("The extension `%s` is invalid", SASLExtKeyAuth)
 	}
 
-	extensions[SASLExtKeyAuth] = "Bearer " + bearerToken
+	ext := ""
 
-	resp := []byte(fmt.Sprintf("n,,\x01%s\x01\x01", mapToString(extensions, "=", "\x01")))
+	if len(extensions) > 0 {
+		ext = "\x01" + mapToString(extensions, "=", "\x01")
+	}
+
+	resp := []byte(fmt.Sprintf("n,,\x01auth=Bearer %s%s\x01\x01", bearerToken, ext))
 
 	return resp, nil
 }

--- a/broker.go
+++ b/broker.go
@@ -998,11 +998,7 @@ func (b *Broker) sendSASLOAuthBearerClientResponse(bearerToken string, extension
 
 	bytesWritten, err := b.conn.Write(buf)
 
-	if err != nil {
-		return 0, err
-	}
-
-	return bytesWritten, nil
+	return bytesWritten, err
 }
 
 func (b *Broker) receiveSASLOAuthBearerServerResponse(correlationID int32) (int, error) {

--- a/broker.go
+++ b/broker.go
@@ -933,7 +933,7 @@ func (b *Broker) sendAndReceiveSASLOAuth(tokenProvider AccessTokenProvider) erro
 
 func (b *Broker) sendSASLOAuthBearerClientResponse(bearerToken string, correlationID int32) (int, error) {
 
-	// Initial client response as described by RFC-7628
+	// Initial client response as described by RFC-7628.
 	// https://tools.ietf.org/html/rfc7628
 	oauthRequest := []byte(fmt.Sprintf("n,,\x01auth=Bearer %s\x01\x01", bearerToken))
 

--- a/broker.go
+++ b/broker.go
@@ -62,10 +62,10 @@ const (
 	SASLHandshakeV1 = int16(1)
 )
 
-// OAuthBearerTokenProvider is the interface that encapsulates how implementors
-// can generate bearer tokens sent to Kafka brokers for authentication.
-type OAuthBearerTokenProvider interface {
-	// Token returns a bearer token. Because this method may be called multiple
+// AccessTokenProvider is the interface that encapsulates how implementors
+// can generate access tokens for Kafka broker authentication.
+type AccessTokenProvider interface {
+	// Token returns an access token. Because this method may be called multiple
 	// times, each invocation returns a new, unexpired token. This method should
 	// not block indefinitely. A timeout error should be returned after a short
 	// period of inactivity so that the broker connection logic can log
@@ -892,7 +892,7 @@ func (b *Broker) sendAndReceiveSASLPlainAuth() error {
 
 // sendAndReceiveSASLOAuth performs the authentication flow as described by KIP-255
 // https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876
-func (b *Broker) sendAndReceiveSASLOAuth(tokenProvider OAuthBearerTokenProvider) error {
+func (b *Broker) sendAndReceiveSASLOAuth(tokenProvider AccessTokenProvider) error {
 
 	if err := b.sendAndReceiveSASLHandshake(SASLTypeOAuth, SASLHandshakeV1); err != nil {
 		return err

--- a/broker.go
+++ b/broker.go
@@ -66,8 +66,10 @@ const (
 // can generate bearer tokens sent to Kafka brokers for authentication.
 type OAuthBearerTokenProvider interface {
 	// Token returns a bearer token. Because this method may be called multiple
-	// times, the implementor must ensure that each invocation returns a new,
-	// unexpired token.
+	// times, each invocation returns a new, unexpired token. This method should
+	// not block indefinitely. A timeout error should be returned after a short
+	// period of inactivity so that the broker connection logic can log
+	// debugging information and retry.
 	Token() (string, error)
 }
 

--- a/broker.go
+++ b/broker.go
@@ -1052,6 +1052,10 @@ func (b *Broker) receiveSASLOAuthBearerServerResponse(correlationID int32) (int,
 		return bytesRead, res.Err
 	}
 
+	if len(res.SaslAuthBytes) > 0 {
+		Logger.Printf("Received SASL auth response: %s", res.SaslAuthBytes)
+	}
+
 	return bytesRead, nil
 }
 

--- a/broker.go
+++ b/broker.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -780,14 +779,10 @@ func (b *Broker) responseReceiver() {
 }
 
 func (b *Broker) authenticateViaSASL() error {
-	switch b.conf.Net.SASL.Mechanism {
-	case SASLTypeOAuth:
+	if b.conf.Net.SASL.Mechanism == SASLTypeOAuth {
 		return b.sendAndReceiveSASLOAuth(b.conf.Net.SASL.TokenProvider, b.conf.Net.SASL.Extensions)
-	case SASLTypePlaintext:
-		return b.sendAndReceiveSASLPlainAuth()
-	default:
-		return b.sendAndReceiveSASLPlainAuth()
 	}
+	return b.sendAndReceiveSASLPlainAuth()
 }
 
 func (b *Broker) sendAndReceiveSASLHandshake(saslType string, version int16) error {
@@ -1020,7 +1015,7 @@ func (b *Broker) receiveSASLOAuthBearerServerResponse(correlationID int32) (int,
 	}
 
 	if header.correlationID != correlationID {
-		return bytesRead, errors.Errorf("correlation ID didn't match, wanted %d, got %d", b.correlationID, header.correlationID)
+		return bytesRead, fmt.Errorf("correlation ID didn't match, wanted %d, got %d", b.correlationID, header.correlationID)
 	}
 
 	buf = make([]byte, header.length-4)

--- a/broker.go
+++ b/broker.go
@@ -953,7 +953,7 @@ func (b *Broker) sendAndReceiveSASLOAuth(provider AccessTokenProvider) error {
 // https://tools.ietf.org/html/rfc7628
 func buildClientInitialResponse(token *AccessToken) ([]byte, error) {
 
-	ext := ""
+	var ext string
 
 	if token.Extensions != nil && len(token.Extensions) > 0 {
 		if _, ok := token.Extensions[SASLExtKeyAuth]; ok {
@@ -1004,9 +1004,7 @@ func (b *Broker) sendSASLOAuthBearerClientResponse(token *AccessToken, correlati
 		return 0, err
 	}
 
-	bytesWritten, err := b.conn.Write(buf)
-
-	return bytesWritten, err
+	return b.conn.Write(buf)
 }
 
 func (b *Broker) receiveSASLOAuthBearerServerResponse(correlationID int32) (int, error) {

--- a/broker.go
+++ b/broker.go
@@ -932,7 +932,6 @@ func (b *Broker) sendSASLOAuthBearerClientResponse(bearerToken string) (int, err
 
 	// Initial client response as described by RFC-7628
 	// https://tools.ietf.org/html/rfc7628
-
 	oauthRequest := []byte(fmt.Sprintf("n,,\x01auth=Bearer %s\x01\x01", bearerToken))
 
 	rb := &SaslAuthenticateRequest{oauthRequest}

--- a/broker.go
+++ b/broker.go
@@ -74,18 +74,21 @@ type AccessToken struct {
 	Token string
 	// Extensions is a optional map of arbitrary key-value pairs that can be
 	// sent with the SASL/OAUTHBEARER initial client response. These values are
-	// ignored by the SASL server if they are unexpected.
+	// ignored by the SASL server if they are unexpected. This feature is only
+	// supported by Kafka >= 2.1.0.
 	Extensions map[string]string
 }
 
 // AccessTokenProvider is the interface that encapsulates how implementors
 // can generate access tokens for Kafka broker authentication.
 type AccessTokenProvider interface {
-	// Token returns an access token. Because this method may be called multiple
-	// times, each invocation returns a new, unexpired token. This method should
-	// not block indefinitely. A timeout error should be returned after a short
-	// period of inactivity so that the broker connection logic can log
-	// debugging information and retry.
+	// Token returns an access token. The implementation should ensure token
+	// reuse so that multiple calls at connect time do not create multiple
+	// tokens. The implementation should also periodically refresh the token in
+	// order to guarantee that each call returns an unexpired token.  This
+	// method should not block indefinitely--a timeout error should be returned
+	// after a short period of inactivity so that the broker connection logic
+	// can log debugging information and retry.
 	Token() (*AccessToken, error)
 }
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -177,7 +177,8 @@ func TestSASLOAuthBearer(t *testing.T) {
 		// mockBroker mocks underlying network logic and broker responses
 		mockBroker := NewMockBroker(t, 0)
 
-		mockSASLAuthResponse := NewMockSaslAuthenticateResponse(t)
+		mockSASLAuthResponse := NewMockSaslAuthenticateResponse(t).
+			SetAuthBytes([]byte(`response_payload`))
 
 		if test.mockAuthErr != ErrNoError {
 			mockSASLAuthResponse = mockSASLAuthResponse.SetError(test.mockAuthErr)

--- a/broker_test.go
+++ b/broker_test.go
@@ -150,12 +150,20 @@ func TestReceiveSASLOAuthBearerServerResponse(t *testing.T) {
 
 		in, out := net.Pipe()
 
-		defer out.Close()
+		defer func() {
+			if err := out.Close(); err != nil {
+				t.Error(err)
+			}
+		}()
 
 		b := &Broker{conn: out}
 
 		go func() {
-			defer in.Close()
+			defer func() {
+				if err := in.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
 			if _, err := in.Write(test.buf); err != nil {
 				t.Error(err)
 			}

--- a/broker_test.go
+++ b/broker_test.go
@@ -146,7 +146,7 @@ func TestReceiveSASLOAuthBearerServerResponse(t *testing.T) {
 			io.ErrUnexpectedEOF},
 	}
 
-	for _, test := range testTable {
+	for i, test := range testTable {
 
 		in, out := net.Pipe()
 
@@ -172,11 +172,11 @@ func TestReceiveSASLOAuthBearerServerResponse(t *testing.T) {
 		bytesRead, err := b.receiveSASLOAuthBearerServerResponse(0)
 
 		if len(test.buf) != bytesRead {
-			t.Errorf("[%s] Expected %d bytes read, got %d", test.name, len(test.buf), bytesRead)
+			t.Errorf("[%d]:[%s] Expected %d bytes read, got %d\n", i, test.name, len(test.buf), bytesRead)
 		}
 
 		if test.err != err {
-			t.Errorf("[%s] Expected error %s, got %s", test.name, test.err, err)
+			t.Errorf("[%d]:[%s] Expected %s error, got %s\n", i, test.name, test.err, err)
 		}
 	}
 }

--- a/broker_test.go
+++ b/broker_test.go
@@ -177,6 +177,9 @@ func TestReceiveSASLOAuthBearerClientResponse(t *testing.T) {
 		broker.requestLatency = metrics.NilHistogram{}
 
 		conf := NewConfig()
+		conf.Net.SASL.Mechanism = SASLTypeOAuth
+		conf.Net.SASL.TokenProvider = test.tokProvider
+
 		broker.conf = conf
 
 		dialer := net.Dialer{
@@ -193,7 +196,7 @@ func TestReceiveSASLOAuthBearerClientResponse(t *testing.T) {
 
 		broker.conn = conn
 
-		err = broker.sendAndReceiveSASLOAuth(test.tokProvider, make(map[string]string))
+		err = broker.authenticateViaSASL()
 
 		if test.err != err {
 			t.Errorf("[%d]:[%s] Expected %s error, got %s\n", i, test.name, test.err, err)

--- a/broker_test.go
+++ b/broker_test.go
@@ -137,35 +137,37 @@ func TestSASLOAuthBearer(t *testing.T) {
 		expectClientErr  bool   // Expect an internal client-side error
 		tokProvider      *TokenProvider
 	}{
-		{"SASL/OAUTHBEARER OK server response",
-			ErrNoError,
-			ErrNoError,
-			false,
-			newTokenProvider(&AccessToken{Token: "access-token-123"}, nil),
+		{
+			name:             "SASL/OAUTHBEARER OK server response",
+			mockAuthErr:      ErrNoError,
+			mockHandshakeErr: ErrNoError,
+			tokProvider:      newTokenProvider(&AccessToken{Token: "access-token-123"}, nil),
 		},
-		{"SASL/OAUTHBEARER authentication failure response",
-			ErrSASLAuthenticationFailed,
-			ErrNoError,
-			false,
-			newTokenProvider(&AccessToken{Token: "access-token-123"}, nil),
+		{
+			name:             "SASL/OAUTHBEARER authentication failure response",
+			mockAuthErr:      ErrSASLAuthenticationFailed,
+			mockHandshakeErr: ErrNoError,
+			tokProvider:      newTokenProvider(&AccessToken{Token: "access-token-123"}, nil),
 		},
-		{"SASL/OAUTHBEARER handshake failure response",
-			ErrNoError,
-			ErrSASLAuthenticationFailed,
-			false,
-			newTokenProvider(&AccessToken{Token: "access-token-123"}, nil),
+		{
+			name:             "SASL/OAUTHBEARER handshake failure response",
+			mockAuthErr:      ErrNoError,
+			mockHandshakeErr: ErrSASLAuthenticationFailed,
+			tokProvider:      newTokenProvider(&AccessToken{Token: "access-token-123"}, nil),
 		},
-		{"SASL/OAUTHBEARER token generation error",
-			ErrNoError,
-			ErrNoError,
-			true,
-			newTokenProvider(&AccessToken{Token: "access-token-123"}, ErrTokenFailure),
+		{
+			name:             "SASL/OAUTHBEARER token generation error",
+			mockAuthErr:      ErrNoError,
+			mockHandshakeErr: ErrNoError,
+			expectClientErr:  true,
+			tokProvider:      newTokenProvider(&AccessToken{Token: "access-token-123"}, ErrTokenFailure),
 		},
-		{"SASL/OAUTHBEARER invalid extension",
-			ErrNoError,
-			ErrNoError,
-			true,
-			newTokenProvider(&AccessToken{
+		{
+			name:             "SASL/OAUTHBEARER invalid extension",
+			mockAuthErr:      ErrNoError,
+			mockHandshakeErr: ErrNoError,
+			expectClientErr:  true,
+			tokProvider: newTokenProvider(&AccessToken{
 				Token:      "access-token-123",
 				Extensions: map[string]string{"auth": "auth-value"},
 			}, nil),
@@ -255,33 +257,31 @@ func TestBuildClientInitialResponse(t *testing.T) {
 		expectError bool
 	}{
 		{
-			"Build SASL client initial response with two extensions",
-			&AccessToken{
+			name: "Build SASL client initial response with two extensions",
+			token: &AccessToken{
 				Token: "the-token",
 				Extensions: map[string]string{
 					"x": "1",
 					"y": "2",
 				},
 			},
-			[]byte("n,,\x01auth=Bearer the-token\x01x=1\x01y=2\x01\x01"),
-			false,
+			expected: []byte("n,,\x01auth=Bearer the-token\x01x=1\x01y=2\x01\x01"),
 		},
 		{
-			"Build SASL client initial response with no extensions",
-			&AccessToken{Token: "the-token"},
-			[]byte("n,,\x01auth=Bearer the-token\x01\x01"),
-			false,
+			name:     "Build SASL client initial response with no extensions",
+			token:    &AccessToken{Token: "the-token"},
+			expected: []byte("n,,\x01auth=Bearer the-token\x01\x01"),
 		},
 		{
-			"Build SASL client initial response using reserved extension",
-			&AccessToken{
+			name: "Build SASL client initial response using reserved extension",
+			token: &AccessToken{
 				Token: "the-token",
 				Extensions: map[string]string{
 					"auth": "auth-value",
 				},
 			},
-			[]byte(""),
-			true,
+			expected:    []byte(""),
+			expectError: true,
 		},
 	}
 

--- a/config.go
+++ b/config.go
@@ -64,10 +64,9 @@ type Config struct {
 			//username and password for SASL/PLAIN authentication
 			User     string
 			Password string
-			// TokenProvider is a bearer token generator for the OAUTHBEARER
-			// flow. You can define an instance of OAuthBearerTokenProvider
-			// that generates authentication tokens according to your Kafka
-			// cluster's configuration.
+			// TokenProvider is a user-defined callback for generating
+			// authentication tokens. See the OAuthBearerTokenProvider docs
+			// for proper implementation guidelines.
 			TokenProvider OAuthBearerTokenProvider
 		}
 

--- a/config.go
+++ b/config.go
@@ -476,9 +476,6 @@ func (c *Config) Validate() error {
 			if c.Net.SASL.TokenProvider == nil {
 				return ConfigurationError("An AccessTokenProvider instance must be provided to Net.SASL.User.TokenProvider")
 			}
-			if !c.Net.SASL.Handshake {
-				Logger.Println("A SASL handshake is required for SASL/OAUTHBEARER, ignoring disabled handshake config")
-			}
 		} else {
 			msg := fmt.Sprintf("The SASL mechanism configuration is invalid. Possible values are `%s` and `%s`",
 				SASLTypeOAuth, SASLTypePlaintext)

--- a/config.go
+++ b/config.go
@@ -54,8 +54,9 @@ type Config struct {
 			// Whether or not to use SASL authentication when connecting to the broker
 			// (defaults to false).
 			Enable bool
-			// The type of SASL mechanism to enable. Possible values: OAUTHBEARER, PLAIN (defaults to PLAIN)
-			Mechanism SaslMechanism
+			// SASLMechanism is the name of the enabled SASL mechanism.
+			// Possible values: OAUTHBEARER, PLAIN (defaults to PLAIN).
+			Mechanism SASLMechanism
 			// Whether or not to send the Kafka SASL handshake first if enabled
 			// (defaults to true). You should only set this to false if you're using
 			// a non-Kafka SASL proxy.
@@ -63,9 +64,10 @@ type Config struct {
 			//username and password for SASL/PLAIN authentication
 			User     string
 			Password string
-			// TokenProvider is a bearer token generator for the OAUTHBEARER flow. You can define an instance of
-			// OAuthBearerTokenProvider that generates authentication tokens according to your Kafka cluster's
-			// configuration.
+			// TokenProvider is a bearer token generator for the OAUTHBEARER
+			// flow. You can define an instance of OAuthBearerTokenProvider
+			// that generates authentication tokens according to your Kafka
+			// cluster's configuration.
 			TokenProvider OAuthBearerTokenProvider
 		}
 
@@ -460,26 +462,26 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Net.WriteTimeout must be > 0")
 	case c.Net.KeepAlive < 0:
 		return ConfigurationError("Net.KeepAlive must be >= 0")
-	case c.Net.SASL.Enable == true:
+	case c.Net.SASL.Enable:
 		// For backwards compatibility, empty mechanism value defaults to PLAIN
-		isSaslPlain := len(c.Net.SASL.Mechanism) == 0 || c.Net.SASL.Mechanism == SaslTypePlaintext
-		if isSaslPlain {
+		isSASLPlain := len(c.Net.SASL.Mechanism) == 0 || c.Net.SASL.Mechanism == SASLTypePlaintext
+		if isSASLPlain {
 			if c.Net.SASL.User == "" {
 				return ConfigurationError("Net.SASL.User must not be empty when SASL is enabled")
 			}
 			if c.Net.SASL.Password == "" {
 				return ConfigurationError("Net.SASL.Password must not be empty when SASL is enabled")
 			}
-		} else if c.Net.SASL.Mechanism == SaslTypeOAuth {
+		} else if c.Net.SASL.Mechanism == SASLTypeOAuth {
 			if c.Net.SASL.TokenProvider == nil {
 				return ConfigurationError("A OAuthBearerTokenProvider instance must be provided to Net.SASL.User.TokenProvider")
 			}
 			if !c.Net.SASL.Handshake {
-				Logger.Println("A SASL hanshake is required for SASL/OAUTHBEARER, ignoring disabled handshake config")
+				Logger.Println("A SASL handshake is required for SASL/OAUTHBEARER, ignoring disabled handshake config")
 			}
 		} else {
 			msg := fmt.Sprintf("The SASL mechanism configuration is invalid. Possible values are `%s` and `%s`",
-				SaslTypeOAuth, SaslTypePlaintext)
+				SASLTypeOAuth, SASLTypePlaintext)
 			return ConfigurationError(msg)
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -474,7 +474,7 @@ func (c *Config) Validate() error {
 			}
 		} else if c.Net.SASL.Mechanism == SASLTypeOAuth {
 			if c.Net.SASL.TokenProvider == nil {
-				return ConfigurationError("A AccessTokenProvider instance must be provided to Net.SASL.User.TokenProvider")
+				return ConfigurationError("An AccessTokenProvider instance must be provided to Net.SASL.User.TokenProvider")
 			}
 			if !c.Net.SASL.Handshake {
 				Logger.Println("A SASL handshake is required for SASL/OAUTHBEARER, ignoring disabled handshake config")

--- a/config.go
+++ b/config.go
@@ -65,9 +65,10 @@ type Config struct {
 			User     string
 			Password string
 			// TokenProvider is a user-defined callback for generating
-			// authentication tokens. See the OAuthBearerTokenProvider docs
-			// for proper implementation guidelines.
-			TokenProvider OAuthBearerTokenProvider
+			// access tokens for SASL/OAUTHBEARER auth. See the
+			// AccessTokenProvider interface docs for proper implementation
+			// guidelines.
+			TokenProvider AccessTokenProvider
 		}
 
 		// KeepAlive specifies the keep-alive period for an active network connection.
@@ -473,7 +474,7 @@ func (c *Config) Validate() error {
 			}
 		} else if c.Net.SASL.Mechanism == SASLTypeOAuth {
 			if c.Net.SASL.TokenProvider == nil {
-				return ConfigurationError("A OAuthBearerTokenProvider instance must be provided to Net.SASL.User.TokenProvider")
+				return ConfigurationError("A AccessTokenProvider instance must be provided to Net.SASL.User.TokenProvider")
 			}
 			if !c.Net.SASL.Handshake {
 				Logger.Println("A SASL handshake is required for SASL/OAUTHBEARER, ignoring disabled handshake config")

--- a/config.go
+++ b/config.go
@@ -69,6 +69,11 @@ type Config struct {
 			// AccessTokenProvider interface docs for proper implementation
 			// guidelines.
 			TokenProvider AccessTokenProvider
+			// Extensions is a optional map of arbitrary key-value pairs that
+			// can be sent with the SASL/OAUTHBEARER initial client response.
+			// These values are ignored by the SASL server if they are
+			// unexpected.
+			Extensions map[string]string
 		}
 
 		// KeepAlive specifies the keep-alive period for an active network connection.
@@ -358,6 +363,7 @@ func NewConfig() *Config {
 	c.Net.ReadTimeout = 30 * time.Second
 	c.Net.WriteTimeout = 30 * time.Second
 	c.Net.SASL.Handshake = true
+	c.Net.SASL.Extensions = make(map[string]string)
 
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond

--- a/config.go
+++ b/config.go
@@ -69,11 +69,6 @@ type Config struct {
 			// AccessTokenProvider interface docs for proper implementation
 			// guidelines.
 			TokenProvider AccessTokenProvider
-			// Extensions is a optional map of arbitrary key-value pairs that
-			// can be sent with the SASL/OAUTHBEARER initial client response.
-			// These values are ignored by the SASL server if they are
-			// unexpected.
-			Extensions map[string]string
 		}
 
 		// KeepAlive specifies the keep-alive period for an active network connection.
@@ -363,7 +358,6 @@ func NewConfig() *Config {
 	c.Net.ReadTimeout = 30 * time.Second
 	c.Net.WriteTimeout = 30 * time.Second
 	c.Net.SASL.Handshake = true
-	c.Net.SASL.Extensions = make(map[string]string)
 
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond

--- a/config_test.go
+++ b/config_test.go
@@ -36,8 +36,8 @@ func TestEmptyClientIDConfigValidates(t *testing.T) {
 type DummyTokenProvider struct {
 }
 
-func (t *DummyTokenProvider) Token() (string, error) {
-	return "access-token-string", nil
+func (t *DummyTokenProvider) Token() (*AccessToken, error) {
+	return &AccessToken{Token: "access-token-string"}, nil
 }
 
 func TestNetConfigValidates(t *testing.T) {

--- a/config_test.go
+++ b/config_test.go
@@ -33,6 +33,13 @@ func TestEmptyClientIDConfigValidates(t *testing.T) {
 	}
 }
 
+type DummyTokenProvider struct {
+}
+
+func (t *DummyTokenProvider) Token() (string, error) {
+	return "access-token-string", nil
+}
+
 func TestNetConfigValidates(t *testing.T) {
 	tests := []struct {
 		name string
@@ -78,6 +85,20 @@ func TestNetConfigValidates(t *testing.T) {
 				cfg.Net.SASL.Password = ""
 			},
 			"Net.SASL.Password must not be empty when SASL is enabled"},
+		{"SASL.Mechanism - Invalid mechanism type",
+			func(cfg *Config) {
+				cfg.Net.SASL.Enable = true
+				cfg.Net.SASL.Mechanism = "AnIncorrectSASLMechanism"
+				cfg.Net.SASL.TokenProvider = &DummyTokenProvider{}
+			},
+			"The SASL mechanism configuration is invalid. Possible values are `OAUTHBEARER` and `PLAIN`"},
+		{"SASL.Mechanism.OAUTHBEARER - Missing token provider",
+			func(cfg *Config) {
+				cfg.Net.SASL.Enable = true
+				cfg.Net.SASL.Mechanism = SASLTypeOAuth
+				cfg.Net.SASL.TokenProvider = nil
+			},
+			"An AccessTokenProvider instance must be provided to Net.SASL.User.TokenProvider"},
 	}
 
 	for i, test := range tests {

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -707,8 +707,9 @@ func (mr *MockListAclsResponse) For(reqBody versionedDecoder) encoder {
 }
 
 type MockSaslAuthenticateResponse struct {
-	t      TestReporter
-	kerror KError
+	t             TestReporter
+	kerror        KError
+	saslAuthBytes []byte
 }
 
 func NewMockSaslAuthenticateResponse(t TestReporter) *MockSaslAuthenticateResponse {
@@ -718,11 +719,17 @@ func NewMockSaslAuthenticateResponse(t TestReporter) *MockSaslAuthenticateRespon
 func (msar *MockSaslAuthenticateResponse) For(reqBody versionedDecoder) encoder {
 	res := &SaslAuthenticateResponse{}
 	res.Err = msar.kerror
+	res.SaslAuthBytes = msar.saslAuthBytes
 	return res
 }
 
 func (msar *MockSaslAuthenticateResponse) SetError(kerror KError) *MockSaslAuthenticateResponse {
 	msar.kerror = kerror
+	return msar
+}
+
+func (msar *MockSaslAuthenticateResponse) SetAuthBytes(saslAuthBytes []byte) *MockSaslAuthenticateResponse {
+	msar.saslAuthBytes = saslAuthBytes
 	return msar
 }
 

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -747,6 +747,11 @@ func (mshr *MockSaslHandshakeResponse) For(reqBody versionedDecoder) encoder {
 	return res
 }
 
+func (mshr *MockSaslHandshakeResponse) SetError(kerror KError) *MockSaslHandshakeResponse {
+	mshr.kerror = kerror
+	return mshr
+}
+
 func (mshr *MockSaslHandshakeResponse) SetEnabledMechanisms(enabledMechanisms []string) *MockSaslHandshakeResponse {
 	mshr.enabledMechanisms = enabledMechanisms
 	return mshr

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -706,8 +706,50 @@ func (mr *MockListAclsResponse) For(reqBody versionedDecoder) encoder {
 	return res
 }
 
+type MockSaslAuthenticateResponse struct {
+	t      TestReporter
+	kerror KError
+}
+
+func NewMockSaslAuthenticateResponse(t TestReporter) *MockSaslAuthenticateResponse {
+	return &MockSaslAuthenticateResponse{t: t}
+}
+
+func (msar *MockSaslAuthenticateResponse) For(reqBody versionedDecoder) encoder {
+	res := &SaslAuthenticateResponse{}
+	res.Err = msar.kerror
+	return res
+}
+
+func (msar *MockSaslAuthenticateResponse) SetError(kerror KError) *MockSaslAuthenticateResponse {
+	msar.kerror = kerror
+	return msar
+}
+
 type MockDeleteAclsResponse struct {
 	t TestReporter
+}
+
+type MockSaslHandshakeResponse struct {
+	enabledMechanisms []string
+	kerror            KError
+	t                 TestReporter
+}
+
+func NewMockSaslHandshakeResponse(t TestReporter) *MockSaslHandshakeResponse {
+	return &MockSaslHandshakeResponse{t: t}
+}
+
+func (mshr *MockSaslHandshakeResponse) For(reqBody versionedDecoder) encoder {
+	res := &SaslHandshakeResponse{}
+	res.Err = mshr.kerror
+	res.EnabledMechanisms = mshr.enabledMechanisms
+	return res
+}
+
+func (mshr *MockSaslHandshakeResponse) SetEnabledMechanisms(enabledMechanisms []string) *MockSaslHandshakeResponse {
+	mshr.enabledMechanisms = enabledMechanisms
+	return mshr
 }
 
 func NewMockDeleteAclsResponse(t TestReporter) *MockDeleteAclsResponse {

--- a/request.go
+++ b/request.go
@@ -140,6 +140,8 @@ func allocateBody(key, version int16) protocolBody {
 		return &DescribeConfigsRequest{}
 	case 33:
 		return &AlterConfigsRequest{}
+	case 36:
+		return &SaslAuthenticateRequest{}
 	case 37:
 		return &CreatePartitionsRequest{}
 	case 42:

--- a/sasl_authenticate_request.go
+++ b/sasl_authenticate_request.go
@@ -4,6 +4,9 @@ type SaslAuthenticateRequest struct {
 	SaslAuthBytes []byte
 }
 
+// APIKeySASLAuth is the API key for the SaslAuthenticate Kafka API
+const APIKeySASLAuth = 36
+
 func (r *SaslAuthenticateRequest) encode(pe packetEncoder) error {
 	if err := pe.putBytes(r.SaslAuthBytes); err != nil {
 		return err
@@ -21,7 +24,7 @@ func (r *SaslAuthenticateRequest) decode(pd packetDecoder, version int16) (err e
 }
 
 func (r *SaslAuthenticateRequest) key() int16 {
-	return 36
+	return APIKeySASLAuth
 }
 
 func (r *SaslAuthenticateRequest) version() int16 {

--- a/sasl_authenticate_request.go
+++ b/sasl_authenticate_request.go
@@ -1,0 +1,33 @@
+package sarama
+
+type SaslAuthenticateRequest struct {
+	SaslAuthBytes []byte
+}
+
+func (r *SaslAuthenticateRequest) encode(pe packetEncoder) error {
+	if err := pe.putBytes(r.SaslAuthBytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *SaslAuthenticateRequest) decode(pd packetDecoder, version int16) (err error) {
+	if r.SaslAuthBytes, err = pd.getBytes(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *SaslAuthenticateRequest) key() int16 {
+	return 36
+}
+
+func (r *SaslAuthenticateRequest) version() int16 {
+	return 0
+}
+
+func (r *SaslAuthenticateRequest) requiredVersion() KafkaVersion {
+	return V1_0_0_0
+}

--- a/sasl_authenticate_request.go
+++ b/sasl_authenticate_request.go
@@ -8,19 +8,12 @@ type SaslAuthenticateRequest struct {
 const APIKeySASLAuth = 36
 
 func (r *SaslAuthenticateRequest) encode(pe packetEncoder) error {
-	if err := pe.putBytes(r.SaslAuthBytes); err != nil {
-		return err
-	}
-
-	return nil
+	return pe.putBytes(r.SaslAuthBytes)
 }
 
 func (r *SaslAuthenticateRequest) decode(pd packetDecoder, version int16) (err error) {
-	if r.SaslAuthBytes, err = pd.getBytes(); err != nil {
-		return err
-	}
-
-	return nil
+	r.SaslAuthBytes, err = pd.getBytes()
+	return err
 }
 
 func (r *SaslAuthenticateRequest) key() int16 {

--- a/sasl_authenticate_request_test.go
+++ b/sasl_authenticate_request_test.go
@@ -4,14 +4,14 @@ import "testing"
 
 var (
 	saslAuthenticateRequest = []byte{
-		0, 3, 'f', 'o', 'o',
+		0, 0, 0, 3, 'f', 'o', 'o',
 	}
 )
 
 func TestSaslAuthenticateRequest(t *testing.T) {
-	var request *SaslHandshakeRequest
+	var request *SaslAuthenticateRequest
 
-	request = new(SaslHandshakeRequest)
-	request.Mechanism = "foo"
+	request = new(SaslAuthenticateRequest)
+	request.SaslAuthBytes = []byte(`foo`)
 	testRequest(t, "basic", request, saslAuthenticateRequest)
 }

--- a/sasl_authenticate_request_test.go
+++ b/sasl_authenticate_request_test.go
@@ -1,0 +1,17 @@
+package sarama
+
+import "testing"
+
+var (
+	saslAuthenticateRequest = []byte{
+		0, 3, 'f', 'o', 'o',
+	}
+)
+
+func TestSaslAuthenticateRequest(t *testing.T) {
+	var request *SaslHandshakeRequest
+
+	request = new(SaslHandshakeRequest)
+	request.Mechanism = "foo"
+	testRequest(t, "basic", request, saslAuthenticateRequest)
+}

--- a/sasl_authenticate_response.go
+++ b/sasl_authenticate_response.go
@@ -26,11 +26,9 @@ func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) error
 		return err
 	}
 
-	if r.SaslAuthBytes, err = pd.getBytes(); err != nil {
-		return err
-	}
+	r.SaslAuthBytes, err = pd.getBytes()
 
-	return nil
+	return err
 }
 
 func (r *SaslAuthenticateResponse) key() int16 {

--- a/sasl_authenticate_response.go
+++ b/sasl_authenticate_response.go
@@ -1,0 +1,46 @@
+package sarama
+
+type SaslAuthenticateResponse struct {
+	Err           KError
+	ErrorMessage  *string
+	SaslAuthBytes []byte
+}
+
+func (r *SaslAuthenticateResponse) encode(pe packetEncoder) error {
+	pe.putInt16(int16(r.Err))
+	if err := pe.putNullableString(r.ErrorMessage); err != nil {
+		return err
+	}
+	return pe.putBytes(r.SaslAuthBytes)
+}
+
+func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) error {
+	kerr, err := pd.getInt16()
+	if err != nil {
+		return err
+	}
+
+	r.Err = KError(kerr)
+
+	if r.ErrorMessage, err = pd.getNullableString(); err != nil {
+		return err
+	}
+
+	if r.SaslAuthBytes, err = pd.getBytes(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *SaslAuthenticateResponse) key() int16 {
+	return 36
+}
+
+func (r *SaslAuthenticateResponse) version() int16 {
+	return 0
+}
+
+func (r *SaslAuthenticateResponse) requiredVersion() KafkaVersion {
+	return V1_0_0_0
+}

--- a/sasl_authenticate_response.go
+++ b/sasl_authenticate_response.go
@@ -34,7 +34,7 @@ func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) error
 }
 
 func (r *SaslAuthenticateResponse) key() int16 {
-	return 36
+	return APIKeySASLAuth
 }
 
 func (r *SaslAuthenticateResponse) version() int16 {

--- a/sasl_authenticate_response_test.go
+++ b/sasl_authenticate_response_test.go
@@ -1,0 +1,27 @@
+package sarama
+
+import "testing"
+
+var (
+	saslAuthenticatResponse = []byte{
+		0, 0,
+		0, 3, 'e', 'r', 'r',
+		0, 0, 0, 3, 'm', 's', 'g',
+	}
+)
+
+func TestSaslAuthenticateResponse(t *testing.T) {
+	var response *SaslAuthenticateResponse
+
+	response = new(SaslAuthenticateResponse)
+	testVersionDecodable(t, "no error", response, saslAuthenticatResponse, 0)
+	if response.Err != ErrNoError {
+		t.Error("Decoding error failed: no error expected but found", response.Err)
+	}
+	if *response.ErrorMessage != "err" {
+		t.Error("Decoding error failed: expected 'err' but found", *response.ErrorMessage)
+	}
+	if string(response.SaslAuthBytes) != "msg" {
+		t.Error("Decoding error failed: expected 'msg' but found", string(response.SaslAuthBytes))
+	}
+}

--- a/sasl_authenticate_response_test.go
+++ b/sasl_authenticate_response_test.go
@@ -3,25 +3,20 @@ package sarama
 import "testing"
 
 var (
-	saslAuthenticatResponse = []byte{
-		0, 0,
+	saslAuthenticatResponseErr = []byte{
+		0, 58,
 		0, 3, 'e', 'r', 'r',
 		0, 0, 0, 3, 'm', 's', 'g',
 	}
 )
 
 func TestSaslAuthenticateResponse(t *testing.T) {
-	var response *SaslAuthenticateResponse
 
-	response = new(SaslAuthenticateResponse)
-	testVersionDecodable(t, "no error", response, saslAuthenticatResponse, 0)
-	if response.Err != ErrNoError {
-		t.Error("Decoding error failed: no error expected but found", response.Err)
-	}
-	if *response.ErrorMessage != "err" {
-		t.Error("Decoding error failed: expected 'err' but found", *response.ErrorMessage)
-	}
-	if string(response.SaslAuthBytes) != "msg" {
-		t.Error("Decoding error failed: expected 'msg' but found", string(response.SaslAuthBytes))
-	}
+	response := new(SaslAuthenticateResponse)
+	response.Err = ErrSASLAuthenticationFailed
+	msg := "err"
+	response.ErrorMessage = &msg
+	response.SaslAuthBytes = []byte(`msg`)
+
+	testResponse(t, "authenticate reponse", response, saslAuthenticatResponseErr)
 }

--- a/sasl_handshake_request.go
+++ b/sasl_handshake_request.go
@@ -2,6 +2,7 @@ package sarama
 
 type SaslHandshakeRequest struct {
 	Mechanism string
+	Version   int16
 }
 
 func (r *SaslHandshakeRequest) encode(pe packetEncoder) error {
@@ -25,7 +26,7 @@ func (r *SaslHandshakeRequest) key() int16 {
 }
 
 func (r *SaslHandshakeRequest) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *SaslHandshakeRequest) requiredVersion() KafkaVersion {


### PR DESCRIPTION
Hello,

This commit implements SASL/OAUTHBEARER client authentication as described in [KIP-255](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876) and issue #1223.

To get started, the user must set `c.Net.SASL.Mechanism:  OAUTHBEARER` and assign a user-defined token generator to `config.Net.SASL.TokenProvider`. For backwards compatibility, a blank value for `c.Net.SASL.Mechanism` defaults to `PLAIN`.

Example:

```go
type TokenProvider struct {
}

func (t *TokenProvider) Token() (*sarama.AccessToken, error) {
	return &sarama.AccessToken{Token: "access-token-string"}, nil
}
// ...
config.Net.SASL.Enable = true
config.Net.SASL.Mechanism = sarama.SASLTypeOAuth
config.Net.SASL.TokenProvider = &TokenProvider{}
```

cc @ggrcha