### PR TITLE
Update documentation with Sarama instead of Sarma

### DIFF
--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Shopify/sarama"
 )
 
-// Sarma configuration options
+// Sarama configuration options
 var (
 	brokers  = ""
 	version  = ""


### PR DESCRIPTION
Sarama was misspelled as Sarma in one part of the file.