### PR TITLE
make a note about incomplete zstd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+#### Next version (unreleased)
+
+ - Please **don't** use Zstd, as it doesn't work right now.
+   See https://github.com/Shopify/sarama/issues/1252
+
 #### Version 1.23.1 (2019-07-22)
 
 Bug Fixes:


### PR DESCRIPTION
Wondering if we need to add this to the readme, as I think the current Zstd support is misleading according to https://github.com/Shopify/sarama/issues/1252

We can even delete all Zstd related code until a proper fix/feature is added. (and remove the cgo dependency :) )

Thoughts @bai @mkaminski1988 @varun06