### PR TITLE
Updated "retrying" log message when BackoffFunc implemented

### DIFF
--- a/client.go
+++ b/client.go
@@ -798,7 +798,7 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 				Logger.Println("client/metadata skipping last retries as we would go past the metadata timeout")
 				return err
 			}
-			Logger.Printf("client/metadata retrying after %dms... (%d attempts remaining)\n", client.conf.Metadata.Retry.Backoff/time.Millisecond, attemptsRemaining)
+			Logger.Printf("client/metadata retrying after %dms... (%d attempts remaining)\n", backoff/time.Millisecond, attemptsRemaining)
 			if backoff > 0 {
 				time.Sleep(backoff)
 			}


### PR DESCRIPTION
The "client/metadata retrying" log message was always reporting
the sleep duration as `config.Metadata.Retry.Backoff`, regardless
of whether `config.Metadata.Retry.BackoffFunc` is implemented.

We now report the actual retry time before sleeping.