### PR TITLE
Use response with the same version as request in MockDeleteAclsResponse

### DIFF
--- a/mockresponses.go
+++ b/mockresponses.go
@@ -912,6 +912,7 @@ func (mr *MockDeleteAclsResponse) For(reqBody versionedDecoder) encoder {
 		response.MatchingAcls = append(response.MatchingAcls, &MatchingAcl{Err: ErrNoError})
 		res.FilterResponses = append(res.FilterResponses, response)
 	}
+	res.Version = int16(req.Version)
 	return res
 }
 


### PR DESCRIPTION
This PR adds a Version field to the MockDeleteAcls response with the same value as request has. This allows to mock a response from Kafka version higher than V2_0_0_0.