### PR TITLE
Added fuzzer with oss-fuzz build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#/bin/bash -eu
+
+compile_go_fuzzer github.com/Shopify/sarama Fuzz fuzz
+ 

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,13 @@
+// +build gofuzz
+
+package sarama
+
+import "bytes"
+
+func Fuzz(data []byte) int {
+	_, _, err := decodeRequest(bytes.NewReader(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for `decodeRequest` along with the build script in case there is interest in setting up continuous fuzzing for Sarama by way of oss-fuzz.

I have the build files available for the oss-fuzz side and I will be happy to integrate Sarama.