### PR TITLE
fix: MetadataRequest version in DescribeCluster

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -216,7 +216,7 @@ func (ca *clusterAdmin) DescribeCluster() (brokers []*Broker, controllerID int32
 		Topics: []string{},
 	}
 
-	if ca.conf.Version.IsAtLeast(V0_11_0_0) {
+	if ca.conf.Version.IsAtLeast(V0_10_0_0) {
 		request.Version = 1
 	}
 


### PR DESCRIPTION
A very minor fix, but the v1 MetadataRequest (which returns the
controller ID) was actually introduced in Kafka 0.10.0.0 (not 0.11.0.0)
under https://issues.apache.org/jira/browse/KAFKA-3306 so can be used
there.