### PR TITLE
Prune Unused Test Types and Variables

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -23,10 +23,8 @@ var (
 	kafkaAvailable, kafkaRequired bool
 	kafkaBrokers                  []string
 
-	proxyClient  *toxiproxy.Client
-	Proxies      map[string]*toxiproxy.Proxy
-	ZKProxies    = []string{"zk1", "zk2", "zk3", "zk4", "zk5"}
-	KafkaProxies = []string{"kafka1", "kafka2", "kafka3", "kafka4", "kafka5"}
+	proxyClient *toxiproxy.Client
+	Proxies     map[string]*toxiproxy.Proxy
 )
 
 func init() {

--- a/kerberos_client_test.go
+++ b/kerberos_client_test.go
@@ -13,20 +13,6 @@ import (
  * properly.
  *
  */
-const TEST_KRB5CONF = `
-[libdefaults]
-default_realm = EXAMPLE.COM
-
-[realms]
-EXAMPLE.COM = {
-kdc = kerberos.example.com
-admin_server = kerberos.example.com
-}
-
-[domain_realm]
-.example.com = EXAMPLE.COM
-example.com = EXAMPLE.COM
-`
 
 func TestFaildToCreateKerberosConfig(t *testing.T) {
 	expectedErr := errors.New("configuration file could not be opened: krb5.conf open krb5.conf: no such file or directory")

--- a/request_test.go
+++ b/request_test.go
@@ -8,21 +8,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-type testRequestBody struct {
-}
-
-func (s *testRequestBody) key() int16 {
-	return 0x666
-}
-
-func (s *testRequestBody) version() int16 {
-	return 0xD2
-}
-
-func (s *testRequestBody) encode(pe packetEncoder) error {
-	return pe.putString("abc")
-}
-
 // not specific to request tests, just helper functions for testing structures that
 // implement the encoder or decoder interfaces that needed somewhere to live
 


### PR DESCRIPTION
This removes some unused variables and the `testRequestBody` type from the tests.