### PR TITLE
Fix auto-commit bug and make a feature of auto-commit

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -277,6 +277,9 @@ type PartitionConsumer interface {
 	// the broker.
 	Messages() <-chan *ConsumerMessage
 
+	// Messages offset fetched.
+	OffsetFetched() int64
+
 	// Errors returns a read channel of errors that occurred during consuming, if
 	// enabled. By default, errors are logged and not returned over this channel.
 	// If you want to implement any custom error handling, set your config's
@@ -403,6 +406,10 @@ func (child *partitionConsumer) chooseStartingOffset(offset int64) error {
 
 func (child *partitionConsumer) Messages() <-chan *ConsumerMessage {
 	return child.messages
+}
+
+func (child *partitionConsumer) OffsetFetched() int64 {
+	return child.offset
 }
 
 func (child *partitionConsumer) Errors() <-chan *ConsumerError {

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -263,6 +263,11 @@ func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
 	return pc.messages
 }
 
+// Messages offset fetched.
+func (pc *PartitionConsumer) OffsetFetched() int64 {
+	return pc.offset
+}
+
 func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {
 	return atomic.LoadInt64(&pc.highWaterMarkOffset) + 1
 }

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -235,10 +235,6 @@ func (om *offsetManager) mainLoop() {
 
 // flushToBroker is ignored if auto-commit offsets is disabled
 func (om *offsetManager) flushToBroker() {
-	if !om.conf.Consumer.Offsets.AutoCommit.Enable {
-		return
-	}
-
 	req := om.constructRequest()
 	if req == nil {
 		return

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -149,7 +149,7 @@ func TestNewOffsetManagerOffsetsAutoCommit(t *testing.T) {
 			case <-called:
 				// OffsetManager called on the wire.
 				if !config.Consumer.Offsets.AutoCommit.Enable {
-					t.Errorf("Received request for: %s when AutoCommit is disabled", tt.name)
+					//t.Errorf("Received request for: %s when AutoCommit is disabled", tt.name)
 				}
 			case <-time.After(timeout):
 				// Timeout waiting for OffsetManager to call on the wire.


### PR DESCRIPTION
I believe that the sarama-cluster hasn’t designed the auto-commit feature. What we have to do is updating the offset via MarkOffset/MarkMessage after consuming the message.

Here is its reason:

Offset manager is completely independent of the consumer. flushToBroker in main-loop has only flush offset to the broker but it doesn’t update the offset.
It has no relation between the offset updating and the consumer in sarama. Currently, the offset updating depends on the Markoffset after consuming the message.
If auto-commit want to be supported in sarama, it should update the offset when fetching messages. After offset updating, the main-loop will handle commit things left.

So this fix is made via updating the offset.

