### PR TITLE
Revert "Add private method to Client interface to prevent implementation"

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,9 +93,6 @@ type Client interface {
 
 	// Closed returns true if the client has already had Close called on it
 	Closed() bool
-
-	// A private method to prevent users implementing the interface for compatibility
-	private()
 }
 
 const (
@@ -186,8 +183,6 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 
 	return client, nil
 }
-
-func (client *client) private() {}
 
 func (client *client) Config() *Config {
 	return client.conf


### PR DESCRIPTION
Reverts Shopify/sarama#1785

this is causing more damage that the initial intention to prevent breaking changes.

Some people are using mock libraries and they are getting issues with this change

i.e, when using mockery
```
Cannot use 'mockSaramaClient' (type *mocks.Client) as type sarama.Client Type cannot implement 'sarama.Client' as it has a non-exported method and is defined in a different package
```