### PR TITLE
Set ServerName using tls.DialWithDialer approach

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -165,6 +165,17 @@ func (b *Broker) Open(conf *Config) error {
 
 		if conf.Net.TLS.Enable {
 			Logger.Printf("Using tls")
+
+			// If no ServerName is set, infer the ServerName
+			// from the hostname we're connecting to.
+			if conf.Net.TLS.Config.ServerName == "" {
+				colonPos := strings.LastIndex(b.addr, ":")
+				if colonPos == -1 {
+					colonPos = len(b.addr)
+				}
+				hostname := b.addr[:colonPos]
+				conf.Net.TLS.Config.ServerName = hostname
+			}
 			b.conn = tls.Client(b.conn, conf.Net.TLS.Config)
 		}
 

--- a/broker.go
+++ b/broker.go
@@ -165,18 +165,22 @@ func (b *Broker) Open(conf *Config) error {
 
 		if conf.Net.TLS.Enable {
 			Logger.Printf("Using tls")
-
+			cfg := conf.Net.TLS.Config
+			if cfg == nil {
+				cfg = &tls.Config{}
+			}
 			// If no ServerName is set, infer the ServerName
 			// from the hostname we're connecting to.
-			if conf.Net.TLS.Config.ServerName == "" {
+			// Gets the hostname as tls.DialWithDialer does it.
+			if cfg.ServerName == "" {
 				colonPos := strings.LastIndex(b.addr, ":")
 				if colonPos == -1 {
 					colonPos = len(b.addr)
 				}
 				hostname := b.addr[:colonPos]
-				conf.Net.TLS.Config.ServerName = hostname
+				cfg.ServerName = hostname
 			}
-			b.conn = tls.Client(b.conn, conf.Net.TLS.Config)
+			b.conn = tls.Client(b.conn, cfg)
 		}
 
 		b.conn = newBufConn(b.conn)

--- a/client_tls_test.go
+++ b/client_tls_test.go
@@ -158,8 +158,7 @@ func TestTLS(t *testing.T) {
 			Succeed: true,
 			Server:  serverTLSConfig,
 			Client: &tls.Config{
-				RootCAs:    pool,
-				ServerName: "127.0.0.1",
+				RootCAs: pool,
 				Certificates: []tls.Certificate{{
 					Certificate: [][]byte{clientDer},
 					PrivateKey:  clientkey,


### PR DESCRIPTION
fixes https://github.com/Shopify/sarama/issues/1691

TBH I'm not sure if this is enough.

There was a big change here:
https://github.com/Shopify/sarama/pull/1666/files#diff-019034382244c82f15c92490660e4a18
`s/tls.DialWithDialer/tls.Client`

and all code that was in `tls.DialWithDialer` is not in `tls.Client`, so no handshake, timeouts, etc.
https://github.com/golang/go/blob/go1.14.2/src/crypto/tls/tls.go#L102