### PR TITLE
update consumer group minimum version

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -96,8 +96,8 @@ func NewConsumerGroupFromClient(groupID string, client Client) (ConsumerGroup, e
 
 func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 	config := client.Config()
-	if !config.Version.IsAtLeast(V0_10_2_0) {
-		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_2_0")
+	if !config.Version.IsAtLeast(V0_10_0_0) {
+		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_0_0")
 	}
 
 	consumer, err := NewConsumerFromClient(client)


### PR DESCRIPTION
Same as this issue https://github.com/Shopify/sarama/issues/1680
I noticed that the consumer group is limited to V0_10_2_0, but the internal implementation is actually [compatible with V0_10_0_0](https://github.com/Shopify/sarama/blob/v1.27.2/consumer_group.go#L309-L312). And I tested that it works fine on V0_10_0_0.