### PR TITLE
Support Go 1.13 error unwrapping

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -267,6 +267,10 @@ func (pe ProducerError) Error() string {
 	return fmt.Sprintf("kafka: Failed to produce message to topic %s: %s", pe.Msg.Topic, pe.Err)
 }
 
+func (pe ProducerError) Unwrap() error {
+	return pe.Err
+}
+
 // ProducerErrors is a type that wraps a batch of "ProducerError"s and implements the Error interface.
 // It can be returned from the Producer's Close method to avoid the need to manually drain the Errors channel
 // when closing a producer.

--- a/consumer.go
+++ b/consumer.go
@@ -35,6 +35,10 @@ func (ce ConsumerError) Error() string {
 	return fmt.Sprintf("kafka: error while consuming %s/%d: %s", ce.Topic, ce.Partition, ce.Err)
 }
 
+func (ce ConsumerError) Unwrap() error {
+	return ce.Err
+}
+
 // ConsumerErrors is a type that wraps a batch of errors and implements the Error interface.
 // It can be returned from the PartitionConsumer's Close methods to avoid the need to manually drain errors
 // when stopping.


### PR DESCRIPTION
A little PR adding support for Go 1.13 `errors.Unwrap` to `ConsumerError` and `ProducerError`. 

This feature might be particularly useful for generic error handling code, such as when propagating custom errors from `Consumer.ConsumeClaim()` or unit testing failure cases using mocks.

I considered extending other error structs in the codebase but they either do not surface external or custom errors; or are aggregated errors that cannot have an unambiguous `Unwrap()` result.

I am not sure what tests might be useful for this change. Please let me know if any tests are needed. 