### PR TITLE
Performance improvement

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -1,28 +1,25 @@
 package sarama
 
 import (
-	"sync"
-
 	"github.com/klauspost/compress/zstd"
+	"sync"
 )
 
-var (
-	zstdDec *zstd.Decoder
-	zstdEnc *zstd.Encoder
+var zstdDec *zstd.Decoder
+var zstdEnc *zstd.Encoder
+var zstdOnce = sync.Once{}
 
-	zstdEncOnce, zstdDecOnce sync.Once
-)
+func init(){
+	zstdOnce.Do(func() {
+		zstdDec, _ = zstd.NewReader(nil)
+		zstdEnc, _ = zstd.NewWriter(nil, zstd.WithZeroFrames(true))
+	})
+}
 
 func zstdDecompress(dst, src []byte) ([]byte, error) {
-	zstdDecOnce.Do(func() {
-		zstdDec, _ = zstd.NewReader(nil)
-	})
 	return zstdDec.DecodeAll(src, dst)
 }
 
 func zstdCompress(dst, src []byte) ([]byte, error) {
-	zstdEncOnce.Do(func() {
-		zstdEnc, _ = zstd.NewWriter(nil, zstd.WithZeroFrames(true))
-	})
 	return zstdEnc.EncodeAll(src, dst), nil
 }

--- a/zstd.go
+++ b/zstd.go
@@ -2,18 +2,14 @@ package sarama
 
 import (
 	"github.com/klauspost/compress/zstd"
-	"sync"
 )
 
 var zstdDec *zstd.Decoder
 var zstdEnc *zstd.Encoder
-var zstdOnce = sync.Once{}
 
 func init(){
-	zstdOnce.Do(func() {
-		zstdDec, _ = zstd.NewReader(nil)
-		zstdEnc, _ = zstd.NewWriter(nil, zstd.WithZeroFrames(true))
-	})
+	zstdDec, _ = zstd.NewReader(nil)
+	zstdEnc, _ = zstd.NewWriter(nil, zstd.WithZeroFrames(true))
 }
 
 func zstdDecompress(dst, src []byte) ([]byte, error) {


### PR DESCRIPTION
the lock in that once per decode/encode is expensive, so just do it once at init

In an empirical test, on a laptop of course, this gained about a few hundred msg/sec in both consumption/production