### PR TITLE
Add support for Kafka 2.2.0

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -159,6 +159,7 @@ var (
 	V2_0_0_0  = newKafkaVersion(2, 0, 0, 0)
 	V2_0_1_0  = newKafkaVersion(2, 0, 1, 0)
 	V2_1_0_0  = newKafkaVersion(2, 1, 0, 0)
+	V2_2_0_0  = newKafkaVersion(2, 2, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -181,9 +182,10 @@ var (
 		V2_0_0_0,
 		V2_0_1_0,
 		V2_1_0_0,
+		V2_2_0_0,
 	}
 	MinVersion = V0_8_2_0
-	MaxVersion = V2_1_0_0
+	MaxVersion = V2_2_0_0
 )
 
 func ParseKafkaVersion(s string) (KafkaVersion, error) {

--- a/vagrant/install_cluster.sh
+++ b/vagrant/install_cluster.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-TOXIPROXY_VERSION=2.1.3
+TOXIPROXY_VERSION=2.1.4
 
 mkdir -p ${KAFKA_INSTALL_ROOT}
 if [ ! -f ${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_VERSION}.tgz ]; then


### PR DESCRIPTION
Since Kafka 2.2.0 RC is out, add support to the next release.