### PR TITLE
fix: mock sync producer does not handle the offset while sending messages

### DIFF
--- a/mocks/sync_producer.go
+++ b/mocks/sync_producer.go
@@ -97,6 +97,8 @@ func (sp *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
 			if expectation.Result != errProduceSuccess {
 				return expectation.Result
 			}
+			sp.lastOffset++
+			msgs[i].Offset = sp.lastOffset
 		}
 		return nil
 	}

--- a/mocks/sync_producer_test.go
+++ b/mocks/sync_producer_test.go
@@ -161,6 +161,13 @@ func TestSyncProducerWithCheckerFunctionForSendMessagesWithoutError(t *testing.T
 		t.Error("No error expected on SendMessages call, found: ", err)
 	}
 
+	for i, msg := range msgs {
+		offset := int64(i + 1)
+		if offset != msg.Offset {
+			t.Errorf("The message should have been assigned offset %d, but got %d", offset, msg.Offset)
+		}
+	}
+
 	if err := sp.Close(); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Mock sync producer does not handle the offset while invoking `SendMessages`.

e.g.

```go
mockSyncProducer := mocks.NewSyncProducer(t, sarama.NewConfig())

msgs := []*sarama.ProducerMessage{
	{Key: sarama.StringEncoder("foo")},
}
mockSyncProducer.SendMessages(msgs)
// Print offset
print(msgs[0].Offset)
```