### PR TITLE
fix memory accumulation

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -680,6 +680,12 @@ func (bp *brokerProducer) run() {
 				bp.timerFired = true
 			}
 		}
+
+		if bp.timerFired {
+			output = bp.output
+			continue
+		}
+
 		select {
 		case msg := <-bp.input:
 			if msg == nil {
@@ -732,8 +738,6 @@ func (bp *brokerProducer) run() {
 			bp.rollOver()
 		case response := <-bp.responses:
 			bp.handleResponse(response)
-		case bp.timerFired == true:
-
 		}
 
 		if bp.timerFired || bp.buffer.readyToFlush() {

--- a/async_producer.go
+++ b/async_producer.go
@@ -676,6 +676,8 @@ func (bp *brokerProducer) run() {
 				output = nil
 			case response := <-bp.responses:
 				bp.handleResponse(response)
+			case <-bp.timer:
+				bp.timerFired = true
 			}
 		}
 		select {
@@ -730,6 +732,8 @@ func (bp *brokerProducer) run() {
 			bp.rollOver()
 		case response := <-bp.responses:
 			bp.handleResponse(response)
+		case bp.timerFired == true:
+
 		}
 
 		if bp.timerFired || bp.buffer.readyToFlush() {

--- a/async_producer.go
+++ b/async_producer.go
@@ -676,6 +676,10 @@ func (bp *brokerProducer) run() {
 				output = nil
 			case response := <-bp.responses:
 				bp.handleResponse(response)
+			case t := <-bp.timer:
+				go func() {
+					bp.timer <- t
+				}()
 			}
 		}
 		select {

--- a/async_producer.go
+++ b/async_producer.go
@@ -676,10 +676,6 @@ func (bp *brokerProducer) run() {
 				output = nil
 			case response := <-bp.responses:
 				bp.handleResponse(response)
-			case t := <-bp.timer:
-				go func() {
-					bp.timer <- t
-				}()
 			}
 		}
 		select {

--- a/async_producer.go
+++ b/async_producer.go
@@ -669,6 +669,15 @@ func (bp *brokerProducer) run() {
 	Logger.Printf("producer/broker/%d starting up\n", bp.broker.ID())
 
 	for {
+		if output != nil {
+			select {
+			case output <- bp.buffer:
+				bp.rollOver()
+				output = nil
+			case response := <-bp.responses:
+				bp.handleResponse(response)
+			}
+		}
 		select {
 		case msg := <-bp.input:
 			if msg == nil {

--- a/async_producer.go
+++ b/async_producer.go
@@ -736,6 +736,7 @@ func (bp *brokerProducer) run() {
 			bp.timerFired = true
 		case output <- bp.buffer:
 			bp.rollOver()
+			output = nil
 		case response := <-bp.responses:
 			bp.handleResponse(response)
 		}


### PR DESCRIPTION
Because input and output channel in one select scope, so if output is not quickly as input, the messages will accumulate in memory and result in message too large. So we send batch message for sending goroutine before continue receive next message from input channel.