### PR TITLE
Fix outdated website readme

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,11 +8,9 @@ API documentation and examples are available via [godoc](https://godoc.org/githu
 
 ## Compatibility and API stability
 
-Sarama provides a "2 releases + 2 months" compatibility guarantee: we support
-the two latest stable releases of Kafka and Go, and we provide a two month
-grace period for older releases. This means we currently officially support
-Go 1.7 and 1.6, and Kafka 0.10.0 and 0.9.0, although older releases are still
-likely to work.
+Sarama provides a "2 releases + 2 months" compatibility guarantee: we support the two latest stable releases of
+Kafka and Go, and we provide a two month grace period for older releases. This means we currently officially
+support Go 1.12 through 1.14, and Kafka 2.1 through 2.4, although older releases are still likely to work.
 
 Sarama follows semantic versioning and provides API stability via the gopkg.in service.
 You can import a version with a guaranteed stable API via http://gopkg.in/Shopify/sarama.v1.


### PR DESCRIPTION
The text on https://shopify.github.io/sarama/ is outdated. 

This updates the text to match the project readme.

Fix https://github.com/Shopify/sarama/issues/1248.