### PR TITLE
support skipPastOffset feature which enable after rebalance start reading message that sent after rebalance event.

### DIFF
--- a/config.go
+++ b/config.go
@@ -273,6 +273,9 @@ type Config struct {
 					// Backoff time between retries during rebalance (default 2s)
 					Backoff time.Duration
 				}
+				// EnableSkipPast enable after rebalance occurred to skip messages that were produced before
+				// rebalance and start consuming only "fresh" messages that were produced after rebalance occurred
+				EnableSkipPast bool
 			}
 			Member struct {
 				// Custom metadata to include when joining the group. The user data for all joined members

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -654,6 +654,15 @@ func (s *consumerGroupSession) consume(topic string, partition int32) {
 		offset, _ = pom.NextOffset()
 	}
 
+	if s.parent.config.Consumer.Group.Rebalance.EnableSkipPast {
+		newestOffset, err := s.parent.client.GetOffset(topic, partition, OffsetNewest)
+		if nil != err {
+			s.parent.handleError(err, topic, partition)
+			return
+		}
+		offset = newestOffset
+	}
+
 	// create new claim
 	claim, err := newConsumerGroupClaim(s, topic, partition, offset)
 	if err != nil {


### PR DESCRIPTION
support skipPastOffset feature which enable after rebalance skip all unconsumed messages sent before rebalance and startOffset consuming messages that were produced after rebalance