### PR TITLE
Run CI builds on ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 go:
 - 1.11.x


### PR DESCRIPTION
Looks like `ld` is too old on Ubuntu 14.04.