### PR TITLE
Provide peekInt8 to reduce allocations

### DIFF
--- a/packet_decoder.go
+++ b/packet_decoder.go
@@ -27,6 +27,7 @@ type packetDecoder interface {
 	remaining() int
 	getSubset(length int) (packetDecoder, error)
 	peek(offset, length int) (packetDecoder, error) // similar to getSubset, but it doesn't advance the offset
+	peekInt8(offset int) (int8, error)              // similar to peek, but just one byte
 
 	// Stacks, see PushDecoder
 	push(in pushDecoder) error

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -290,6 +290,14 @@ func (rd *realDecoder) peek(offset, length int) (packetDecoder, error) {
 	return &realDecoder{raw: rd.raw[off : off+length]}, nil
 }
 
+func (rd *realDecoder) peekInt8(offset int) (int8, error) {
+	if rd.remaining() < offset+1 {
+		return -1, ErrInsufficientData
+	}
+	tmp := int8(rd.raw[rd.off+offset])
+	return tmp, nil
+}
+
 // stacks
 
 func (rd *realDecoder) push(in pushDecoder) error {

--- a/records.go
+++ b/records.go
@@ -185,12 +185,7 @@ func (r *Records) isOverflow() (bool, error) {
 }
 
 func magicValue(pd packetDecoder) (int8, error) {
-	dec, err := pd.peek(magicOffset, magicLength)
-	if err != nil {
-		return 0, err
-	}
-
-	return dec.getInt8()
+	return pd.peekInt8(magicOffset)
 }
 
 func (r *Records) getControlRecord() (ControlRecord, error) {


### PR DESCRIPTION
Background:
In a project I use, sarama produces by far the most ongoing allocations (mainly, I think, because have lots of small messages) which negatively impacts our GC stats. I recently went through and tried to reduce them where I could and have been quite successful in that sarama doesn't show up in the pprof top10 by `alloc_objects`.  This is the simplest change I made so far. The others follow the pattern from #1161 and are more invasive.

I benchmarked this change by consuming 5 million messages and then dumping out a heap profile.
Before the change:
```
Showing nodes accounting for 30777165, 99.24% of 31012468 total
Dropped 6 nodes (cum <= 155062)
Showing top 10 nodes out of 19
      flat  flat%   sum%        cum   cum%
  10362760 33.41% 33.41%   25777082 83.12%  github.com/Shopify/sarama.(*MessageBlock).decode
   5172719 16.68% 50.09%   25887933 83.48%  github.com/Shopify/sarama.(*MessageSet).decode
   5123816 16.52% 66.62%    5123816 16.52%  github.com/Shopify/sarama.(*partitionConsumer).parseMessages
   5087542 16.40% 83.02%    5087542 16.40%  github.com/Shopify/sarama.(*realDecoder).peek
```

Here you can see that peek is responsible for 16.4% of the objects allocated, a little over one per message (makes sense, because of the record batching in kafka). 

After the change:
```
Showing nodes accounting for 25577632, 99.73% of 25647802 total
```

Peek doesn't show up at all and we allocate 25.6 million objects vs 31 million, which is the expected reduction.