### PR TITLE
Set request version in ListAcls ClusterAdmin method

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -513,6 +513,10 @@ func (ca *clusterAdmin) ListAcls(filter AclFilter) ([]ResourceAcls, error) {
 
 	request := &DescribeAclsRequest{AclFilter: filter}
 
+	if ca.conf.Version.IsAtLeast(V2_0_0_0) && filter.Version == 1 {
+		request.Version = 1
+	}
+
 	b, err := ca.Controller()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I have encountered a problem with unavailability to set the request version other than 0 in DescribeAclsRequest when using ListAcls method. So it is not possible to get use of ResourcePatternTypeFilter in AclFilter or get the pattern types in response.

Setting Version in AclFilter itself has no effect because this value is being rewritten in encode method in acl_describe_request.go.

So this PR contains the obvious fix and allows to request pattern types in ListAcls.