### PR TITLE
Fix spelling of sarama in example

### DIFF
--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Shopify/sarama"
 )
 
-// Sarma configuration options
+// Sarama configuration options
 var (
 	brokers  = ""
 	version  = ""


### PR DESCRIPTION
Change example to say Sarama instead of Sarma.