### PR TITLE
removes gofork direct usage as fix is part of go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,7 @@ get:
 .PHONY: clean
 clean:
 	go clean ./...
+
+.PHONY: tidy
+tidy:
+	go mod tidy -v

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
-	github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03
+	github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03 // indirect
 	github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/stretchr/testify v1.3.0

--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -1,18 +1,19 @@
 package sarama
 
 import (
+	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
-	"github.com/jcmturner/gofork/encoding/asn1"
+	"io"
+	"strings"
+	"time"
+
 	"gopkg.in/jcmturner/gokrb5.v7/asn1tools"
 	"gopkg.in/jcmturner/gokrb5.v7/gssapi"
 	"gopkg.in/jcmturner/gokrb5.v7/iana/chksumtype"
 	"gopkg.in/jcmturner/gokrb5.v7/iana/keyusage"
 	"gopkg.in/jcmturner/gokrb5.v7/messages"
 	"gopkg.in/jcmturner/gokrb5.v7/types"
-	"io"
-	"strings"
-	"time"
 )
 
 const (


### PR DESCRIPTION
fixes https://github.com/Shopify/sarama/issues/1438

`jcmturner/gokrb5` needs to use the `jcmturner/gofork` in order to have
some workarounds about some stuff not implemented or not working as
expected.

For the specific case of github.com/jcmturner/gofork/encoding/asn1 there
is no reason right now to keep using `jcmturner/gofork` as the issue
golang/go#17321 was solved/closed in Dec 15, 2016 and released in go
1.10

`jcmturner/gokrb5` still uses internally `jcmturner/gofork`, it seems
the `gofork` `asn1` part could be removed and use the standar library,
but that will need some more work and PRs on the `jcmturner/gokrb5`
side.