### PR TITLE
Allow consumer configuration to specify replica selector

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,6 +29,9 @@ type Client interface {
 	// Brokers returns the current set of active brokers as retrieved from cluster metadata.
 	Brokers() []*Broker
 
+	// Broker returns the active Broker if available for the brokerID
+	Broker(brokerID int32) (*Broker, error)
+
 	// Topics returns the set of available topics as retrieved from cluster metadata.
 	Topics() ([]string, error)
 
@@ -194,6 +197,17 @@ func (client *client) Brokers() []*Broker {
 		brokers = append(brokers, broker)
 	}
 	return brokers
+}
+
+func (client *client) Broker(brokerID int32) (*Broker, error) {
+	client.lock.RLock()
+	defer client.lock.RUnlock()
+	broker, ok := client.brokers[brokerID]
+	if !ok {
+		return nil, ErrBrokerNotFound
+	}
+	_ = broker.Open(client.conf)
+	return broker, nil
 }
 
 func (client *client) InitProducerID() (*InitProducerIDResponse, error) {

--- a/config.go
+++ b/config.go
@@ -471,6 +471,9 @@ func NewConfig() *Config {
 	c.Consumer.Group.Rebalance.Timeout = 60 * time.Second
 	c.Consumer.Group.Rebalance.Retry.Max = 4
 	c.Consumer.Group.Rebalance.Retry.Backoff = 2 * time.Second
+	c.Consumer.ReplicaSelector = func(topic string, partition int32, client Client) (*Broker, error) {
+	  return client.Leader(topic, partition)
+	}
 
 	c.ClientID = defaultClientID
 	c.ChannelBufferSize = 256

--- a/config.go
+++ b/config.go
@@ -391,6 +391,10 @@ type Config struct {
 		// 	- use `ReadUncommitted` (default) to consume and return all messages in message channel
 		//	- use `ReadCommitted` to hide messages that are part of an aborted transaction
 		IsolationLevel IsolationLevel
+
+		// Called to select the consumer's replica dynamically. Defaults to the
+		// partition leader.
+		ReplicaSelector func(topic string, partition int32, client Client) (*Broker, error)
 	}
 
 	// A user-provided string sent with every request to the brokers for logging,

--- a/consumer.go
+++ b/consumer.go
@@ -146,14 +146,8 @@ func (c *consumer) ConsumePartition(topic string, partition int32, offset int64)
 
 	var replica *Broker
 	var err error
-	if c.conf.Consumer.ReplicaSelector == nil {
-		if replica, err = c.client.Leader(child.topic, child.partition); err != nil {
-			return nil, err
-		}
-	} else {
-		if replica, err = c.conf.Consumer.ReplicaSelector(child.topic, child.partition, c.client); err != nil {
-			return nil, err
-		}
+	if replica, err = c.conf.Consumer.ReplicaSelector(topic, partition, c.client); err != nil {
+		return nil, err
 	}
 
 	if err := c.addChild(child); err != nil {
@@ -372,14 +366,8 @@ func (child *partitionConsumer) dispatch() error {
 
 	var replica *Broker
 	var err error
-	if child.conf.Consumer.ReplicaSelector == nil {
-		if replica, err = child.consumer.client.Leader(child.topic, child.partition); err != nil {
-			return err
-		}
-	} else {
-		if replica, err = child.conf.Consumer.ReplicaSelector(child.topic, child.partition, child.consumer.client); err != nil {
-			return err
-		}
+	if replica, err = child.conf.Consumer.ReplicaSelector(child.topic, child.partition, child.consumer.client); err != nil {
+		return err
 	}
 
 	child.broker = child.consumer.refBrokerConsumer(replica)

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,9 @@ import (
 // or otherwise failed to respond.
 var ErrOutOfBrokers = errors.New("kafka: client has run out of available brokers to talk to (Is your cluster reachable?)")
 
+// ErrBrokerNotFound is returned when there's no broker found for the requested id.
+var ErrBrokerNotFound = errors.New("kafka: broker for id is not found")
+
 // ErrClosedClient is the error returned when a method is called on a client that has been closed.
 var ErrClosedClient = errors.New("kafka: tried to use a client that was closed")
 


### PR DESCRIPTION
Rather than always using the leader partition, this lets the consumer application specify a function to select which broker they wish to consume from. The function has the signature 

    fn(topic string, partition int32, client Client) (*Broker, error)

Allowing the client to implement their own logic for broker slection. If none is specified, the default behavior is backwards compatible and selects the leader.

This pulls some changes from #1696, but in our use case we want to spread the load across multiple replicas, not pick based on geographic considerations. I didn't think our specific use case made sense for the general library, but it also wasn't possible without changes to Sarama, so I made a generalizable solution. It might be possible to implement the changes for KIP-392 as a ReplicaSelector function, though that may still require some additional code changes to support communications regarding which broker should be used for a given rack.

I've tested that this works with sufficiently high protocol versions.

If you'd like to take a different approach with this, I'm open to helping. If you need more / different tests, let me know.