### PR TITLE
added SASLVersion in config

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -441,6 +441,7 @@ func TestSASLPlainAuth(t *testing.T) {
 		conf.Net.SASL.Mechanism = SASLTypePlaintext
 		conf.Net.SASL.User = "token"
 		conf.Net.SASL.Password = "password"
+		conf.Net.SASL.Version = SASLHandshakeV1
 
 		broker.conf = conf
 		broker.conf.Version = V1_0_0_0

--- a/config.go
+++ b/config.go
@@ -58,6 +58,9 @@ type Config struct {
 			// SASLMechanism is the name of the enabled SASL mechanism.
 			// Possible values: OAUTHBEARER, PLAIN (defaults to PLAIN).
 			Mechanism SASLMechanism
+			// Version is the SASL Protocol Version to use
+			// Kafka > 1.x should use V1, except on Azure EventHub which use V0
+			Version int16
 			// Whether or not to send the Kafka SASL handshake first if enabled
 			// (defaults to true). You should only set this to false if you're using
 			// a non-Kafka SASL proxy.
@@ -398,6 +401,7 @@ func NewConfig() *Config {
 	c.Net.ReadTimeout = 30 * time.Second
 	c.Net.WriteTimeout = 30 * time.Second
 	c.Net.SASL.Handshake = true
+	c.Net.SASL.Version = SASLHandshakeV0
 
 	c.Metadata.Retry.Max = 3
 	c.Metadata.Retry.Backoff = 250 * time.Millisecond


### PR DESCRIPTION
Sarama force SASL V1 handshake when Kafka protocol is greater than 1.0.
Azure Eventhub is still using SASLV0.

I moved the SASL protocol version to the config, defaulting to V0 (like before), but I also removed the auto V1 when Kafka > 1.0

Refer to https://github.com/Shopify/sarama/issues/1408 for more info.

@varun06 Let me know if this is what you expected or let me know what you prefer, like keeping the old behaviour but adding a config flag to disable the force change to V1 when Kafka > 1.0
