### PR TITLE
fix: enable nilerr linter and fix iferr checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,7 @@ linters:
     # - ineffassign
     # - misspell
     # - nakedret
+    - nilerr
     # - scopelint
     - staticcheck
     - structcheck

--- a/alter_configs_response.go
+++ b/alter_configs_response.go
@@ -61,12 +61,12 @@ func (a *AlterConfigsResourceResponse) encode(pe packetEncoder) error {
 	pe.putInt16(a.ErrorCode)
 	err := pe.putString(a.ErrorMsg)
 	if err != nil {
-		return nil
+		return err
 	}
 	pe.putInt8(int8(a.Type))
 	err = pe.putString(a.Name)
 	if err != nil {
-		return nil
+		return err
 	}
 	return nil
 }

--- a/describe_configs_response.go
+++ b/describe_configs_response.go
@@ -308,19 +308,19 @@ func (c *ConfigSynonym) encode(pe packetEncoder, version int16) (err error) {
 func (c *ConfigSynonym) decode(pd packetDecoder, version int16) error {
 	name, err := pd.getString()
 	if err != nil {
-		return nil
+		return err
 	}
 	c.ConfigName = name
 
 	value, err := pd.getString()
 	if err != nil {
-		return nil
+		return err
 	}
 	c.ConfigValue = value
 
 	source, err := pd.getInt8()
 	if err != nil {
-		return nil
+		return err
 	}
 	c.Source = ConfigSource(source)
 	return nil

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,7 +6,7 @@ import "testing"
 // logs of the given T passed from Test functions.
 // and records the text in the error log.
 //
-// nolint
+
 type testLogger struct {
 	t *testing.T
 }


### PR DESCRIPTION
nilerr finds code which returns nil even though it checks that error is
not nil. This flagged up a few incorrect checks in some of our packet
encoder/decoders, so fix those.