### PR TITLE
Set request version in CreateACL ClusterAdmin method

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -500,6 +500,10 @@ func (ca *clusterAdmin) CreateACL(resource Resource, acl Acl) error {
 	acls = append(acls, &AclCreation{resource, acl})
 	request := &CreateAclsRequest{AclCreations: acls}
 
+	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		request.Version = 1
+	}
+
 	b, err := ca.Controller()
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now the request version is always set to 0 when using CreateACL method. And it is therefore ignores the ResourcePatternType value causing created ACLs to be always of LITERAL type.

This PR fixes the issue and allows to create ACLs of any pattern type on brokers with versions 2.0+.