### PR TITLE
Set the Kafka version in ListAcls method

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -508,9 +508,9 @@ func (ca *clusterAdmin) ListAcls(filter AclFilter) ([]ResourceAcls, error) {
 
 	request := &DescribeAclsRequest{AclFilter: filter}
 
-        if ca.conf.Version.IsAtLeast(V2_0_0_0) {
-                request.Version = 1
-        }
+	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		request.Version = 1
+	}
 
 	b, err := ca.Controller()
 	if err != nil {

--- a/admin.go
+++ b/admin.go
@@ -508,6 +508,10 @@ func (ca *clusterAdmin) ListAcls(filter AclFilter) ([]ResourceAcls, error) {
 
 	request := &DescribeAclsRequest{AclFilter: filter}
 
+        if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+                request.Version = 1
+        }
+
 	b, err := ca.Controller()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds a conditional to set the Kafka version. If the version is at last 2 then it sets request.Version = 1, which enables the functionality of getting the AclResourcePatternType field for the ACLs.