### PR TITLE
Set correct version in MockDeleteTopicsResponse

### DIFF
--- a/mockresponses.go
+++ b/mockresponses.go
@@ -667,6 +667,7 @@ func (mr *MockDeleteTopicsResponse) For(reqBody versionedDecoder) encoder {
 	for _, topic := range req.Topics {
 		res.TopicErrorCodes[topic] = ErrNoError
 	}
+	res.Version = int16(req.Version)
 	return res
 }
 


### PR DESCRIPTION
This PR adds a Version field to the MockDeleteTopics response with the same value as request has. This allows to mock a response from Kafka version higher than V0_11_0_0.