### PR TITLE
Use gofork for encoding/asn1 to fix ASN errors during Kerberos authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/eapache/queue v1.1.0
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/frankban/quicktest v1.11.3 // indirect
+	github.com/jcmturner/gofork v1.0.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/klauspost/compress v1.12.2
 	github.com/kr/text v0.2.0 // indirect

--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -1,7 +1,6 @@
 package sarama
 
 import (
-	"encoding/asn1"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -10,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jcmturner/gofork/encoding/asn1"
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
 	"github.com/jcmturner/gokrb5/v8/gssapi"
 	"github.com/jcmturner/gokrb5/v8/iana/chksumtype"


### PR DESCRIPTION
Fixes  #1932 