### PR TITLE
fixed potential deadlock when a heartbeat request fails

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -657,6 +657,12 @@ func (s *consumerGroupSession) heartbeatLoop() {
 		resp, err := s.parent.heartbeatRequest(coordinator, s.memberID, s.generationID)
 		if err != nil {
 			_ = coordinator.Close()
+
+			if retries <= 0 {
+				s.parent.handleError(err, "", -1)
+				return
+			}
+
 			retries--
 			continue
 		}


### PR DESCRIPTION
When using a ConsumerGroup I managed to block all but one consumers after Kafka went down (but Zookeeper kept running).

Test setup:
* zookeeper + kafka
* 1 partition
* run a consumer multiple times, restarting as desired causing the group to be rebalanced (just in case)
* kill kafka - one consumer properly leaves the "Consume" method while the others keep waiting

Debugging revealed that the "retries" went into negative numbers, simply because the failed retries were not evaluated at that point in the code. My PR adds this missing check and therefore allows a clean shutdown on a failed kafka connection.