### PR TITLE
Fix client.tryRefreshMetadata Println

### DIFF
--- a/client.go
+++ b/client.go
@@ -822,7 +822,7 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 	}
 
 	if broker != nil {
-		Logger.Println("client/metadata not fetching metadata from broker %s as we would go past the metadata timeout\n", broker.addr)
+		Logger.Printf("client/metadata not fetching metadata from broker %s as we would go past the metadata timeout\n", broker.addr)
 		return retry(ErrOutOfBrokers)
 	}
 


### PR DESCRIPTION
# Bugfix

`Println` is used instead of `Printf` for logging in `client.tryRefreshMetadata` which result in a bad `%s` substitution and a two lines log statement (see below).
This was introduced in commit fe1b1849d04059a2b197e824095364637405e31f.

## Versions

| Sarama | Kafka | Go |
|--------|-------|----|
| 1358e9c (`v1.24.0`)  | N/A | 1.13  |

## Logs

```
$ DEBUG=true go test -v -run=TestClientMetadataTimeout/timeout=250ms | grep -C 2 "not fetching
metadata"
[sarama] 2019/11/07 09:17:58 Closed connection to broker 127.0.0.1:50294
[sarama] 2019/11/07 09:17:58 ClientID is the default of 'sarama', you should consider setting it to something application-specific.
[sarama] 2019/11/07 09:17:58 client/metadata not fetching metadata from broker %s as we would go past the metadata timeout
 127.0.0.1:50295
[sarama] 2019/11/07 09:17:58 client/metadata skipping last retries as we would go past the metadata timeout
```

## Changes

- use `Printf` instead of `Println`

## Testing done

Ran the same test after applying the fix:
```
$ DEBUG=true go test -v -run=TestClientMetadataTimeout/timeout=250ms | grep -C 2 "not fetching metadata"
[sarama] 2019/11/07 09:18:22 Closed connection to broker 127.0.0.1:50323
[sarama] 2019/11/07 09:18:22 ClientID is the default of 'sarama', you should consider setting it to something application-specific.
[sarama] 2019/11/07 09:18:22 client/metadata not fetching metadata from broker 127.0.0.1:50324 as we would go past the metadata timeout
[sarama] 2019/11/07 09:18:22 client/metadata skipping last retries as we would go past the metadata timeout
[sarama] 2019/11/07 09:18:22 Closing Client
```

## 