### PR TITLE
Make size a uint to build on GOARCH=386

### DIFF
--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -58,7 +58,7 @@ type KerberosClient interface {
 // writePackage appends length in big endian before the payload, and sends it to kafka
 func (krbAuth *GSSAPIKerberosAuth) writePackage(broker *Broker, payload []byte) (int, error) {
 	length := len(payload)
-	size := length + 4 // 4 byte length header + payload
+	size := uint(length + 4) // 4 byte length header + payload
 	if size > math.MaxUint32 {
 		return 0, errors.New("payload too large, will overflow uint32")
 	}


### PR DESCRIPTION
This is failing to build with `GOARCH=386` on a linux box.

Explicitly forcing size to a `uint` fixes this problem.