### PR TITLE
ability to filter topic's config options when listing topics

### DIFF
--- a/mockresponses.go
+++ b/mockresponses.go
@@ -784,7 +784,8 @@ func (mr *MockDescribeConfigsResponse) For(reqBody versionedDecoder) encoderWith
 					Name:     "min.insync.replicas",
 					Value:    "2",
 					ReadOnly: false,
-					Default:  false,
+					Default:  true,
+					Source:   SourceDefault,
 				},
 			)
 			res.Resources = append(res.Resources, &ResourceResponse{
@@ -808,12 +809,14 @@ func (mr *MockDescribeConfigsResponse) For(reqBody versionedDecoder) encoderWith
 			maxMessageBytes := &ConfigEntry{Name: "max.message.bytes",
 				Value:     "1000000",
 				ReadOnly:  false,
-				Default:   !includeSource,
+				Source:    SourceTopic,
 				Sensitive: false,
 			}
-			if includeSource {
-				maxMessageBytes.Source = SourceDefault
+			if !includeSource {
+				maxMessageBytes.Source = SourceUnknown
 			}
+			maxMessageBytes.Default = maxMessageBytes.Source == SourceDefault
+
 			if includeSynonyms {
 				maxMessageBytes.Synonyms = []*ConfigSynonym{
 					{


### PR DESCRIPTION
related to https://github.com/Shopify/sarama/issues/1514

Sarama `ListTopics` returns by default config options that are not _default_, however, it also returns brokers static configs, the java command line tool only returns by defaults the dynamic topic config options, however it also have the option to return all the configuration. This PR tries to offer an option to allow to get the required topic's configuration options.

This PR allows to use a new function `ListTopicsAndFilterConfigEntries` (please some help with the naming), which allows to pass a different filter, so we can get whatever combination that we'd like:

a few examples:
all options: `kafka-configs.sh --bootstrap-server localhost:9092 --entity-type topics --entity-name xxxtopic --describe -all`
```go
	filter := func(entry *ConfigEntry) bool {
		return true
	}
        ListTopicsAndFilterConfigEntries(filter)
```

only sensitive:
```go
	filter := func(entry *ConfigEntry) bool {
		return entry.Sensitive
	}
```

what java returs by default: `kafka-configs.sh --bootstrap-server localhost:9092 --entity-type topics --entity-name xxxtopic --describe`
```go
	filter := func(entry *ConfigEntry) bool {
		return entry.Source == SourceTopic
	}
```

I didn't want to modify the current expectation of `ListTopics` as some people might be depending on current results


ping @sladkoff as I see you worked on https://github.com/Shopify/sarama/pull/1594