### PR TITLE
fix typo in deprecation notice for FetchResponseBlock.Records

### DIFF
--- a/fetch_response.go
+++ b/fetch_response.go
@@ -33,7 +33,7 @@ type FetchResponseBlock struct {
 	HighWaterMarkOffset int64
 	LastStableOffset    int64
 	AbortedTransactions []*AbortedTransaction
-	Records             *Records // deprecated: use FetchResponseBlock.Records
+	Records             *Records // deprecated: use FetchResponseBlock.RecordsSet
 	RecordsSet          []*Records
 	Partial             bool
 }


### PR DESCRIPTION
The deprecation notice for `FetchResponseBlock.Records` is a bit confusing.
Not sure which one between `Records` and `RecordsSet` is actually deprecated.

Looking through commit history it seem it is supposed to be that way.