### PR TITLE
Set request version in DeleteACL ClusterAdmin method

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -535,6 +535,10 @@ func (ca *clusterAdmin) DeleteACL(filter AclFilter, validateOnly bool) ([]Matchi
 	filters = append(filters, &filter)
 	request := &DeleteAclsRequest{Filters: filters}
 
+	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		request.Version = 1
+	}
+
 	b, err := ca.Controller()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
One more PR to enable ResourcePatternTypeFilter in the request. For method DeleteACL this time.
This fix will allow deleting ACLs with pattern type other than LITERAL.