### PR TITLE
fix: explicitly use uint64 for payload length

### DIFF
--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -57,7 +57,7 @@ type KerberosClient interface {
 
 // writePackage appends length in big endian before the payload, and sends it to kafka
 func (krbAuth *GSSAPIKerberosAuth) writePackage(broker *Broker, payload []byte) (int, error) {
-	length := len(payload)
+	length := uint64(len(payload))
 	size := length + 4 // 4 byte length header + payload
 	if size > math.MaxUint32 {
 		return 0, errors.New("payload too large, will overflow uint32")


### PR DESCRIPTION
Tested with:
```
docker run --platform=linux/i386 --rm -v "$PWD":/usr/src -w /usr/src golang:1.16 go build -v
```

Fixes #1943