### PR TITLE
Adding note for clarification

### DIFF
--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -122,6 +122,11 @@ func (consumer *Consumer) Cleanup(sarama.ConsumerGroupSession) error {
 
 // ConsumeClaim must start a consumer loop of ConsumerGroupClaim's Messages().
 func (consumer *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+
+	// NOTE:
+	// Do not move the code below to a goroutine.
+	// The `ConsumeClaim` itself is called within a goroutine, see:
+	// https://github.com/Shopify/sarama/blob/master/consumer_group.go#L27-L29
 	for message := range claim.Messages() {
 		log.Printf("Message claimed: value = %s, timestamp = %v, topic = %s", string(message.Value), message.Timestamp, message.Topic)
 		session.MarkMessage(message, "")


### PR DESCRIPTION
I did accidently put a goroutine inside the `ConsumeClaim`, but that was wrong.
In the docs it's mentioned that the `ConsumeClaim` itself is called w/in a goroutine.

I felt like adding a note, to avoid others doing the same mistake.