### PR TITLE
fixed panic on calling updateMetadata on closed client

### DIFF
--- a/client.go
+++ b/client.go
@@ -242,6 +242,9 @@ func (client *client) Close() error {
 }
 
 func (client *client) Closed() bool {
+	client.lock.RLock()
+	defer client.lock.RUnlock()
+
 	return client.brokers == nil
 }
 
@@ -529,6 +532,11 @@ func (client *client) RefreshCoordinator(consumerGroup string) error {
 // in the brokers map. It returns the broker that is registered, which may be the provided broker,
 // or a previously registered Broker instance. You must hold the write lock before calling this function.
 func (client *client) registerBroker(broker *Broker) {
+	if client.brokers == nil {
+		Logger.Printf("cannot register broker #%d at %s, client already closed", broker.ID(), broker.Addr())
+		return
+	}
+
 	if client.brokers[broker.ID()] == nil {
 		client.brokers[broker.ID()] = broker
 		Logger.Printf("client/brokers registered new broker #%d at %s", broker.ID(), broker.Addr())

--- a/client.go
+++ b/client.go
@@ -833,6 +833,10 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 
 // if no fatal error, returns a list of topics that need retrying due to ErrLeaderNotAvailable
 func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bool) (retry bool, err error) {
+	if client.Closed() {
+		return
+	}
+
 	client.lock.Lock()
 	defer client.lock.Unlock()
 

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -417,12 +417,6 @@ func (c *consumerGroup) leave() error {
 }
 
 func (c *consumerGroup) handleError(err error, topic string, partition int32) {
-	select {
-	case <-c.closed:
-		return
-	default:
-	}
-
 	if _, ok := err.(*ConsumerError); !ok && topic != "" && partition > -1 {
 		err = &ConsumerError{
 			Topic:     topic,
@@ -431,13 +425,23 @@ func (c *consumerGroup) handleError(err error, topic string, partition int32) {
 		}
 	}
 
-	if c.config.Consumer.Return.Errors {
-		select {
-		case c.errors <- err:
-		default:
-		}
-	} else {
+	if !c.config.Consumer.Return.Errors {
 		Logger.Println(err)
+		return
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	select {
+	case <-c.closed:
+		return
+	default:
+	}
+
+	select {
+	case c.errors <- err:
+	default:
 	}
 }
 

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -435,6 +435,7 @@ func (c *consumerGroup) handleError(err error, topic string, partition int32) {
 
 	select {
 	case <-c.closed:
+		//consumer is closed
 		return
 	default:
 	}
@@ -442,6 +443,7 @@ func (c *consumerGroup) handleError(err error, topic string, partition int32) {
 	select {
 	case c.errors <- err:
 	default:
+		// no error listener
 	}
 }
 


### PR DESCRIPTION
Hello, after updateing sarama to `v1.24.1` in https://github.com/ThreeDotsLabs/watermill-kafka our tests are failing because of `assignment to entry in nil map`:
```
[watermill] 2019/11/01 16:20:41.213125 subscriber.go:211: 	level=INFO  msg="Starting consuming" consumer_group=test kafka_consumer_uuid=jPK7fjGRZHsbSueM94mnqg provider=kafka subscriber_uuid=GZqfP4ixUbbvvoQYMHJcVF topic=topic_620ff2d2-616d-472e-a016-8329edb4738d 
[watermill] 2019/11/01 16:20:41.505179 subscriber.go:298: 	level=DEBUG msg="Consume stopped without any error" consumer_group=cg_9d09a750-cee9-402d-b6e9-5549781ef810 kafka_consumer_uuid=fsXW4sWL3Bs2XPoaHY5PXj provider=kafka subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F topic=topic_a1916770-8048-4928-ae01-3768f760d229 
[watermill] 2019/11/01 16:20:41.506553 subscriber.go:304: 	level=DEBUG msg="Group closed" consumer_group=cg_9d09a750-cee9-402d-b6e9-5549781ef810 kafka_consumer_uuid=fsXW4sWL3Bs2XPoaHY5PXj provider=kafka subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F topic=topic_a1916770-8048-4928-ae01-3768f760d229 
[watermill] 2019/11/01 16:20:41.506622 subscriber.go:307: 	level=INFO  msg="Consuming done" consumer_group=cg_9d09a750-cee9-402d-b6e9-5549781ef810 kafka_consumer_uuid=fsXW4sWL3Bs2XPoaHY5PXj provider=kafka subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F topic=topic_a1916770-8048-4928-ae01-3768f760d229 
[watermill] 2019/11/01 16:20:41.506718 subscriber.go:249: 	level=DEBUG msg="Client closed" consumer_group=cg_9d09a750-cee9-402d-b6e9-5549781ef810 kafka_consumer_uuid=fsXW4sWL3Bs2XPoaHY5PXj provider=kafka subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F topic=topic_a1916770-8048-4928-ae01-3768f760d229 
[watermill] 2019/11/01 16:20:41.506775 subscriber.go:172: 	level=DEBUG msg="consumeMessages stopped" consumer_group=cg_9d09a750-cee9-402d-b6e9-5549781ef810 kafka_consumer_uuid=fsXW4sWL3Bs2XPoaHY5PXj provider=kafka subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F topic=topic_a1916770-8048-4928-ae01-3768f760d229 
[watermill] 2019/11/01 16:20:41.506828 subscriber.go:181: 	level=DEBUG msg="Closing subscriber, no reconnect needed" consumer_group=cg_9d09a750-cee9-402d-b6e9-5549781ef810 kafka_consumer_uuid=fsXW4sWL3Bs2XPoaHY5PXj provider=kafka subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F topic=topic_a1916770-8048-4928-ae01-3768f760d229 
[watermill] 2019/11/01 16:20:41.506867 subscriber.go:417: 	level=DEBUG msg="Kafka subscriber closed" subscriber_uuid=6PLBzrNsMkvZZFjPzWxa9F 
panic: assignment to entry in nil map

goroutine 1939 [running]:
github.com/Shopify/sarama.(*client).registerBroker(0xc0015b6f30, 0xc004cce380)
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/client.go:533 +0x2cb
github.com/Shopify/sarama.(*client).updateMetadata(0xc0015b6f30, 0xc00254a500, 0xc00254a500, 0x0, 0x0, 0x0)
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/client.go:844 +0xde
github.com/Shopify/sarama.(*client).tryRefreshMetadata(0xc0015b6f30, 0xc00027e1e0, 0x1, 0x1, 0x3, 0x0, 0x0, 0x0, 0xd83b20, 0x1)
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/client.go:789 +0x831
github.com/Shopify/sarama.(*client).RefreshMetadata(0xc0015b6f30, 0xc00027e1e0, 0x1, 0x1, 0x28, 0x7f9011ab2601)
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/client.go:442 +0xb0
github.com/Shopify/sarama.(*consumerGroup).topicToPartitionNumbers(0xc000179560, 0xc00027e1e0, 0x1, 0x1, 0xc000036500, 0xc001b4d6b8, 0x4)
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/consumer_group.go:472 +0x72
github.com/Shopify/sarama.(*consumerGroup).loopCheckPartitionNumbers(0xc000179560, 0xc00027e1e0, 0x1, 0x1, 0xc0015e3980)
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/consumer_group.go:450 +0x105
created by github.com/Shopify/sarama.(*consumerGroup).Consume
	/home/robert/go/pkg/mod/github.com/!shopify/sarama@v1.24.1/consumer_group.go:178 +0x236
FAIL	github.com/ThreeDotsLabs/watermill-kafka/v2/pkg/kafka	3.635s
```

It can be reproduced by running in https://github.com/ThreeDotsLabs/watermill-kafka on commit `bdc2102750adb8d43389a8bd9d1621e645c787dc` from `fix-tests` branch repository:

```
go get -u github.com/Shopify/sarama@v1.24.1
docker-compose up -d
make test_short
```

