### PR TITLE
KIP-42 Add producer and consumer interceptors

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -348,6 +348,10 @@ func (p *asyncProducer) dispatcher() {
 			p.inFlight.Add(1)
 		}
 
+		for _, interceptor := range p.conf.Producer.Interceptors {
+			msg.safelyApplyInterceptor(interceptor)
+		}
+
 		version := 1
 		if p.conf.Version.IsAtLeast(V0_11_0_0) {
 			version = 2

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1235,7 +1235,7 @@ type appendInterceptor struct {
 	i int
 }
 
-func (b *appendInterceptor) onSend(msg *ProducerMessage) {
+func (b *appendInterceptor) OnSend(msg *ProducerMessage) {
 	if b.i < 0 {
 		panic("hey, the interceptor has failed")
 	}
@@ -1244,7 +1244,7 @@ func (b *appendInterceptor) onSend(msg *ProducerMessage) {
 	b.i++
 }
 
-func (b *appendInterceptor) onConsume(msg *ConsumerMessage) {
+func (b *appendInterceptor) OnConsume(msg *ConsumerMessage) {
 	if b.i < 0 {
 		panic("hey, the interceptor has failed")
 	}

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1237,7 +1237,7 @@ type appendInterceptor struct {
 
 func (b *appendInterceptor) onSend(msg *ProducerMessage) {
 	if b.i < 0 {
-		panic("hey, the interceptor have failed")
+		panic("hey, the interceptor has failed")
 	}
 	v, _ := msg.Value.Encode()
 	msg.Value = StringEncoder(string(v) + strconv.Itoa(b.i))
@@ -1246,7 +1246,7 @@ func (b *appendInterceptor) onSend(msg *ProducerMessage) {
 
 func (b *appendInterceptor) onConsume(msg *ConsumerMessage) {
 	if b.i < 0 {
-		panic("hey, the interceptor have failed")
+		panic("hey, the interceptor has failed")
 	}
 	msg.Value = []byte(string(msg.Value) + strconv.Itoa(b.i))
 	b.i++

--- a/config.go
+++ b/config.go
@@ -229,6 +229,14 @@ type Config struct {
 			// `Backoff` if set.
 			BackoffFunc func(retries, maxRetries int) time.Duration
 		}
+
+		// Interceptors to be called when the producer dispatcher reads the
+		// message for the first time. Interceptors allows to intercept and
+		// possible mutate the message before they are published to Kafka
+		// cluster. *ProducerMessage modified by the first interceptor's
+		// onSend() is passed to the second interceptor onSend(), and so on in
+		// the interceptor chain.
+		Interceptors []ProducerInterceptor
 	}
 
 	// Consumer is the namespace for configuration related to consuming messages,
@@ -391,6 +399,14 @@ type Config struct {
 		// 	- use `ReadUncommitted` (default) to consume and return all messages in message channel
 		//	- use `ReadCommitted` to hide messages that are part of an aborted transaction
 		IsolationLevel IsolationLevel
+
+		// Interceptors to be called just before the record is sent to the
+		// messages channel. Interceptors allows to intercept and possible
+		// mutate the message before they are returned to the client.
+		// *ConsumerMessage modified by the first interceptor's onConsume() is
+		// passed to the second interceptor onConsume(), and so on in the
+		// interceptor chain.
+		Interceptors []ConsumerInterceptor
 	}
 
 	// A user-provided string sent with every request to the brokers for logging,

--- a/config.go
+++ b/config.go
@@ -234,7 +234,7 @@ type Config struct {
 		// message for the first time. Interceptors allows to intercept and
 		// possible mutate the message before they are published to Kafka
 		// cluster. *ProducerMessage modified by the first interceptor's
-		// onSend() is passed to the second interceptor onSend(), and so on in
+		// OnSend() is passed to the second interceptor OnSend(), and so on in
 		// the interceptor chain.
 		Interceptors []ProducerInterceptor
 	}
@@ -403,8 +403,8 @@ type Config struct {
 		// Interceptors to be called just before the record is sent to the
 		// messages channel. Interceptors allows to intercept and possible
 		// mutate the message before they are returned to the client.
-		// *ConsumerMessage modified by the first interceptor's onConsume() is
-		// passed to the second interceptor onConsume(), and so on in the
+		// *ConsumerMessage modified by the first interceptor's OnConsume() is
+		// passed to the second interceptor OnConsume(), and so on in the
 		// interceptor chain.
 		Interceptors []ConsumerInterceptor
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -451,6 +451,9 @@ feederLoop:
 		}
 
 		for i, msg := range msgs {
+			for _, interceptor := range child.conf.Consumer.Interceptors {
+				msg.safelyApplyInterceptor(interceptor)
+			}
 		messageSelect:
 			select {
 			case <-child.dying:

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1406,7 +1406,7 @@ func TestConsumerInterceptors(t *testing.T) {
 				ev, _ := testMsg.Encode()
 				expected := string(ev) + strconv.Itoa(i)
 				v := string(msg.Value)
-				if string(v) != expected {
+				if v != expected {
 					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
 				}
 			},
@@ -1418,7 +1418,7 @@ func TestConsumerInterceptors(t *testing.T) {
 				ev, _ := testMsg.Encode()
 				expected := string(ev) + strconv.Itoa(i) + strconv.Itoa(i+1000)
 				v := string(msg.Value)
-				if string(v) != expected {
+				if v != expected {
 					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
 				}
 			},
@@ -1430,7 +1430,7 @@ func TestConsumerInterceptors(t *testing.T) {
 				ev, _ := testMsg.Encode()
 				expected := string(ev) + strconv.Itoa(i+1000)
 				v := string(msg.Value)
-				if string(v) != expected {
+				if v != expected {
 					t.Errorf("Interceptor should have not changed the value, got %s, expected %s", v, expected)
 				}
 			},
@@ -1442,7 +1442,7 @@ func TestConsumerInterceptors(t *testing.T) {
 				ev, _ := testMsg.Encode()
 				expected := string(ev)
 				v := string(msg.Value)
-				if string(v) != expected {
+				if v != expected {
 					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
 				}
 			},

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1340,5 +1341,114 @@ func Test_partitionConsumer_parseResponse(t *testing.T) {
 				t.Errorf("partitionConsumer.parseResponse() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func testConsumerInterceptor(
+	t *testing.T,
+	interceptors []ConsumerInterceptor,
+	expectationFn func(*testing.T, int, *ConsumerMessage),
+) {
+	// Given
+	broker0 := NewMockBroker(t, 0)
+
+	mockFetchResponse := NewMockFetchResponse(t, 1)
+	for i := 0; i < 10; i++ {
+		mockFetchResponse.SetMessage("my_topic", 0, int64(i), testMsg)
+	}
+
+	broker0.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetBroker(broker0.Addr(), broker0.BrokerID()).
+			SetLeader("my_topic", 0, broker0.BrokerID()),
+		"OffsetRequest": NewMockOffsetResponse(t).
+			SetOffset("my_topic", 0, OffsetOldest, 0).
+			SetOffset("my_topic", 0, OffsetNewest, 0),
+		"FetchRequest": mockFetchResponse,
+	})
+	config := NewConfig()
+	config.Consumer.Interceptors = interceptors
+	// When
+	master, err := NewConsumer([]string{broker0.Addr()}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	consumer, err := master.ConsumePartition("my_topic", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case msg := <-consumer.Messages():
+			expectationFn(t, i, msg)
+		case err := <-consumer.Errors():
+			t.Error(err)
+		}
+	}
+
+	safeClose(t, consumer)
+	safeClose(t, master)
+	broker0.Close()
+}
+
+func TestConsumerInterceptors(t *testing.T) {
+	tests := []struct {
+		name          string
+		interceptors  []ConsumerInterceptor
+		expectationFn func(*testing.T, int, *ConsumerMessage)
+	}{
+		{
+			name:         "intercept messages",
+			interceptors: []ConsumerInterceptor{&appendInterceptor{i: 0}},
+			expectationFn: func(t *testing.T, i int, msg *ConsumerMessage) {
+				ev, _ := testMsg.Encode()
+				expected := string(ev) + strconv.Itoa(i)
+				v := string(msg.Value)
+				if string(v) != expected {
+					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
+				}
+			},
+		},
+		{
+			name:         "interceptor chain",
+			interceptors: []ConsumerInterceptor{&appendInterceptor{i: 0}, &appendInterceptor{i: 1000}},
+			expectationFn: func(t *testing.T, i int, msg *ConsumerMessage) {
+				ev, _ := testMsg.Encode()
+				expected := string(ev) + strconv.Itoa(i) + strconv.Itoa(i+1000)
+				v := string(msg.Value)
+				if string(v) != expected {
+					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
+				}
+			},
+		},
+		{
+			name:         "interceptor chain with one interceptor failing",
+			interceptors: []ConsumerInterceptor{&appendInterceptor{i: -1}, &appendInterceptor{i: 1000}},
+			expectationFn: func(t *testing.T, i int, msg *ConsumerMessage) {
+				ev, _ := testMsg.Encode()
+				expected := string(ev) + strconv.Itoa(i+1000)
+				v := string(msg.Value)
+				if string(v) != expected {
+					t.Errorf("Interceptor should have not changed the value, got %s, expected %s", v, expected)
+				}
+			},
+		},
+		{
+			name:         "interceptor chain with all interceptors failing",
+			interceptors: []ConsumerInterceptor{&appendInterceptor{i: -1}, &appendInterceptor{i: -1}},
+			expectationFn: func(t *testing.T, i int, msg *ConsumerMessage) {
+				ev, _ := testMsg.Encode()
+				expected := string(ev)
+				v := string(msg.Value)
+				if string(v) != expected {
+					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) { testConsumerInterceptor(t, tt.interceptors, tt.expectationFn) })
 	}
 }

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -243,9 +243,9 @@ func TestInterceptors(t *testing.T) {
 		case err := <-consumer.Errors():
 			t.Error(err)
 		case msg := <-consumer.Messages():
-			// producer interceptors: strconv.Itoa(i) + strconv.Itoa(i+100)
-			// consumer interceptor: strconv.Itoa(i+20)
-			expected := TestMessage + strconv.Itoa(i) + strconv.Itoa(i+100) + strconv.Itoa(i+20)
+			prodInteExpectation := strconv.Itoa(i) + strconv.Itoa(i+100)
+			consInteExpectation := strconv.Itoa(i + 20)
+			expected := TestMessage + prodInteExpectation + consInteExpectation
 			v := string(msg.Value)
 			if v != expected {
 				t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -5,6 +5,7 @@ package sarama
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -181,6 +182,78 @@ func TestFuncProducingIdempotentWithBrokerFailure(t *testing.T) {
 			break
 		}
 	}
+}
+
+func TestInterceptors(t *testing.T) {
+	config := NewConfig()
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	config.Producer.Return.Successes = true
+	config.Consumer.Return.Errors = true
+	config.Producer.Interceptors = []ProducerInterceptor{&appendInterceptor{i: 0}, &appendInterceptor{i: 100}}
+	config.Consumer.Interceptors = []ConsumerInterceptor{&appendInterceptor{i: 20}}
+
+	client, err := NewClient(kafkaBrokers, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initialOffset, err := client.GetOffset("test.1", 0, OffsetNewest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	producer, err := NewAsyncProducerFromClient(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		producer.Input() <- &ProducerMessage{Topic: "test.1", Key: nil, Value: StringEncoder(TestMessage)}
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case msg := <-producer.Errors():
+			t.Error(msg.Err)
+		case msg := <-producer.Successes():
+			v, _ := msg.Value.Encode()
+			expected := TestMessage + strconv.Itoa(i) + strconv.Itoa(i+100)
+			if string(v) != expected {
+				t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
+			}
+		}
+	}
+	safeClose(t, producer)
+
+	master, err := NewConsumerFromClient(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	consumer, err := master.ConsumePartition("test.1", 0, initialOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		select {
+		case <-time.After(10 * time.Second):
+			t.Fatal("Not received any more events in the last 10 seconds.")
+		case err := <-consumer.Errors():
+			t.Error(err)
+		case msg := <-consumer.Messages():
+			// producer interceptors: strconv.Itoa(i) + strconv.Itoa(i+100)
+			// consumer interceptor: strconv.Itoa(i+20)
+			expected := TestMessage + strconv.Itoa(i) + strconv.Itoa(i+100) + strconv.Itoa(i+20)
+			v := string(msg.Value)
+			if string(v) != expected {
+				t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
+			}
+		}
+	}
+	safeClose(t, consumer)
+	safeClose(t, client)
 }
 
 func testProducingMessages(t *testing.T, config *Config) {

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -247,7 +247,7 @@ func TestInterceptors(t *testing.T) {
 			// consumer interceptor: strconv.Itoa(i+20)
 			expected := TestMessage + strconv.Itoa(i) + strconv.Itoa(i+100) + strconv.Itoa(i+20)
 			v := string(msg.Value)
-			if string(v) != expected {
+			if v != expected {
 				t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expected)
 			}
 		}

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -194,7 +194,7 @@ func TestInterceptors(t *testing.T) {
 	config.Producer.Interceptors = []ProducerInterceptor{&appendInterceptor{i: 0}, &appendInterceptor{i: 100}}
 	config.Consumer.Interceptors = []ConsumerInterceptor{&appendInterceptor{i: 20}}
 
-	client, err := NewClient(kafkaBrokers, config)
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/interceptors.go
+++ b/interceptors.go
@@ -1,0 +1,43 @@
+package sarama
+
+// ProducerInterceptor allows you to intercept (and possibly mutate) the records
+// received by the producer before they are published to the Kafka cluster.
+// https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors#KIP42:AddProducerandConsumerInterceptors-Motivation
+type ProducerInterceptor interface {
+
+	// onSend is called when the producer message is intercepted. Please avoid
+	// modifying the message until it's safe to do so, as this is _not_ a copy
+	// of the message.
+	onSend(*ProducerMessage)
+}
+
+// ConsumerInterceptor allows you to intercept (and possibly mutate) the records
+// received by the consumer before they are sent to the messages channel.
+// https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors#KIP42:AddProducerandConsumerInterceptors-Motivation
+type ConsumerInterceptor interface {
+
+	// onConsume is called when the consumed message is intercepted. Please
+	// avoid modifying the message until it's safe to do so, as this is _not_ a
+	// copy of the message.
+	onConsume(*ConsumerMessage)
+}
+
+func (msg *ProducerMessage) safelyApplyInterceptor(interceptor ProducerInterceptor) {
+	defer func() {
+		if r := recover(); r != nil {
+			Logger.Printf("Error when calling producer interceptor: %s, %w\n", interceptor, r)
+		}
+	}()
+
+	interceptor.onSend(msg)
+}
+
+func (msg *ConsumerMessage) safelyApplyInterceptor(interceptor ConsumerInterceptor) {
+	defer func() {
+		if r := recover(); r != nil {
+			Logger.Printf("Error when calling consumer interceptor: %s, %w\n", interceptor, r)
+		}
+	}()
+
+	interceptor.onConsume(msg)
+}

--- a/interceptors.go
+++ b/interceptors.go
@@ -5,10 +5,10 @@ package sarama
 // https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors#KIP42:AddProducerandConsumerInterceptors-Motivation
 type ProducerInterceptor interface {
 
-	// onSend is called when the producer message is intercepted. Please avoid
+	// OnSend is called when the producer message is intercepted. Please avoid
 	// modifying the message until it's safe to do so, as this is _not_ a copy
 	// of the message.
-	onSend(*ProducerMessage)
+	OnSend(*ProducerMessage)
 }
 
 // ConsumerInterceptor allows you to intercept (and possibly mutate) the records
@@ -16,10 +16,10 @@ type ProducerInterceptor interface {
 // https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors#KIP42:AddProducerandConsumerInterceptors-Motivation
 type ConsumerInterceptor interface {
 
-	// onConsume is called when the consumed message is intercepted. Please
+	// OnConsume is called when the consumed message is intercepted. Please
 	// avoid modifying the message until it's safe to do so, as this is _not_ a
 	// copy of the message.
-	onConsume(*ConsumerMessage)
+	OnConsume(*ConsumerMessage)
 }
 
 func (msg *ProducerMessage) safelyApplyInterceptor(interceptor ProducerInterceptor) {
@@ -29,7 +29,7 @@ func (msg *ProducerMessage) safelyApplyInterceptor(interceptor ProducerIntercept
 		}
 	}()
 
-	interceptor.onSend(msg)
+	interceptor.OnSend(msg)
 }
 
 func (msg *ConsumerMessage) safelyApplyInterceptor(interceptor ConsumerInterceptor) {
@@ -39,5 +39,5 @@ func (msg *ConsumerMessage) safelyApplyInterceptor(interceptor ConsumerIntercept
 		}
 	}()
 
-	interceptor.onConsume(msg)
+	interceptor.OnConsume(msg)
 }


### PR DESCRIPTION
[KIP-42 Add producer and consumer interceptors](https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors)

This PR includes:
Producer: `OnSend` but it doesn't implement `onAcknowledgement`
Consumer: `OnConsume` but it doesn't implement `onCommit`

I tried on purpose to not follow the Java design too closely. This PR tries to follow Go idioms to the degree possible.
I didn't add an `onClose` method on the interface, Go has other alternatives for this if needed.

for:
> Since there may be multiple interceptors, the first interceptor will get a record from client passed as the 'record' parameter. The next interceptor in the list will get the record returned by the previous interceptor, and so on. Since interceptors are allowed to mutate records, interceptors may potentially get the record already modified by other interceptors. However, we will state in the javadoc that building a pipeline of mutable interceptors that depend on the output of the previous interceptors is discouraged, because of potential side-effects caused by interceptors potentially failing to mutate the record and throwing and exception. If one of the interceptors in the list throws an exception from onSend(), the exception is caught, logged,and the next interceptor is called with the record returned by the last successful interceptor in the list, or otherwise the client.

specifically the section:
> If one of the interceptors in the list throws an exception from onSend(), the exception is caught, logged,and the next interceptor is called with the record returned by the last successful interceptor in the list, or otherwise the client.

My implementation does the following, as I'm passing the value by reference:
If one of the interceptors in the list throws an exception from onSend(), the exception is caught, logged,and the next interceptor is called ~with the record returned by the last successful interceptor in the list~.

The interceptor method needs to make sure to only modify the object when it's safe to do so, otherwise it can modify the object and then fail, which will make the next interceptor to use a modified value from maybe a non successful interceptor.
For some reason, Sarama `ProducerMessage` contains a channel, which makes hard to clone this object.

Another alternative will be to make a copy of the body, headers, topic, partition data, and if the interceptor call fails, revert the message to this original data, but I'm not sure if it worth the effort, as anyone working with go know that if you modify an object passed as a reference, it'll modify the source object.

Closes https://github.com/Shopify/sarama/issues/1710