### PR TITLE
Return ErrRebalanceInProgress errors via the group errors channel

### DIFF
--- a/config.go
+++ b/config.go
@@ -246,6 +246,11 @@ type Config struct {
 					// Backoff time between retries during rebalance (default 2s)
 					Backoff time.Duration
 				}
+
+				// If enabled, any ErrRebalanceInProgress errors are returned on the Errors channel (default disabled).
+				// This gives the user the ability to cancel all in progress message handlers so that the consumer can
+				// rejoin the consumer group.
+				SendGroupError bool
 			}
 			Member struct {
 				// Custom metadata to include when joining the group. The user data for all joined members

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -691,7 +691,12 @@ func (s *consumerGroupSession) heartbeatLoop() {
 		switch resp.Err {
 		case ErrNoError:
 			retries = s.parent.config.Metadata.Retry.Max
-		case ErrRebalanceInProgress, ErrUnknownMemberId, ErrIllegalGeneration:
+		case ErrRebalanceInProgress:
+			if s.parent.config.Consumer.Group.Rebalance.SendGroupError {
+				s.parent.errors <- resp.Err
+			}
+			return
+		case ErrUnknownMemberId, ErrIllegalGeneration:
 			return
 		default:
 			s.parent.handleError(err, "", -1)


### PR DESCRIPTION
I'm using `github.com/cenkalti/backoff` to perform retries in my consumer group handler.  `backoff` allows for cancelation via context, but I need to be notified by `sarama` that a rebalance is in progress in order to call `cancel`.  I may be missing an existing way to handle this, but if not, I'm thinking that returning the `ErrRebalanceInProgress` error to the group's error channel is simple enough.  To make the change backward compatible I added the `Consumer.Group.Rebalance.SendGroupError` option.  Would this be a reasonable solution?

cc @dim (thanks for adding the consumer group feature!)