### PR TITLE
Return the response error in heartbeatLoop

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -760,7 +760,7 @@ func (s *consumerGroupSession) heartbeatLoop() {
 		case ErrRebalanceInProgress, ErrUnknownMemberId, ErrIllegalGeneration:
 			return
 		default:
-			s.parent.handleError(err, "", -1)
+			s.parent.handleError(resp.Err, "", -1)
 			return
 		}
 


### PR DESCRIPTION
`err` is always `nil`, it is checked above already.