### PR TITLE
Option to skip ahead when consumer falls behind

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -77,6 +77,18 @@ func (err ConfigurationError) Error() string {
 	return "kafka: invalid configuration (" + string(err) + ")"
 }
 
+// SkippedMessagesError is returned when AutoSkipLostMessages is turned on, a consumer fell behind the retention log
+// and advanced its offset without having consumed messages.
+type SkippedMessagesError struct {
+	Topic     string
+	Partition int32
+	Skipped   int64
+}
+
+func (err SkippedMessagesError) Error() string {
+	return fmt.Sprintf("consumer/%s/%d is not keeping up and skipped %d messages", err.Topic, err.Partition, err.Skipped)
+}
+
 // KError is the type of error that can be returned directly by the Kafka broker.
 // See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ErrorCodes
 type KError int16


### PR DESCRIPTION
Hey!

The current behaviour when a consumer tries to process messages starting from the oldest offset but is not keeping up is to stop the consumer and let the application decide what to do. Obviously, since it is a pathological state, it is a reasonable default: the partition may need to go to a different consumer, or more consumers should be added, or an alert should go off, etc.

In some cases however it might be preferable to continue processing as fast as possible and not waste time restarting/rebalancing. So I'm suggesting this patch adding the possibility to let the consumer continue even if it is not keeping up with the retention limit of the log in case it might be useful to other people.

Let me know your thoughts!