### PR TITLE
fix(test): remove testLogger from TrackLeader test

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -900,10 +900,6 @@ func TestConsumeMessagesFromReadReplicaErrorUnknown(t *testing.T) {
 //
 // See https://github.com/Shopify/sarama/issues/1927
 func TestConsumeMessagesTrackLeader(t *testing.T) {
-	prevLogger := Logger
-	defer func() { Logger = prevLogger }()
-	Logger = &testLogger{t}
-
 	cfg := NewConfig()
 	cfg.ClientID = t.Name()
 	cfg.Metadata.RefreshFrequency = time.Millisecond * 50

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,11 +6,12 @@ import "testing"
 // logs of the given T passed from Test functions.
 // and records the text in the error log.
 //
-
+// nolint:unused
 type testLogger struct {
 	t *testing.T
 }
 
+// nolint:unused
 func (l *testLogger) Print(v ...interface{}) {
 	if l.t != nil {
 		l.t.Helper()
@@ -18,6 +19,7 @@ func (l *testLogger) Print(v ...interface{}) {
 	}
 }
 
+// nolint:unused
 func (l *testLogger) Printf(format string, v ...interface{}) {
 	if l.t != nil {
 		l.t.Helper()
@@ -25,6 +27,7 @@ func (l *testLogger) Printf(format string, v ...interface{}) {
 	}
 }
 
+// nolint:unused
 func (l *testLogger) Println(v ...interface{}) {
 	if l.t != nil {
 		l.t.Helper()


### PR DESCRIPTION
As it turns out, this setup was periodically causing the test to fail
due to a data race occurring on the `Logger` global when the defer ran
(!)

Fixes #2011