### PR TITLE
fix `config.net.keepalive`

### DIFF
--- a/config.go
+++ b/config.go
@@ -538,8 +538,6 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Net.ReadTimeout must be > 0")
 	case c.Net.WriteTimeout <= 0:
 		return ConfigurationError("Net.WriteTimeout must be > 0")
-	case c.Net.KeepAlive < 0:
-		return ConfigurationError("Net.KeepAlive must be >= 0")
 	case c.Net.SASL.Enable:
 		if c.Net.SASL.Mechanism == "" {
 			c.Net.SASL.Mechanism = SASLTypePlaintext

--- a/config.go
+++ b/config.go
@@ -96,8 +96,9 @@ type Config struct {
 			GSSAPI GSSAPIConfig
 		}
 
-		// KeepAlive specifies the keep-alive period for an active network connection.
-		// If zero, keep-alives are disabled. (default is 0: disabled).
+		// KeepAlive specifies the keep-alive period for an active network connection (defaults to 0).
+		// If zero or positive, keep-alives are enabled.
+		// If negative, keep-alives are disabled.
 		KeepAlive time.Duration
 
 		// LocalAddr is the local address to use when dialing an

--- a/config_test.go
+++ b/config_test.go
@@ -67,11 +67,6 @@ func TestNetConfigValidates(t *testing.T) {
 				cfg.Net.WriteTimeout = 0
 			},
 			"Net.WriteTimeout must be > 0"},
-		{"KeepAlive",
-			func(cfg *Config) {
-				cfg.Net.KeepAlive = -1
-			},
-			"Net.KeepAlive must be >= 0"},
 		{"SASL.User",
 			func(cfg *Config) {
 				cfg.Net.SASL.Enable = true


### PR DESCRIPTION
According to https://github.com/golang/go/blob/master/src/net/dial.go#L81

tcp keepalive is **ENABLED** when `KeepAlive` is set to 0 by default