### PR TITLE
fix memory accumulation

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -656,6 +656,7 @@ type brokerProducer struct {
 	output    chan<- *produceSet
 	responses <-chan *brokerProducerResponse
 
+	setLock    sync.Mutex
 	buffer     *produceSet
 	timer      <-chan time.Time
 	timerFired bool
@@ -782,9 +783,11 @@ func (bp *brokerProducer) waitForSpace(msg *ProducerMessage) error {
 }
 
 func (bp *brokerProducer) rollOver() {
+	bp.setLock.Lock()
 	bp.timer = nil
 	bp.timerFired = false
 	bp.buffer = newProduceSet(bp.parent)
+	bp.setLock.Unlock()
 }
 
 func (bp *brokerProducer) handleResponse(response *brokerProducerResponse) {


### PR DESCRIPTION
Because input and output channel in one select scope, so if output is not quickly as input, the messages will accumulate in memory and result in message too large. So we send batch message for sending goroutine before continue receive next message from input channel.