### PR TITLE
Add support for Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
 - 1.11.x
 - 1.12.x
+- 1.13.x
 
 env:
   global:
@@ -12,7 +13,6 @@ env:
   - KAFKA_HOSTNAME=localhost
   - DEBUG=true
   matrix:
-  - KAFKA_VERSION=2.1.1 KAFKA_SCALA_VERSION=2.12
   - KAFKA_VERSION=2.2.1 KAFKA_SCALA_VERSION=2.12
   - KAFKA_VERSION=2.3.0 KAFKA_SCALA_VERSION=2.12
 
@@ -29,7 +29,7 @@ script:
 - make test
 - make vet
 - make errcheck
-- if [[ "$TRAVIS_GO_VERSION" == 1.12* ]]; then make fmt; fi
+- if [[ "$TRAVIS_GO_VERSION" == 1.13* ]]; then make fmt; fi
 
 after_success:
 - go tool cover -func coverage.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-sarama
-======
+# sarama
 
 [![GoDoc](https://godoc.org/github.com/Shopify/sarama?status.svg)](https://godoc.org/github.com/Shopify/sarama)
 [![Build Status](https://travis-ci.org/Shopify/sarama.svg?branch=master)](https://travis-ci.org/Shopify/sarama)
@@ -7,7 +6,7 @@ sarama
 
 Sarama is an MIT-licensed Go client library for [Apache Kafka](https://kafka.apache.org/) version 0.8 (and later).
 
-### Getting started
+## Getting started
 
 - API documentation and examples are available via [godoc](https://godoc.org/github.com/Shopify/sarama).
 - Mocks for testing are available in the [mocks](./mocks) subpackage.
@@ -16,24 +15,22 @@ Sarama is an MIT-licensed Go client library for [Apache Kafka](https://kafka.apa
 
 You might also want to look at the [Frequently Asked Questions](https://github.com/Shopify/sarama/wiki/Frequently-Asked-Questions).
 
-### Compatibility and API stability
+## Compatibility and API stability
 
 Sarama provides a "2 releases + 2 months" compatibility guarantee: we support
 the two latest stable releases of Kafka and Go, and we provide a two month
 grace period for older releases. This means we currently officially support
-Go 1.11 through 1.12, and Kafka 2.0 through 2.3, although older releases are
+Go 1.11 through 1.13, and Kafka 2.1 through 2.3, although older releases are
 still likely to work.
 
 Sarama follows semantic versioning and provides API stability via the gopkg.in service.
 You can import a version with a guaranteed stable API via http://gopkg.in/Shopify/sarama.v1.
 A changelog is available [here](CHANGELOG.md).
 
-### Contributing
+## Contributing
 
-* Get started by checking our [contribution guidelines](https://github.com/Shopify/sarama/blob/master/.github/CONTRIBUTING.md).
-* Read the [Sarama wiki](https://github.com/Shopify/sarama/wiki) for more
-  technical and design details.
-* The [Kafka Protocol Specification](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol)
-  contains a wealth of useful information.
-* For more general issues, there is [a google group](https://groups.google.com/forum/#!forum/kafka-clients) for Kafka client developers.
-* If you have any questions, just ask!
+- Get started by checking our [contribution guidelines](https://github.com/Shopify/sarama/blob/master/.github/CONTRIBUTING.md).
+- Read the [Sarama wiki](https://github.com/Shopify/sarama/wiki) for more technical and design details.
+- The [Kafka Protocol Specification](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol) contains a wealth of useful information.
+- For more general issues, there is [a google group](https://groups.google.com/forum/#!forum/kafka-clients) for Kafka client developers.
+- If you have any questions, just ask!

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: sarama
 
 up:
   - go:
-      version: '1.12'
+      version: '1.13'
 
 commands:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/Shopify/sarama
 
+go 1.13
+
 require (
 	github.com/DataDog/zstd v1.4.0
 	github.com/Shopify/toxiproxy v2.1.4+incompatible


### PR DESCRIPTION
Add support for Go 1.13 and remove Kafka 2.1 from build matrix according to 2 releases + 2 months schedule.