### PR TITLE
log: add a DebugLogger that proxies to Logger

### DIFF
--- a/sarama.go
+++ b/sarama.go
@@ -108,3 +108,21 @@ type StdLogger interface {
 	Printf(format string, v ...interface{})
 	Println(v ...interface{})
 }
+
+type debugLogger struct{}
+
+func (d *debugLogger) Print(v ...interface{}) {
+	Logger.Print(v)
+}
+func (d *debugLogger) Printf(format string, v ...interface{}) {
+	Logger.Printf(format, v)
+}
+func (d *debugLogger) Println(v ...interface{}) {
+	Logger.Println(v)
+}
+
+// DebugLogger is the instance of a StdLogger that Sarama writes more verbose
+// debug information to. By default it is set to redirect all debug to the
+// default Logger above, but you can optionally set it to another StdLogger
+// instance to (e.g.,) discard debug information
+var DebugLogger StdLogger = &debugLogger{}


### PR DESCRIPTION
Currently Sarama has the single `Logger` instance of a `StdLogger` that
is used for all log statements within the module. This works well
because user applications can trivially redirect it to their own logging
library of choice simply by implementing the StdLogger interface and
changing the package root variable.

However, currently there are a fair number of quite verbose log statements in the
module that output during normal golden path operation and it would be
helpful to be able to differentiate those from the abnormal output.
e.g.,
```go
Logger.Println("Initializing new client")
Logger.Printf("client/metadata fetching metadata for %v from broker %s\n", topics, broker.addr)
Logger.Printf("client/metadata fetching metadata for all topics from broker %s\n", broker.addr)
```
etc.

This PR adds an additional `DebugLogger` variable that will by default
just proxy all requests to whatever is referenced by the existing
`Logger` variable.

For now, none of the existing log statements have been switched to use
the new DebugLogger as I wanted to confirm that the maintainers are
happy with the proposal.