### PR TITLE
Remove redundant switch-case, fix doc typos

### DIFF
--- a/acl_delete_request.go
+++ b/acl_delete_request.go
@@ -48,7 +48,7 @@ func (d *DeleteAclsRequest) version() int16 {
 	return int16(d.Version)
 }
 
-func (c *DeleteAclsRequest) headerVersion() int16 {
+func (d *DeleteAclsRequest) headerVersion() int16 {
 	return 1
 }
 

--- a/admin.go
+++ b/admin.go
@@ -165,14 +165,14 @@ func isErrNoController(err error) bool {
 }
 
 // retryOnError will repeatedly call the given (error-returning) func in the
-// case that its response is non-nil and retriable (as determined by the
-// provided retriable func) up to the maximum number of tries permitted by
+// case that its response is non-nil and retryable (as determined by the
+// provided retryable func) up to the maximum number of tries permitted by
 // the admin client configuration
-func (ca *clusterAdmin) retryOnError(retriable func(error) bool, fn func() error) error {
+func (ca *clusterAdmin) retryOnError(retryable func(error) bool, fn func() error) error {
 	var err error
 	for attempt := 0; attempt < ca.conf.Admin.Retry.Max; attempt++ {
 		err = fn()
-		if err == nil || !retriable(err) {
+		if err == nil || !retryable(err) {
 			return err
 		}
 		Logger.Printf(

--- a/encoder_decoder.go
+++ b/encoder_decoder.go
@@ -45,7 +45,7 @@ func encode(e encoder, metricRegistry metrics.Registry) ([]byte, error) {
 	return realEnc.raw, nil
 }
 
-// Decoder is the interface that wraps the basic Decode method.
+// decoder is the interface that wraps the basic Decode method.
 // Anything implementing Decoder can be extracted from bytes using Kafka's encoding rules.
 type decoder interface {
 	decode(pd packetDecoder) error
@@ -55,7 +55,7 @@ type versionedDecoder interface {
 	decode(pd packetDecoder, version int16) error
 }
 
-// Decode takes bytes and a Decoder and fills the fields of the decoder from the bytes,
+// decode takes bytes and a decoder and fills the fields of the decoder from the bytes,
 // interpreted using Kafka's encoding rules.
 func decode(buf []byte, in decoder) error {
 	if buf == nil {

--- a/message.go
+++ b/message.go
@@ -146,14 +146,7 @@ func (m *Message) decode(pd packetDecoder) (err error) {
 	// for future metrics about the compression ratio in fetch requests
 	m.compressedSize = len(m.Value)
 
-	switch m.Codec {
-	case CompressionNone:
-		// nothing to do
-	default:
-		if m.Value == nil {
-			break
-		}
-
+	if m.Value != nil {
 		m.Value, err = decompress(m.Codec, m.Value)
 		if err != nil {
 			return err

--- a/message.go
+++ b/message.go
@@ -146,11 +146,12 @@ func (m *Message) decode(pd packetDecoder) (err error) {
 	// for future metrics about the compression ratio in fetch requests
 	m.compressedSize = len(m.Value)
 
-	if m.Value != nil {
+	if m.Value != nil && m.Codec == CompressionNone {
 		m.Value, err = decompress(m.Codec, m.Value)
 		if err != nil {
 			return err
 		}
+
 		if err := m.decodeSet(); err != nil {
 			return err
 		}

--- a/message.go
+++ b/message.go
@@ -146,7 +146,7 @@ func (m *Message) decode(pd packetDecoder) (err error) {
 	// for future metrics about the compression ratio in fetch requests
 	m.compressedSize = len(m.Value)
 
-	if m.Value != nil && m.Codec == CompressionNone {
+	if m.Value != nil && m.Codec != CompressionNone {
 		m.Value, err = decompress(m.Codec, m.Value)
 		if err != nil {
 			return err

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -30,7 +30,7 @@ type RequestNotifierFunc func(bytesRead, bytesWritten int)
 // to facilitate testing of higher level or specialized consumers and producers
 // built on top of Sarama. Note that it does not 'mimic' the Kafka API protocol,
 // but rather provides a facility to do that. It takes care of the TCP
-// transport, request unmarshaling, response marshaling, and makes it the test
+// transport, request unmarshalling, response marshalling, and makes it the test
 // writer responsibility to program correct according to the Kafka API protocol
 // MockBroker behaviour.
 //

--- a/partitioner.go
+++ b/partitioner.go
@@ -42,7 +42,7 @@ type PartitionerConstructor func(topic string) Partitioner
 
 type manualPartitioner struct{}
 
-// HashPartitionOption lets you modify default values of the partitioner
+// HashPartitionerOption lets you modify default values of the partitioner
 type HashPartitionerOption func(*hashPartitioner)
 
 // WithAbsFirst means that the partitioner handles absolute values


### PR DESCRIPTION
The switch-case here is redundant. There is the logic of this part of the code in the `decompress` function.