### PR TITLE
Fix auto-commit bug and make a feature of auto-commit

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -235,10 +235,6 @@ func (om *offsetManager) mainLoop() {
 
 // flushToBroker is ignored if auto-commit offsets is disabled
 func (om *offsetManager) flushToBroker() {
-	if !om.conf.Consumer.Offsets.AutoCommit.Enable {
-		return
-	}
-
 	req := om.constructRequest()
 	if req == nil {
 		return


### PR DESCRIPTION
I believe that the sarama-cluster hasn’t designed the auto-commit feature. What we have to do is updating the offset via MarkOffset/MarkMessage after consuming the message.

Here is its reason:
1. Offset manager is completely independent of the consumer. flushToBroker in main-loop has only flush offset to the broker but it doesn’t update the offset. 
2. It has no relation between the offset updating and the consumer in sarama. Currently, the offset updating depends on the Markoffset after consuming the message.   
3. If auto-commit want to be supported in sarama, it should update the offset when fetching messages. After offset updating, the main-loop will handle commit things left. 


So this fix is made via updating the offset.