### PR TITLE
fix misleading example for cluster admin

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -615,8 +615,8 @@ func TestClusterAdminAlterConfig(t *testing.T) {
 
 	var value string
 	entries := make(map[string]*string)
-	value = "3"
-	entries["ReplicationFactor"] = &value
+	value = "60000"
+	entries["retention.ms"] = &value
 	err = admin.AlterConfig(TopicResource, "my_topic", entries, false)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
fixes https://github.com/Shopify/sarama/issues/1238


``` text
kafka_1        | [2020-01-31 20:01:54,868] INFO [Admin Manager on Broker 1001]: Updating topic test.1.nokey with new configuration org.apache.kafka.common.requests.AlterConfigsRequest$Config@614a2b22 (kafka.server.AdminManager)
zookeeper_1    | [2020-01-31 20:01:54,880] INFO Got user-level KeeperException when processing sessionid:0x100008cfc4f0000 type:create cxid:0x3bf zxid:0x1eb txntype:-1 reqpath:n/a Error Path:/config/changes Error:KeeperErrorCode = NodeExists for /config/changes (org.apache.zookeeper.server.PrepRequestProcessor)
kafka_1        | [2020-01-31 20:01:54,930] INFO Processing notification(s) to /config/changes (kafka.common.ZkNodeChangeNotificationListener)
kafka_1        | [2020-01-31 20:01:54,953] INFO Processing override for entityPath: topics/test.1.nokey with config: Map(retention.ms -> 60000) (kafka.server.DynamicConfigManager)
kafka_1        | [2020-01-31 20:01:54,961] WARN [Log partition=test.1.nokey-0, dir=/kafka/kafka-logs-d40879780272] retention.ms for topic test.1.nokey is set to 60000. It is smaller than message.timestamp.difference.max.ms's value 9223372036854775807. This may result in frequent log rolling. (kafka.log.Log)

```