### PR TITLE
fix incorrect SetTopicMetadata name mentions (introduced in 2052bd9)

### DIFF
--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -63,13 +63,13 @@ func (c *Consumer) ConsumePartition(topic string, partition int32, offset int64)
 	return pc, nil
 }
 
-// Topics returns a list of topics, as registered with SetMetadata
+// Topics returns a list of topics, as registered with SetTopicMetadata
 func (c *Consumer) Topics() ([]string, error) {
 	c.l.Lock()
 	defer c.l.Unlock()
 
 	if c.metadata == nil {
-		c.t.Errorf("Unexpected call to Topics. Initialize the mock's topic metadata with SetMetadata.")
+		c.t.Errorf("Unexpected call to Topics. Initialize the mock's topic metadata with SetTopicMetadata.")
 		return nil, sarama.ErrOutOfBrokers
 	}
 
@@ -80,13 +80,13 @@ func (c *Consumer) Topics() ([]string, error) {
 	return result, nil
 }
 
-// Partitions returns the list of parititons for the given topic, as registered with SetMetadata
+// Partitions returns the list of parititons for the given topic, as registered with SetTopicMetadata
 func (c *Consumer) Partitions(topic string) ([]int32, error) {
 	c.l.Lock()
 	defer c.l.Unlock()
 
 	if c.metadata == nil {
-		c.t.Errorf("Unexpected call to Partitions. Initialize the mock's topic metadata with SetMetadata.")
+		c.t.Errorf("Unexpected call to Partitions. Initialize the mock's topic metadata with SetTopicMetadata.")
 		return nil, sarama.ErrOutOfBrokers
 	}
 	if c.metadata[topic] == nil {


### PR DESCRIPTION
2052bd96dcab85d948d0160df9f9c812f39e7641 introduced function [SetTopicMetadata](https://github.com/Shopify/sarama/commit/2052bd96dcab85d948d0160df9f9c812f39e7641#diff-6acb248b0c9e15a39154801da6ee192eR120) but referred to it as to `SetMetadata` in the code which causes confusion if you try to use mock consumer. This PR fixes references to correct name.

UPD: I've signed the CLA.