### PR TITLE
Fix metrics taking up too much memory

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -180,7 +180,7 @@ func (b *Broker) Open(conf *Config) error {
 		b.requestsInFlight = metrics.GetOrRegisterCounter("requests-in-flight", conf.MetricRegistry)
 		// Do not gather metrics for seeded broker (only used during bootstrap) because they share
 		// the same id (-1) and are already exposed through the global metrics above
-		if b.id >= 0 {
+		if b.id >= 0 && !metrics.UseNilMetrics {
 			b.registerMetrics()
 		}
 


### PR DESCRIPTION
Fix metrics taking up too much memory
We call `broker.Open()` multiple times, and we have the problem of excessive memory usage.
The crawl flame graph can be seen as follows.
![image](https://user-images.githubusercontent.com/4846144/123273269-16f3ee00-d535-11eb-9a0c-6b3a406651b8.png)

The fix is to turn off the call to `registerMetrics` when setting `metrics.UseNilMetrics=true`.