### PR TITLE
Fix memory leak when Broker.Open and Broker.Close called repeatedly

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1367,6 +1367,7 @@ func (b *Broker) unregisterMetrics() {
 	for _, name := range b.registeredMetrics {
 		b.conf.MetricRegistry.Unregister(name)
 	}
+	b.registeredMetrics = nil
 }
 
 func (b *Broker) registerMeter(name string) metrics.Meter {


### PR DESCRIPTION
Broker.registeredMetrics is increased in Broker.Open, but isn't cleared in Broker.Close.
So when Open and Close is called repeatedly it causes memory leak.