### PR TITLE
Do not ignore Consumer.Offsets.AutoCommit.Enable config on Close

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -113,10 +113,12 @@ func (om *offsetManager) Close() error {
 		om.asyncClosePOMs()
 
 		// flush one last time
-		for attempt := 0; attempt <= om.conf.Consumer.Offsets.Retry.Max; attempt++ {
-			om.flushToBroker()
-			if om.releasePOMs(false) == 0 {
-				break
+		if om.conf.Consumer.Offsets.AutoCommit.Enable {
+			for attempt := 0; attempt <= om.conf.Consumer.Offsets.Retry.Max; attempt++ {
+				om.flushToBroker()
+				if om.releasePOMs(false) == 0 {
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
Adds ``om.conf.Consumer.Offsets.AutoCommit.Enable`` during closing of the ``offset_manager`` and hence fixing #1843 