### PR TITLE
Produce records with consistent timestamps

### DIFF
--- a/produce_set.go
+++ b/produce_set.go
@@ -44,9 +44,10 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 	}
 
 	timestamp := msg.Timestamp
-	if msg.Timestamp.IsZero() {
+	if timestamp.IsZero() {
 		timestamp = time.Now()
 	}
+	timestamp = timestamp.Truncate(time.Millisecond)
 
 	partitions := ps.msgs[msg.Topic]
 	if partitions == nil {


### PR DESCRIPTION
It is possible for the same record to have a different timestamp depending on where it appears in a produceSet, as the test case in this commit illustrates.

The problem is that the produceSet's FirstTimestamp and the record's TimestampDelta are each calculated with nanosecond precision, and then truncated to millisecond precision during encoding. This leads to accumulated rounding error when the original timestamp is later reconstructed.

Instead, truncate all timestamps to millisecond precision before calculating the FirstTimestamp and TimestampDelta, so that if the same record is produced multiple times, it will always have the same timestamp.

It might be better to call encode on each record instead of reproducing the logic of how to encode a timestamp in the test, but I can't see an easy way to get the result of encoding a record. I'm open to feedback on how to improve the test.