### PR TITLE
remove go keyword from channel close in singleton

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -576,6 +576,6 @@ func (pom *partitionOffsetManager) handleError(err error) {
 
 func (pom *partitionOffsetManager) release() {
 	pom.releaseOnce.Do(func() {
-		go close(pom.errors)
+		close(pom.errors)
 	})
 }


### PR DESCRIPTION
- I don't think that go routine add anything to that code, it's a singleton already and shouldn't spin a go routine, saves 1 go routine scheduling :)