### PR TITLE
Fix auto-commit bug and make a feature of auto-commit

### DIFF
--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -190,6 +190,7 @@ type PartitionConsumer struct {
 	consumed                bool
 	errorsShouldBeDrained   bool
 	messagesShouldBeDrained bool
+	offsetFetched           chan int64
 }
 
 ///////////////////////////////////////////////////
@@ -262,6 +263,12 @@ func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
 func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
 	return pc.messages
 }
+
+// Messages offset fetched.
+func (pc *PartitionConsumer) OffsetFetched() <-chan int64 {
+	return pc.offsetFetched
+}
+
 
 func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {
 	return atomic.LoadInt64(&pc.highWaterMarkOffset) + 1

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -235,10 +235,6 @@ func (om *offsetManager) mainLoop() {
 
 // flushToBroker is ignored if auto-commit offsets is disabled
 func (om *offsetManager) flushToBroker() {
-	if !om.conf.Consumer.Offsets.AutoCommit.Enable {
-		return
-	}
-
 	req := om.constructRequest()
 	if req == nil {
 		return


### PR DESCRIPTION
I believe that the sarama-cluster hasn’t designed the auto-commit feature. What we have to do is updating the offset via MarkOffset/MarkMessage after consuming the message.

Here is its reason:

Offset manager is completely independent of the consumer. flushToBroker in main-loop has only flush offset to the broker but it doesn’t update the offset.
It has no relation between the offset updating and the consumer in sarama. Currently, the offset updating depends on the Markoffset after consuming the message.
If auto-commit want to be supported in sarama, it should update the offset when fetching messages. After offset updating, the main-loop will handle commit things left.

So this fix is made via updating the offset.

