### PR TITLE
testfix: give kafka longer to startup

### DIFF
--- a/vagrant/boot_cluster.sh
+++ b/vagrant/boot_cluster.sh
@@ -4,8 +4,8 @@ set -ex
 
 # Launch and wait for toxiproxy
 ${REPOSITORY_ROOT}/vagrant/run_toxiproxy.sh &
-while ! nc -q 1 localhost 2181 </dev/null; do echo "Waiting"; sleep 1; done
-while ! nc -q 1 localhost 9092 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost 2185 </dev/null; do echo "Waiting"; sleep 1; done
+while ! nc -q 1 localhost 9095 </dev/null; do echo "Waiting"; sleep 1; done
 
 # Launch and wait for Zookeeper
 for i in 1 2 3 4 5; do
@@ -21,21 +21,20 @@ for i in 1 2 3 4 5; do
 done
 ps auxww | grep -i kafka
 
-N=10
+N=120
 RC=1
 set +x
-printf "Waiting for Kafka to become available."
+printf "Waiting for kafka5 to become available."
 for _ in $(seq 1 "$N"); do
   if nc -z 127.0.0.1 29095 </dev/null; then
       RC=0
       break
   fi
-  printf "."
   sleep 1
 done
 printf "\n"
 if [ "$RC" -gt 0 ]; then
-  echo 'Error: Kafka failed to startup' >&2
-  find "${KAFKA_INSTALL_ROOT}" -name "server.log" -print0 | xargs tail -256
+  echo 'Error: kafka5 failed to startup' >&2
+  find "${KAFKA_INSTALL_ROOT}/kafka-${KAFKA_PORT}" -name "server.log" -print0 | xargs -0 --no-run-if-empty tail -256
   exit ${RC}
 fi


### PR DESCRIPTION
For some reason we'd ended up with quite a short (10s) limit on waiting
for Kafka to startup and open its listener and since moving from Travis
to GitHub actions, this can periodically take longer causing the build
to abort early. Bump it up to 2m and tweak a couple of other parts of
the boot script.