### PR TITLE
Fix test case that was comparing the same operands.

### DIFF
--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -2151,7 +2151,7 @@ func verifyValidityAndBalance(t *testing.T, consumers map[string]ConsumerGroupMe
 		for assignedTopic := range plan[memberID] {
 			found := false
 			for _, assignableTopic := range consumers[memberID].Topics {
-				if assignableTopic == assignableTopic {
+				if assignedTopic == assignableTopic {
 					found = true
 					break
 				}


### PR DESCRIPTION
Hey there!
I was scanning a bunch of Go code (https://semgrep.live/scan/aa183fff-28ad-475b-ba8e-26a3830a7f1d) and found what looks like an issue.

[Semgrep](https://semgrep.dev) lets us specify code patterns to search for, and we like to use `x == x` to test because it is usually an indicator of a bug. In this case, I happened to find this comparison `assignableTopic == assignableTopic` in the test file `balance_strategy_test.go`.
From the context, I assume that `assignedTopic == assignableTopic` was intended.

This probably isn't a big deal, but this PR fixes this identical comparison. Hope it's helpful!