### PR TITLE
Make flushToBroker function retryable in the main loop

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -225,8 +225,12 @@ func (om *offsetManager) mainLoop() {
 	for {
 		select {
 		case <-om.ticker.C:
-			om.flushToBroker()
-			om.releasePOMs(false)
+			for attempt := 0; attempt <= om.conf.Consumer.Offsets.Retry.Max; attempt++ {
+				om.flushToBroker()
+				if om.releasePOMs(false) == 0 {
+					break
+				}
+			}
 		case <-om.closing:
 			return
 		}


### PR DESCRIPTION
https://github.com/Shopify/sarama/issues/1562

Trying to make a `flushToBroker` function retryable when an error occurs in the main loop. Cherry-picked the features from https://github.com/Shopify/sarama/blob/master/offset_manager.go#L108-L113 