### PR TITLE
Fix ConfigResourceType to match the protocol and server.

### DIFF
--- a/config_resource_type.go
+++ b/config_resource_type.go
@@ -3,20 +3,16 @@ package sarama
 //ConfigResourceType is a type for config resource
 type ConfigResourceType int8
 
-// Taken from :
-// https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs#KIP-133:DescribeandAlterConfigsAdminAPIs-WireFormattypes
+// Note that the ResourceType described here is only accurate for ACLs:
+//   https://cwiki.apache.org/confluence/display/KAFKA/KIP-133%3A+Describe+and+Alter+Configs+Admin+APIs#KIP-133:DescribeandAlterConfigsAdminAPIs-WireFormattypes
+// See the following for the ConfigResource type that is used for Describe and Alter Config operations.
+//   https://github.com/apache/kafka/blob/2.3/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java#L36
 
 const (
 	//UnknownResource constant type
 	UnknownResource ConfigResourceType = iota
-	//AnyResource constant type
-	AnyResource
 	//TopicResource constant type
-	TopicResource
-	//GroupResource constant type
-	GroupResource
-	//ClusterResource constant type
-	ClusterResource
+	TopicResource = 2
 	//BrokerResource constant type
-	BrokerResource
+	BrokerResource = 4
 )


### PR DESCRIPTION
The struct was erroneously setup identical to the ACL Resources and therefore
(a) had more types than describe and alter config operations actually
supported (they only support Broker and Topic types) and (b) had the
wrong integer values.  See reference for actual integer constants
that the server is expecting.