### PR TITLE
sarama: remove deprecated tls options from test

### DIFF
--- a/client_tls_test.go
+++ b/client_tls_test.go
@@ -171,9 +171,6 @@ func TestTLS(t *testing.T) {
 }
 
 func doListenerTLSTest(t *testing.T, expectSuccess bool, serverConfig, clientConfig *tls.Config) {
-	serverConfig.BuildNameToCertificate()
-	clientConfig.BuildNameToCertificate()
-
 	seedListener, err := tls.Listen("tcp", "127.0.0.1:0", serverConfig)
 	if err != nil {
 		t.Fatal("cannot open listener", err)


### PR DESCRIPTION
`tls.Config.BuildNameToCertificate()` is deprecated. `godoc` advises:
>// Deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates.

This removes both uses of it from `doListenerTLSTest()`