### PR TITLE
chore: replace deprecated Go calls

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"regexp"
 	"time"
@@ -669,7 +669,7 @@ func (c *Config) Validate() error {
 
 	if c.Producer.Compression == CompressionGZIP {
 		if c.Producer.CompressionLevel != CompressionLevelDefault {
-			if _, err := gzip.NewWriterLevel(ioutil.Discard, c.Producer.CompressionLevel); err != nil {
+			if _, err := gzip.NewWriterLevel(io.Discard, c.Producer.CompressionLevel); err != nil {
 				return ConfigurationError(fmt.Sprintf("gzip compression does not work with level %d: %v", c.Producer.CompressionLevel, err))
 			}
 		}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1563,7 +1563,7 @@ func TestConsumerTimestamps(t *testing.T) {
 			select {
 			case msg := <-consumer.Messages():
 				assertMessageOffset(t, msg, int64(i)+1)
-				if msg.Timestamp != ts {
+				if !msg.Timestamp.Equal(ts) {
 					t.Errorf("Wrong timestamp (kversion:%v, logAppendTime:%v): got: %v, want: %v",
 						d.kversion, d.logAppendTime, msg.Timestamp, ts)
 				}

--- a/decompress.go
+++ b/decompress.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 
 	snappy "github.com/eapache/go-xerial-snappy"
@@ -40,7 +40,7 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 
 		defer gzipReaderPool.Put(reader)
 
-		return ioutil.ReadAll(reader)
+		return io.ReadAll(reader)
 	case CompressionSnappy:
 		return snappy.Decode(data)
 	case CompressionLZ4:
@@ -52,7 +52,7 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 		}
 		defer lz4ReaderPool.Put(reader)
 
-		return ioutil.ReadAll(reader)
+		return io.ReadAll(reader)
 	case CompressionZSTD:
 		return zstdDecompress(nil, data)
 	default:

--- a/examples/http_server/http_server.go
+++ b/examples/http_server/http_server.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -61,7 +60,7 @@ func createTlsConfiguration() (t *tls.Config) {
 			log.Fatal(err)
 		}
 
-		caCert, err := ioutil.ReadFile(*caFile)
+		caCert, err := os.ReadFile(*caFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/examples/sasl_scram_client/main.go
+++ b/examples/sasl_scram_client/main.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -44,7 +43,7 @@ func createTLSConfiguration() (t *tls.Config) {
 			log.Fatal(err)
 		}
 
-		caCert, err := ioutil.ReadFile(*caFile)
+		caCert, err := os.ReadFile(*caFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/functional_test.go
+++ b/functional_test.go
@@ -231,7 +231,7 @@ func existingEnvironment(ctx context.Context, env *testEnvironment) (bool, error
 		if err != nil {
 			return false, fmt.Errorf("proxy.Listen not a host:port combo: %w", err)
 		}
-		env.KafkaBrokerAddrs = append(env.KafkaBrokerAddrs, fmt.Sprintf("%s:%s", toxiproxyHost, proxyPort))
+		env.KafkaBrokerAddrs = append(env.KafkaBrokerAddrs, net.JoinHostPort(toxiproxyHost, proxyPort))
 	}
 
 	env.KafkaVersion, ok = os.LookupEnv("KAFKA_VERSION")

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -93,7 +93,7 @@ func TestProduceResponseDecode(t *testing.T) {
 				t.Error("Decoding failed for foo/1/Offset, got:", block.Offset)
 			}
 			if v >= 2 {
-				if block.Timestamp != time.Unix(1, 0) {
+				if !block.Timestamp.Equal(time.Unix(1, 0)) {
 					t.Error("Decoding failed for foo/1/Timestamp, got:", block.Timestamp)
 				}
 			}

--- a/produce_set_test.go
+++ b/produce_set_test.go
@@ -255,7 +255,7 @@ func TestProduceSetV3RequestBuilding(t *testing.T) {
 	}
 
 	batch := req.records["t1"][0].RecordBatch
-	if batch.FirstTimestamp != now.Truncate(time.Millisecond) {
+	if !batch.FirstTimestamp.Equal(now.Truncate(time.Millisecond)) {
 		t.Errorf("Wrong first timestamp: %v", batch.FirstTimestamp)
 	}
 	for i := 0; i < 10; i++ {
@@ -334,7 +334,7 @@ func TestProduceSetIdempotentRequestBuilding(t *testing.T) {
 	}
 
 	batch := req.records["t1"][0].RecordBatch
-	if batch.FirstTimestamp != now.Truncate(time.Millisecond) {
+	if !batch.FirstTimestamp.Equal(now.Truncate(time.Millisecond)) {
 		t.Errorf("Wrong first timestamp: %v", batch.FirstTimestamp)
 	}
 	if batch.ProducerID != pID {

--- a/sarama.go
+++ b/sarama.go
@@ -78,7 +78,7 @@ Consumer related metrics:
 package sarama
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 )
 
@@ -86,7 +86,7 @@ var (
 	// Logger is the instance of a StdLogger interface that Sarama writes connection
 	// management events to. By default it is set to discard all log messages via ioutil.Discard,
 	// but you can set it to redirect wherever you want.
-	Logger StdLogger = log.New(ioutil.Discard, "[Sarama] ", log.LstdFlags)
+	Logger StdLogger = log.New(io.Discard, "[Sarama] ", log.LstdFlags)
 
 	// PanicHandler is called for recovering from panics spawned internally to the library (and thus
 	// not recoverable by the caller's goroutine). Defaults to nil, which means panics are not recovered.

--- a/sync_producer.go
+++ b/sync_producer.go
@@ -94,8 +94,8 @@ func (sp *syncProducer) SendMessage(msg *ProducerMessage) (partition int32, offs
 	msg.expectation = expectation
 	sp.producer.Input() <- msg
 
-	if err := <-expectation; err != nil {
-		return -1, -1, err.Err
+	if pErr := <-expectation; pErr != nil {
+		return -1, -1, pErr.Err
 	}
 
 	return msg.Partition, msg.Offset, nil
@@ -115,8 +115,8 @@ func (sp *syncProducer) SendMessages(msgs []*ProducerMessage) error {
 
 	var errors ProducerErrors
 	for expectation := range expectations {
-		if err := <-expectation; err != nil {
-			errors = append(errors, err)
+		if pErr := <-expectation; pErr != nil {
+			errors = append(errors, pErr)
 		}
 	}
 

--- a/tools/kafka-console-producer/kafka-console-producer.go
+++ b/tools/kafka-console-producer/kafka-console-producer.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -92,7 +92,7 @@ func main() {
 	if *value != "" {
 		message.Value = sarama.StringEncoder(*value)
 	} else if stdinAvailable() {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			printErrorAndExit(66, "Failed to read data from the standard input: %s", err)
 		}

--- a/tools/kafka-producer-performance/main.go
+++ b/tools/kafka-producer-performance/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -267,7 +266,7 @@ func main() {
 		}
 
 		if *tlsRootCACerts != "" {
-			rootCAsBytes, err := ioutil.ReadFile(*tlsRootCACerts)
+			rootCAsBytes, err := os.ReadFile(*tlsRootCACerts)
 			if err != nil {
 				printErrorAndExit(69, "failed to read root CA certificates: %v", err)
 			}


### PR DESCRIPTION
- always perform time.Time comparison with the Equal func
  see https://pkg.go.dev/time#Time.Equal
- replace deprecated ioutil usage with corresponding io.|os. calls