### PR TITLE
fix: set DescribeConfigRequest Version field

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -452,13 +452,20 @@ func dependsOnSpecificNode(resource ConfigResource) bool {
 }
 
 func (ca *clusterAdmin) DescribeConfig(resource ConfigResource) ([]ConfigEntry, error) {
-
 	var entries []ConfigEntry
 	var resources []*ConfigResource
 	resources = append(resources, &resource)
 
 	request := &DescribeConfigsRequest{
 		Resources: resources,
+	}
+
+	if ca.conf.Version.IsAtLeast(V1_1_0_0) {
+		request.Version = 1
+	}
+
+	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		request.Version = 2
 	}
 
 	var (

--- a/admin_test.go
+++ b/admin_test.go
@@ -2,10 +2,6 @@ package sarama
 
 import (
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"log"
-	"os"
 	"strings"
 	"testing"
 )
@@ -550,9 +546,6 @@ func TestClusterAdminDescribeConfig(t *testing.T) {
 // TestClusterAdminDescribeBrokerConfig ensures that a describe broker config
 // is sent to the broker in the resource struct, _not_ the controller
 func TestClusterAdminDescribeBrokerConfig(t *testing.T) {
-	Logger = log.New(os.Stdout, fmt.Sprintf("[%s] ", t.Name()), log.LstdFlags)
-	defer func() { Logger = log.New(ioutil.Discard, "[Sarama] ", log.LstdFlags) }()
-
 	controllerBroker := NewMockBroker(t, 1)
 	defer controllerBroker.Close()
 	configBroker := NewMockBroker(t, 2)


### PR DESCRIPTION
Although fbd8338 had added protocol support for DescribeConfigsRequest
v1 and v2, nothing in the admin client was actually setting the Version
field to utilise these. Set the Version based on the selected
sarama.Config version.