### PR TITLE
Uses a valid release of zstd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install_dependencies: get
 
 .PHONY: get
 get:
-	go get -t -v ./...
+	go get -v ./...
 
 .PHONY: clean
 clean:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/Shopify/sarama
 
 require (
-	github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798
+	github.com/DataDog/zstd v1.4.0
 	github.com/Shopify/toxiproxy v2.1.4+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/eapache/go-resiliency v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798 h1:2T/jmrHeTezcCM58lvEQXs0UpQJCo5SoGAcg+mbSTIg=
-github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/DataDog/zstd v1.4.0 h1:vhoV+DUHnRZdKW1i5UMjAk2G4JY8wN4ayRfYDNdEhwo=
+github.com/DataDog/zstd v1.4.0/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Uses a valid release of zstd

`v1.3.6` doesn't exist in https://github.com/DataDog/zstd/releases

Fixes https://github.com/Shopify/sarama/issues/1401
