### PR TITLE
Parsing only known control batches value

### DIFF
--- a/control_record.go
+++ b/control_record.go
@@ -23,16 +23,6 @@ type ControlRecord struct {
 
 func (cr *ControlRecord) decode(key, value packetDecoder) error {
 	var err error
-	cr.Version, err = value.getInt16()
-	if err != nil {
-		return err
-	}
-
-	cr.CoordinatorEpoch, err = value.getInt32()
-	if err != nil {
-		return err
-	}
-
 	// There a version for the value part AND the key part. And I have no idea if they are supposed to match or not
 	// Either way, all these version can only be 0 for now
 	cr.Version, err = key.getInt16()
@@ -54,6 +44,18 @@ func (cr *ControlRecord) decode(key, value packetDecoder) error {
 		// from JAVA implementation:
 		// UNKNOWN is used to indicate a control type which the client is not aware of and should be ignored
 		cr.Type = ControlRecordUnknown
+	}
+	// we want to parse value only if we are decoding control record of known type
+	if cr.Type != ControlRecordUnknown {
+		cr.Version, err = value.getInt16()
+		if err != nil {
+			return err
+		}
+
+		cr.CoordinatorEpoch, err = value.getInt32()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/control_record_test.go
+++ b/control_record_test.go
@@ -1,1 +1,67 @@
 package sarama
+
+import (
+	"testing"
+)
+
+var (
+	abortTxCtrlRecKey = []byte{
+		0, 0, // version
+		0, 0, // TX_ABORT = 0
+	}
+	abortTxCtrlRecValue = []byte{
+		0, 0, // version
+		0, 0, 0, 10, // coordinator epoch
+	}
+	commitTxCtrlRecKey = []byte{
+		0, 0, // version
+		0, 1, // TX_COMMIT = 1
+	}
+	commitTxCtrlRecValue = []byte{
+		0, 0, // version
+		0, 0, 0, 15, // coordinator epoch
+	}
+	unknownCtrlRecKey = []byte{
+		0, 0, // version
+		0, 128, // UNKNOWN = -1
+	}
+	// empty value for unknown record
+	unknownCtrlRecValue = []byte{}
+)
+
+func testDecode(t *testing.T, tp string, key []byte, value []byte) ControlRecord {
+	controlRecord := ControlRecord{}
+	err := controlRecord.decode(&realDecoder{raw: key}, &realDecoder{raw: value})
+	if err != nil {
+		t.Error("Decoding control record of type " + tp + " failed")
+		return ControlRecord{}
+	}
+	return controlRecord
+}
+
+func assertRecordType(t *testing.T, r *ControlRecord, expected ControlRecordType) {
+	if r.Type != expected {
+		t.Errorf("control record type mismatch, expected: %v, have %v", expected, r.Type)
+	}
+}
+
+func TestDecodingControlRecords(t *testing.T) {
+	abortTx := testDecode(t, "abort transaction", abortTxCtrlRecKey, abortTxCtrlRecValue)
+
+	assertRecordType(t, &abortTx, ControlRecordAbort)
+
+	if abortTx.CoordinatorEpoch != 10 {
+		t.Errorf("abort tx control record coordinator epoch mismatch")
+	}
+
+	commitTx := testDecode(t, "commit transaction", commitTxCtrlRecKey, commitTxCtrlRecValue)
+
+	if commitTx.CoordinatorEpoch != 15 {
+		t.Errorf("commit tx control record coordinator epoch mismatch")
+	}
+	assertRecordType(t, &commitTx, ControlRecordCommit)
+
+	unknown := testDecode(t, "unknown", unknownCtrlRecKey, unknownCtrlRecValue)
+
+	assertRecordType(t, &unknown, ControlRecordUnknown)
+}


### PR DESCRIPTION
Kafka documentation defines control batches as a single record batches
containing data that shouldn't be passed to applications. The record
contained inside the control batch consist of a key with well defined
format and a value which format is defined by the control batch type.

Control batch key format:
```
ControlRecordKey => version type
  version => INT16
  type => INT16
```

Fixed control batch parsing logic by first parsing the key to check if
control batch is of known type and only then parsing corresponding
record value.

Signed-off-by: Michal Maslanka <michal@vectorized.io>