### PR TITLE
fix(test): disable encoded response/request check when map contains multiple elements

### DIFF
--- a/delete_offsets_request_test.go
+++ b/delete_offsets_request_test.go
@@ -7,27 +7,6 @@ var (
 		0, 3, 'f', 'o', 'o', // group name: foo
 		0, 0, 0, 0, // 0 partition
 	}
-
-	doubleDeleteOffsetsRequest = []byte{
-		0, 3, 'f', 'o', 'o', // group name: foo
-		0, 0, 0, 1, // 1 topic
-		0, 3, 'b', 'a', 'r', // topic name: bar
-		0, 0, 0, 2, // 2 partitions
-		0, 0, 0, 6, // partition 6
-		0, 0, 0, 7, // partition 7
-	}
-
-	tripleDeleteOffsetsRequest = []byte{
-		0, 3, 'f', 'o', 'o', // group name: foo
-		0, 0, 0, 2, // 2 topics
-		0, 3, 'b', 'a', 'r', // topic name: bar
-		0, 0, 0, 2, // 2 partitions
-		0, 0, 0, 6, // partition 6
-		0, 0, 0, 7, // partition 7
-		0, 3, 'b', 'a', 'z', // topic name: baz
-		0, 0, 0, 1, // 1 partition
-		0, 0, 0, 0, // partition 0
-	}
 )
 
 func TestDeleteOffsetsRequest(t *testing.T) {
@@ -42,12 +21,16 @@ func TestDeleteOffsetsRequest(t *testing.T) {
 	request.Group = "foo"
 	request.AddPartition("bar", 6)
 	request.AddPartition("bar", 7)
-	testRequest(t, "two offsets on one topic", request, doubleDeleteOffsetsRequest)
+	// The response encoded form cannot be checked for it varies due to
+	// unpredictable map traversal order.
+	testRequest(t, "two offsets on one topic", request, nil)
 
 	request = new(DeleteOffsetsRequest)
 	request.Group = "foo"
 	request.AddPartition("bar", 6)
 	request.AddPartition("bar", 7)
 	request.AddPartition("baz", 0)
-	testRequest(t, "three offsets on two topics", request, tripleDeleteOffsetsRequest)
+	// The response encoded form cannot be checked for it varies due to
+	// unpredictable map traversal order.
+	testRequest(t, "three offsets on two topics", request, nil)
 }

--- a/delete_offsets_response_test.go
+++ b/delete_offsets_response_test.go
@@ -11,18 +11,6 @@ var (
 		0, 0, 0, 0, // 0 topics
 	}
 
-	noErrorDeleteOffsetsResponse = []byte{
-		0, 0, // no error
-		0, 0, 0, 0, // 0 throttle
-		0, 0, 0, 1, // 1 topic
-		0, 3, 'b', 'a', 'r', // topic name: bar
-		0, 0, 0, 2, // 2 partitions
-		0, 0, 0, 6, // partition 6
-		0, 0, // no error
-		0, 0, 0, 7, // partition 7
-		0, 0, // no error
-	}
-
 	errorDeleteOffsetsResponse = []byte{
 		0, 16, // error 16 : ErrNotCoordinatorForConsumer
 		0, 0, 0, 0, // 0 throttle
@@ -63,7 +51,9 @@ func TestDeleteOffsetsResponse(t *testing.T) {
 			},
 		},
 	}
-	testResponse(t, "no error", response, noErrorDeleteOffsetsResponse)
+	// The response encoded form cannot be checked for it varies due to
+	// unpredictable map traversal order.
+	testResponse(t, "no error", response, nil)
 
 	response = &DeleteOffsetsResponse{
 		ErrorCode:    16,


### PR DESCRIPTION
Fix #2012 
Disable encoded response/request check when map contains multiple elements. In that situation the encoded/request response varies because of unpredictable map traversal order


