### PR TITLE
feat: allow balance strategies to provide initial state

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 MEMORY = 3072
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/trusty64"
 
   config.vm.provision :shell, path: "vagrant/provision.sh"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 MEMORY = 3072
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/bionic64"
 
   config.vm.provision :shell, path: "vagrant/provision.sh"
 


### PR DESCRIPTION
This update will allow stateful balance strategies to provide initial state information to send as part of the `joinGroupRequest`.

Previous to this PR if initial data was provided via `c.config.Consumer.Group.Member.UserData` it would always be sent when re-joining. This would trump the previous assignment data returned as part of the `syncGroupRequest`. After this PR the initial data will be sent when there is no currently assigned user-data that was returned as part of the assignment.