### PR TITLE
Enables zstd (for real this time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+
+#### Unreleased
+
+Improvements:
+- Enable zstd compression
+  ([1574](https://github.com/Shopify/sarama/pull/1574),
+  [1582](https://github.com/Shopify/sarama/pull/1582))
+
 #### Version 1.25.0 (2020-01-13)
 
 New Features:

--- a/config.go
+++ b/config.go
@@ -629,6 +629,10 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if c.Producer.Compression == CompressionZSTD && !c.Version.IsAtLeast(V2_1_0_0) {
+		return ConfigurationError("zstd compression requires Version >= V2_1_0_0")
+	}
+
 	if c.Producer.Idempotent {
 		if !c.Version.IsAtLeast(V0_11_0_0) {
 			return ConfigurationError("Idempotent producer requires Version >= V0_11_0_0")

--- a/config_test.go
+++ b/config_test.go
@@ -405,6 +405,18 @@ func TestLZ4ConfigValidation(t *testing.T) {
 	}
 }
 
+func TestZstdConfigValidation(t *testing.T) {
+	config := NewConfig()
+	config.Producer.Compression = CompressionZSTD
+	if err := config.Validate(); string(err.(ConfigurationError)) != "zstd compression requires Version >= V2_1_0_0" {
+		t.Error("Expected invalid zstd/kafka version error, got ", err)
+	}
+	config.Version = V2_1_0_0
+	if err := config.Validate(); err != nil {
+		t.Error("Expected zstd to work, got ", err)
+	}
+}
+
 // This example shows how to integrate with an existing registry as well as publishing metrics
 // on the standard output
 func ExampleConfig_metrics() {

--- a/consumer.go
+++ b/consumer.go
@@ -888,6 +888,10 @@ func (bc *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 		request.Isolation = bc.consumer.conf.Consumer.IsolationLevel
 	}
 
+	if bc.consumer.conf.Version.IsAtLeast(V2_1_0_0) {
+		request.Version = 10
+	}
+
 	for child := range bc.subscriptions {
 		request.AddBlock(child.topic, child.partition, child.offset, child.fetchSize)
 	}

--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -106,6 +106,21 @@ func TestVersionMatrixLZ4(t *testing.T) {
 	consumeMsgs(t, testVersions, producedMessages)
 }
 
+// Support for zstd codec was introduced in v2.1.0.0
+func TestVersionMatrixZstd(t *testing.T) {
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	// Produce lot's of message with all possible combinations of supported
+	// protocol versions starting with v2.1.0.0 (first where zstd was supported)
+	testVersions := versionRange(V2_1_0_0)
+	allCodecs := []CompressionCodec{CompressionZSTD}
+	producedMessages := produceMsgs(t, testVersions, allCodecs, 17, 100, false)
+
+	// When/Then
+	consumeMsgs(t, testVersions, producedMessages)
+}
+
 func TestVersionMatrixIdempotent(t *testing.T) {
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)

--- a/produce_request.go
+++ b/produce_request.go
@@ -214,6 +214,8 @@ func (r *ProduceRequest) requiredVersion() KafkaVersion {
 		return V0_10_0_0
 	case 3:
 		return V0_11_0_0
+	case 7:
+		return V2_1_0_0
 	default:
 		return MinVersion
 	}

--- a/produce_response.go
+++ b/produce_response.go
@@ -5,11 +5,27 @@ import (
 	"time"
 )
 
+// Protocol, http://kafka.apache.org/protocol.html
+// v1
+// v2 = v3 = v4
+// v5 = v6 = v7
+// Produce Response (Version: 7) => [responses] throttle_time_ms
+//   responses => topic [partition_responses]
+//     topic => STRING
+//     partition_responses => partition error_code base_offset log_append_time log_start_offset
+//       partition => INT32
+//       error_code => INT16
+//       base_offset => INT64
+//       log_append_time => INT64
+//       log_start_offset => INT64
+//   throttle_time_ms => INT32
+
+// partition_responses in protocol
 type ProduceResponseBlock struct {
-	Err    KError
-	Offset int64
-	// only provided if Version >= 2 and the broker is configured with `LogAppendTime`
-	Timestamp time.Time
+	Err         KError    // v0, error_code
+	Offset      int64     // v0, base_offset
+	Timestamp   time.Time // v2, log_append_time, and the broker is configured with `LogAppendTime`
+	StartOffset int64     // v5, log_start_offset
 }
 
 func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err error) {
@@ -32,6 +48,13 @@ func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err erro
 		}
 	}
 
+	if version >= 5 {
+		b.StartOffset, err = pd.getInt64()
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -49,13 +72,17 @@ func (b *ProduceResponseBlock) encode(pe packetEncoder, version int16) (err erro
 		pe.putInt64(timestamp)
 	}
 
+	if version >= 5 {
+		pe.putInt64(b.StartOffset)
+	}
+
 	return nil
 }
 
 type ProduceResponse struct {
-	Blocks       map[string]map[int32]*ProduceResponseBlock
+	Blocks       map[string]map[int32]*ProduceResponseBlock // v0, responses
 	Version      int16
-	ThrottleTime time.Duration // only provided if Version >= 1
+	ThrottleTime time.Duration // v1, throttle_time_ms
 }
 
 func (r *ProduceResponse) decode(pd packetDecoder, version int16) (err error) {
@@ -129,6 +156,7 @@ func (r *ProduceResponse) encode(pe packetEncoder) error {
 			}
 		}
 	}
+
 	if r.Version >= 1 {
 		pe.putInt32(int32(r.ThrottleTime / time.Millisecond))
 	}
@@ -141,19 +169,6 @@ func (r *ProduceResponse) key() int16 {
 
 func (r *ProduceResponse) version() int16 {
 	return r.Version
-}
-
-func (r *ProduceResponse) requiredVersion() KafkaVersion {
-	switch r.Version {
-	case 1:
-		return V0_9_0_0
-	case 2:
-		return V0_10_0_0
-	case 3:
-		return V0_11_0_0
-	default:
-		return MinVersion
-	}
 }
 
 func (r *ProduceResponse) GetBlock(topic string, partition int32) *ProduceResponseBlock {

--- a/produce_set.go
+++ b/produce_set.go
@@ -129,6 +129,10 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 		req.Version = 3
 	}
 
+	if ps.parent.conf.Producer.Compression == CompressionZSTD && ps.parent.conf.Version.IsAtLeast(V2_1_0_0) {
+		req.Version = 7
+	}
+
 	for topic, partitionSets := range ps.msgs {
 		for partition, set := range partitionSets {
 			if req.Version >= 3 {


### PR DESCRIPTION
Zstd support was initially added to sarama before
https://issues.apache.org/jira/browse/KAFKA-4514
https://cwiki.apache.org/confluence/display/KAFKA/KIP-110%3A+Add+Codec+for+ZStandard+Compression
was done.

The final release added some changes like bumping the produce and fetch
requests to only allow new clients to use zstd.

This PR tries to do that, however, there are some other protocol changes
that are not addressed on this PR, and I'm not sure what would be the
effect of bumping the produce and fetch requests without filling the
protocol gaps.

Tries to solve https://github.com/Shopify/sarama/issues/1252

TODO:
- [x] Test consumers via https://github.com/Shopify/sarama/pull/1582

## Update 2020-01-15 13:00 ET

- it seems it's working fine after my latests commits 🎉 

Now I need to figure it out what to do with the new producer response field, or just leave it like that?


## Update 2020-01-15 11:00 ET
- It still doesn't work :(~

It's however and improvement from the current state, this is the new error message:
```
producer/broker/1 state change to [closing] because kafka: error decoding packet: invalid length
```

current master result: (from https://github.com/Shopify/sarama/issues/1252)
```
SARAMA: producer/broker/1 starting up
SARAMA: producer/broker/1 state change to [open] on sarama-test/0
SARAMA: Connected to broker at localhost:9092 (registered as #1)
SARAMA: producer/broker/1 state change to [closing] because EOF
SARAMA: Closed connection to broker localhost:9092
TEST:   sending message failed: EOF
SARAMA: Producer shutting down.
SARAMA: Closing Client
SARAMA: Closed connection to broker localhost:9092
SARAMA: producer/broker/1 shut down
```

Proposed change: (`make testzstd`)
```
╭─[10:44:05] diegoalvarez@d1egoaz-MBP/ ~/src/github.com/Shopify/sarama
( diego_zstd-support-kafka-2_1_0_0: ✔
╰─✘ make testzstd
go test -run TestSaramaZSTD
>>> kafka version 2.1.0
Initializing new client
client/metadata fetching metadata for all topics from broker localhost:9092
Connected to broker at localhost:9092 (unregistered)
>>> encoder_decoder.go on versionedDecode, realDecoder, version: 5
>>> encoder_decoder.go helper.off != len(buf), off: 163, len: 163, version: 5
client/brokers registered new broker #1 at localhost:9092
Successfully initialized new client
producer/broker/1 starting up
producer/broker/1 state change to [open] on sarama-test/0
>>> produce_set.go buildRequest() set req.Version = 7 with compression zstd
Connected to broker at localhost:9092 (registered as #1)
>>> produce_request.go requiredVersion r.Version 7
>>> record_batch.go on encode
>>> record_batch.go/encodeRecords() compressing message on encodeRecords
>>> compressing with zstd
>>> record_batch.go/encodeRecords() NO err compressing message on encodeRecords
>>> record_batch.go put raw bytes on encode
>>> record_batch.go pe.pop on encode
>>> record_batch.go NO err pe.pop on encode
>>> record_batch.go on encode
>>> record_batch.go put raw bytes on encode
>>> record_batch.go pe.pop on encode
>>> record_batch.go NO err pe.pop on encode
>>> encoder_decoder.go on versionedDecode, realDecoder, version: 7
>>> encoder_decoder.go helper.off != len(buf), off: 47, len: 55, version: 7
>>> encoder_decoder.go on versionedDecode, version 7
producer/broker/1 state change to [closing] because kafka: error decoding packet: invalid length
Closed connection to broker localhost:9092
Producer shutting down.
Closing Client
Closed connection to broker localhost:9092
producer/broker/1 input chan closed
producer/broker/1 shut down
--- FAIL: TestSaramaZSTD (0.03s)
    zstd_test.go:45: TEST:   sending message failed: kafka: error decoding packet: invalid length
FAIL
exit status 1
FAIL    github.com/Shopify/sarama       5.422s
```

Code is failing here:
```
>>> encoder_decoder.go helper.off != len(buf), off: 47, len: 55, version: 7
```
I'm not sure what I'm missing, I'm currently 👀 the java source code.

Any help would be appreciated.