### PR TITLE
go.doc -> pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sarama is an MIT-licensed Go client library for [Apache Kafka](https://kafka.apa
 
 ## Getting started
 
-- API documentation and examples are available via [godoc](https://godoc.org/github.com/Shopify/sarama).
+- API documentation and examples are available via [pkg.go.dev](https://godoc.org/github.com/Shopify/sarama).
 - Mocks for testing are available in the [mocks](./mocks) subpackage.
 - The [examples](./examples) directory contains more elaborate example applications.
 - The [tools](./tools) directory contains command line tools that can be useful for testing, diagnostics, and instrumentation.


### PR DESCRIPTION
Updated the API Documentation link in `README.md` to read "pkg.go.dev" instead of "godoc," and updated the link accordingly.