### PR TITLE
tests: remove unused testLogger

### DIFF
--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -311,22 +311,6 @@ func TestAsyncProducerFailureRetry(t *testing.T) {
 	closeProducer(t, producer)
 }
 
-type testLogger struct {
-	t *testing.T
-}
-
-func (l *testLogger) Print(v ...interface{}) {
-	l.t.Log(v...)
-}
-
-func (l *testLogger) Printf(format string, v ...interface{}) {
-	l.t.Logf(format, v...)
-}
-
-func (l *testLogger) Println(v ...interface{}) {
-	l.t.Log(v...)
-}
-
 func TestAsyncProducerRecoveryWithRetriesDisabled(t *testing.T) {
 	tt := func(t *testing.T, kErr KError) {
 		seedBroker := NewMockBroker(t, 1)


### PR DESCRIPTION
This removes `testLogger{}` and its functions. It is unused today, and it appears to have been unused since its introduction in 8/2019.

@dnwe, am I missing anything here?