### PR TITLE
fix auto create topic on metadata request when request version greate…

### DIFF
--- a/client.go
+++ b/client.go
@@ -751,13 +751,15 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int)
 	}
 
 	for broker := client.any(); broker != nil; broker = client.any() {
+		allowAutoTopicCreation := true
 		if len(topics) > 0 {
 			Logger.Printf("client/metadata fetching metadata for %v from broker %s\n", topics, broker.addr)
 		} else {
+			allowAutoTopicCreation = false
 			Logger.Printf("client/metadata fetching metadata for all topics from broker %s\n", broker.addr)
 		}
 
-		req := &MetadataRequest{Topics: topics}
+		req := &MetadataRequest{Topics: topics, AllowAutoTopicCreation: allowAutoTopicCreation}
 		if client.conf.Version.IsAtLeast(V1_0_0_0) {
 			req.Version = 5
 		} else if client.conf.Version.IsAtLeast(V0_10_0_0) {


### PR DESCRIPTION
When the request version is greater than 3, MetadataRequest will encode the AllowAutoTopicCreation field to the request.

This field is always false so the topic will not create by the broker.