### PR TITLE
Support LogAppend timestamps

### DIFF
--- a/message.go
+++ b/message.go
@@ -19,6 +19,8 @@ const (
 	CompressionZSTD   CompressionCodec = 4
 )
 
+const timestampTypeMask = 0x08
+
 func (cc CompressionCodec) String() string {
 	return []string{
 		"none",
@@ -36,6 +38,7 @@ const CompressionLevelDefault = -1000
 type Message struct {
 	Codec            CompressionCodec // codec used to compress the message contents
 	CompressionLevel int              // compression level
+	LogAppendTime    bool             // the used timestamp is LogAppendTime
 	Key              []byte           // the message key, may be nil
 	Value            []byte           // the message contents
 	Set              *MessageSet      // the message set a message might wrap
@@ -108,6 +111,7 @@ func (m *Message) decode(pd packetDecoder) (err error) {
 		return err
 	}
 	m.Codec = CompressionCodec(attribute & compressionCodecMask)
+	m.LogAppendTime = attribute&timestampTypeMask == timestampTypeMask
 
 	if m.Version == 1 {
 		if err := (Timestamp{&m.Timestamp}).decode(pd); err != nil {

--- a/record_batch.go
+++ b/record_batch.go
@@ -36,6 +36,7 @@ type RecordBatch struct {
 	Codec                 CompressionCodec
 	CompressionLevel      int
 	Control               bool
+	LogAppendTime         bool
 	LastOffsetDelta       int32
 	FirstTimestamp        time.Time
 	MaxTimestamp          time.Time
@@ -120,6 +121,7 @@ func (b *RecordBatch) decode(pd packetDecoder) (err error) {
 	}
 	b.Codec = CompressionCodec(int8(attributes) & compressionCodecMask)
 	b.Control = attributes&controlMask == controlMask
+	b.LogAppendTime = attributes&timestampTypeMask == timestampTypeMask
 
 	if b.LastOffsetDelta, err = pd.getInt32(); err != nil {
 		return err


### PR DESCRIPTION
Currently sarama does seem to properly support LogAppend type of timestamps. The patch is addressing this issue. The following was used is the reference for the change:
   * https://github.com/dpkp/kafka-python/blob/34fcb11c1cf96d69573274104d3b746ce67a97f4/kafka/record/default_records.py#L204 and 
   * https://github.com/dpkp/kafka-python/blob/34fcb11c1cf96d69573274104d3b746ce67a97f4/kafka/record/legacy_records.py#L262