### PR TITLE
Handle missed error codes on TopicMetaDataRequest and GroupCoordinatorRequest

### DIFF
--- a/client.go
+++ b/client.go
@@ -804,8 +804,9 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 				return err
 			}
 
-			if err.(KError) == ErrGroupAuthorizationFailed {
-				Logger.Println("client is not authorized to access this group.")
+			if err.(KError) == ErrTopicAuthorizationFailed {
+				Logger.Println("client is not authorized to access this topic. The topics were: ", topics)
+				return err
 			}
 			// else remove that broker and try again
 			Logger.Printf("client/metadata got error from broker %d while fetching metadata: %v\n", broker.ID(), err)

--- a/client.go
+++ b/client.go
@@ -803,6 +803,10 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 				Logger.Println("client/metadata failed SASL authentication")
 				return err
 			}
+
+			if err.(KError) == ErrGroupAuthorizationFailed {
+				Logger.Println("client is not authorized to access this group.")
+			}
 			// else remove that broker and try again
 			Logger.Printf("client/metadata got error from broker %d while fetching metadata: %v\n", broker.ID(), err)
 			_ = broker.Close()
@@ -966,6 +970,10 @@ func (client *client) getConsumerMetadata(consumerGroup string, attemptsRemainin
 			}
 
 			return retry(ErrConsumerCoordinatorNotAvailable)
+		case ErrGroupAuthorizationFailed:
+			Logger.Printf("client was not authorized to access group %s while attempting to find coordinator", consumerGroup)
+			return retry(ErrGroupAuthorizationFailed)
+
 		default:
 			return nil, response.Err
 		}

--- a/errors.go
+++ b/errors.go
@@ -188,6 +188,7 @@ const (
 	ErrMemberIdRequired                   KError = 79
 	ErrPreferredLeaderNotAvailable        KError = 80
 	ErrGroupMaxSizeReached                KError = 81
+	ErrFencedInstancedId                  KError = 82
 )
 
 func (err KError) Error() string {
@@ -360,6 +361,8 @@ func (err KError) Error() string {
 		return "kafka server: The preferred leader was not available"
 	case ErrGroupMaxSizeReached:
 		return "kafka server: Consumer group The consumer group has reached its max size. already has the configured maximum number of members."
+	case ErrFencedInstancedId:
+		return "kafka server: The broker rejected this static consumer since another consumer with the same group.instance.id has registered with a different member.id."
 	}
 
 	return fmt.Sprintf("Unknown error, how did this happen? Error code = %d", err)


### PR DESCRIPTION
Adds a few missed errors that I've encountered, in particular one https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-TopicMetadataRequest and one https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-GroupCoordinatorRequest 

Also adds https://kafka.apache.org/protocol#protocol_error_codes code # `82`

The CLA check is failing, but I have previously signed it - if I try to do so again, I get
```
To sign our CLA 1 field needs to be changed
GitHub username has already signed a CLA
```