### PR TITLE
Set correct Kafka version for DescribeConfigsRequest v1

### DIFF
--- a/describe_configs_request.go
+++ b/describe_configs_request.go
@@ -103,7 +103,7 @@ func (r *DescribeConfigsRequest) version() int16 {
 func (r *DescribeConfigsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
 	case 1:
-		return V1_0_0_0
+		return V1_1_0_0
 	case 2:
 		return V2_0_0_0
 	default:


### PR DESCRIPTION
V1 is only supported on Kafka 1.1.0 and higher.

Difficult to find an official page, other than [this](https://cwiki.apache.org/confluence/display/KAFKA/Kafka+APIs),  where this is documented, but from a describe api versions

Kafka 1.0
```
Key:32, Min: 0, Max: 0
```

Kafka 1.1
```
Key:32, Min: 0, Max: 1
```
