### PR TITLE
Add requests-in-flight metric

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -217,6 +217,7 @@ func TestSASLOAuthBearer(t *testing.T) {
 		broker.responseSize = metrics.NilHistogram{}
 		broker.responseRate = metrics.NilMeter{}
 		broker.requestLatency = metrics.NilHistogram{}
+		broker.requestsInFlight = metrics.NilCounter{}
 
 		conf := NewConfig()
 		conf.Net.SASL.Mechanism = SASLTypeOAuth
@@ -335,6 +336,7 @@ func TestSASLSCRAMSHAXXX(t *testing.T) {
 		broker.responseSize = metrics.NilHistogram{}
 		broker.responseRate = metrics.NilMeter{}
 		broker.requestLatency = metrics.NilHistogram{}
+		broker.requestsInFlight = metrics.NilCounter{}
 
 		mockSASLAuthResponse := NewMockSaslAuthenticateResponse(t).SetAuthBytes([]byte(test.scramChallengeResp))
 		mockSASLHandshakeResponse := NewMockSaslHandshakeResponse(t).SetEnabledMechanisms([]string{SASLTypeSCRAMSHA256, SASLTypeSCRAMSHA512})
@@ -453,6 +455,7 @@ func TestSASLPlainAuth(t *testing.T) {
 		broker.responseSize = metrics.NilHistogram{}
 		broker.responseRate = metrics.NilMeter{}
 		broker.requestLatency = metrics.NilHistogram{}
+		broker.requestsInFlight = metrics.NilCounter{}
 
 		conf := NewConfig()
 		conf.Net.SASL.Mechanism = SASLTypePlaintext
@@ -536,6 +539,7 @@ func TestSASLReadTimeout(t *testing.T) {
 		broker.responseSize = metrics.NilHistogram{}
 		broker.responseRate = metrics.NilMeter{}
 		broker.requestLatency = metrics.NilHistogram{}
+		broker.requestsInFlight = metrics.NilCounter{}
 	}
 
 	conf := NewConfig()
@@ -626,6 +630,7 @@ func TestGSSAPIKerberosAuth_Authorize(t *testing.T) {
 		broker.responseSize = metrics.NilHistogram{}
 		broker.responseRate = metrics.NilMeter{}
 		broker.requestLatency = metrics.NilHistogram{}
+		broker.requestsInFlight = metrics.NilCounter{}
 		conf := NewConfig()
 		conf.Net.SASL.Mechanism = SASLTypeGSSAPI
 		conf.Net.SASL.GSSAPI.ServiceName = "kafka"
@@ -989,6 +994,9 @@ func validateBrokerMetrics(t *testing.T, broker *Broker, mockBrokerMetrics broke
 	metricValidators.registerForAllBrokers(broker, countMeterValidator("request-rate", 1))
 	metricValidators.registerForAllBrokers(broker, countHistogramValidator("request-size", 1))
 	metricValidators.registerForAllBrokers(broker, minMaxHistogramValidator("request-size", mockBrokerBytesRead, mockBrokerBytesRead))
+
+	// Check that there is no more requests in flight
+	metricValidators.registerForAllBrokers(broker, counterValidator("requests-in-flight", 0))
 
 	// Run the validators
 	metricValidators.run(t, broker.conf.MetricRegistry)

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -260,6 +260,9 @@ func validateMetrics(t *testing.T, client Client) {
 		metricValidators.registerForBroker(broker, minValHistogramValidator("response-size", 1))
 	}
 
+	// There should be no requests in flight anymore
+	metricValidators.registerForAllBrokers(broker, counterValidator("requests-in-flight", 0))
+
 	// Run the validators
 	metricValidators.run(t, client.Config().MetricRegistry)
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -170,3 +170,19 @@ func maxValHistogramValidator(name string, maxMax int) *metricValidator {
 		}
 	})
 }
+
+func counterValidator(name string, expectedCount int) *metricValidator {
+	return &metricValidator{
+		name: name,
+		validator: func(t *testing.T, metric interface{}) {
+			if counter, ok := metric.(metrics.Counter); !ok {
+				t.Errorf("Expected counter metric for '%s', got %T", name, metric)
+			} else {
+				count := counter.Count()
+				if count != int64(expectedCount) {
+					t.Errorf("Expected counter metric '%s' count = %d, got %d", name, expectedCount, count)
+				}
+			}
+		},
+	}
+}

--- a/sarama.go
+++ b/sarama.go
@@ -39,6 +39,10 @@ Broker related metrics:
 	| response-rate-for-broker-<broker-id>         | meter      | Responses/second received from a given broker                 |
 	| response-size                                | histogram  | Distribution of the response size in bytes for all brokers    |
 	| response-size-for-broker-<broker-id>         | histogram  | Distribution of the response size in bytes for a given broker |
+	| requests-in-flight                           | counter    | The current number of in-flight requests awaiting a response  |
+	|                                              |            | for all brokers                                               |
+	| requests-in-flight-for-broker-<broker-id>    | counter    | The current number of in-flight requests awaiting a response  |
+	|                                              |            | for a given broker                                            |
 	+----------------------------------------------+------------+---------------------------------------------------------------+
 
 Note that we do not gather specific metrics for seed brokers but they are part of the "all brokers" metrics.


### PR DESCRIPTION
# Feature

Add `requests-in-flight` metric similar to the Kafka Java client described as:

> The current number of in-flight requests awaiting a response.

This is an interesting metric to monitor for optimizing throughput when writing to a Kafka cluster on a high latency network link and something that is recommended when implementing the Kafka protocol as described in [their network section](https://kafka.apache.org/protocol#protocol_network):

> The broker's request processing allows only a single in-flight request per connection in order to guarantee this ordering. Note that clients can (and ideally should) use non-blocking IO to implement request pipelining and achieve higher throughput. i.e., clients can send requests even while awaiting responses for preceding requests since the outstanding requests will be buffered in the underlying OS socket buffer.

The related configuration in Sarama is `config.MaxOpenRequests` and defaults to `5` like the Java Kafka client (`max.in.flight.requests.per.connection`).

This configuration is actually not fully honoured when using the `AsyncProducer`, more on that below.

## Changes

- add `requests-in-flight` and `requests-in-flight-for-broker-<brokerID>` metrics to the broker
- move some `b.updateOutgoingCommunicationMetrics(...)` just after `b.write(...)` for consistency
- add `-max-open-requests` flag to `kafka-producer-performance`
- update `kafka-producer-performance` to monitor total requests in flight
- update unit tests
- document new metrics

## Testing done

Running the updated tests:
```
$ export KAFKA_PEERS=192.168.100.67:9091,192.168.100.67:9092,192.168.100.67:9093,192.168.100.67:9094,192.168.100.67:9095
$ go test ./...
ok      github.com/Shopify/sarama       207.703s
ok      github.com/Shopify/sarama/examples/http_server  0.057s
?       github.com/Shopify/sarama/examples/sasl_scram_client    [no test files]
ok      github.com/Shopify/sarama/mocks 0.056s
?       github.com/Shopify/sarama/tools/kafka-console-consumer  [no test files]
?       github.com/Shopify/sarama/tools/kafka-console-partitionconsumer [no test files]
?       github.com/Shopify/sarama/tools/kafka-console-producer  [no test files]
?       github.com/Shopify/sarama/tools/kafka-producer-performance      [no test files]
?       github.com/Shopify/sarama/tools/tls     [no test files]
```

Using the updated `kafka-producer-performance` to see how many total requests are in flight when writing to 5 brokers (with a network latency of ~70ms):
```
$ ./kafka-producer-performance \
  -brokers kafka:9093 \
  -security-protocol SSL \
  -topic topic \
  -message-load 1000000 \
  -message-size 1000 \
  -required-acks -1 \
  -flush-bytes 500000 \
  -flush-frequency 100ms \
  | sed 's/latency,.*,/latency,/'
449761 records sent, 96105.2 records/sec (91.65 MiB/sec ingress, 29.84 MiB/sec egress), 302.5 ms avg latency, 5 total req. in flight
692402 records sent, 63983.6 records/sec (61.02 MiB/sec ingress, 32.43 MiB/sec egress), 382.8 ms avg latency, 1 total req. in flight
981950 records sent, 66890.9 records/sec (63.79 MiB/sec ingress, 38.83 MiB/sec egress), 380.3 ms avg latency, 5 total req. in flight
1000000 records sent, 59960.3 records/sec (57.18 MiB/sec ingress, 36.58 MiB/sec egress), 379.7 ms avg latency, 0 total req. in flight
```

Note that the maximum number of requests in flight is `5` which corresponds to the number of brokers (the topic has 64 partitions spread mostly evenly between those 5 brokers).

And when writing to a single broker/topic partition:
```
$ ./kafka-producer-performance \
  -brokers kafka:9093 \
  -security-protocol SSL \
  -topic topic \
  -message-load 200000 \
  -message-size 1000 \
  -required-acks -1 \
  -flush-bytes 500000 \
  -flush-frequency 100ms \
  | sed 's/latency,.*,/latency,/'
24838 records sent, 9202.7 records/sec (8.78 MiB/sec ingress, 5.09 MiB/sec egress), 100.8 ms avg latency, 1 total req. in flight
76460 records sent, 9931.2 records/sec (9.47 MiB/sec ingress, 7.66 MiB/sec egress), 94.7 ms avg latency, 1 total req. in flight
131004 records sent, 10316.1 records/sec (9.84 MiB/sec ingress, 8.68 MiB/sec egress), 90.9 ms avg latency, 1 total req. in flight
187496 records sent, 10593.6 records/sec (10.10 MiB/sec ingress, 9.28 MiB/sec egress), 88.5 ms avg latency, 1 total req. in flight
200000 records sent, 10549.3 records/sec (10.06 MiB/sec ingress, 9.31 MiB/sec egress), 88.8 ms avg latency, 0 total req. in flight
```

As you can see the number of requests in flight seems to never go above `1` per broker despite having `config.MaxOpenRequests = 5`.

This can be explained by a few things:
- the metric exposed by the `kafka-producer-performance` is captured every 5 seconds and there might not be much requests in flight at that time (could even be `0` when accumulating records or building a `ProduceRequest` prior to sending it)
- the request might be acknowledged fairly fast (hence the scenario with a ~70ms network latency and using `-required-acks=-1`)
- the `AsyncProducer` only allows a single `ProduceRequest` in flight at a time to a broker

The last point can be seen when looking at the following section of the `brokerProducer` where the "bridge" goroutine builds and forwards `ProduceRequest`s one at a time:
https://github.com/Shopify/sarama/blob/675b0b1ff204c259877004140a540d6adf38db17/async_producer.go#L660-L674
and the fact that the `Produce` receiver on a `Broker` is blocking till a response is received or an error occurs:
https://github.com/Shopify/sarama/blob/675b0b1ff204c259877004140a540d6adf38db17/broker.go#L336-L355

I have another contribution pending to address that limitation without creating more go routines that results in better throughput in such scenario.
Nevertheless having such metric is one way to check how many requests are awaiting a response to a given broker or to the whole cluster.