### PR TITLE
Add private method to Client interface to prevent implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,6 +93,9 @@ type Client interface {
 
 	// Closed returns true if the client has already had Close called on it
 	Closed() bool
+
+	// A private method to prevent users implementing the interface for compatibility
+	private()
 }
 
 const (
@@ -186,6 +189,8 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 
 	return client, nil
 }
+
+func (client *client) private() {}
 
 func (client *client) Config() *Config {
 	return client.conf


### PR DESCRIPTION
Related: https://github.com/Shopify/sarama/pull/1781#discussion_r473121038

https://github.com/Shopify/sarama/pull/1781 added an interface method for `Client`.
 
Adding interface methods will break backwards compatibility if there's anyone implementing it.This PR adds a `private()` method to prevent implementation,