### PR TITLE
docs: do not mention buffered messages in sync producer Close method

### DIFF
--- a/sync_producer.go
+++ b/sync_producer.go
@@ -25,10 +25,9 @@ type SyncProducer interface {
 	// SendMessages will return an error.
 	SendMessages(msgs []*ProducerMessage) error
 
-	// Close shuts down the producer and waits for any buffered messages to be
-	// flushed. You must call this function before a producer object passes out of
-	// scope, as it may otherwise leak memory. You must call this before calling
-	// Close on the underlying client.
+	// Close shuts down the producer; you must call this function before a producer
+	// object passes out of scope, as it may otherwise leak memory.
+	// You must call this before calling Close on the underlying client.
 	Close() error
 }
 


### PR DESCRIPTION
Do not mention buffered messages in sync producer Close method.

As far as I understood - although channels are used - it is practically impossible for a message to be "buffered" when using the sync producer, because a synchronous reply for each specific message has already been spooled off the channels every time a Send method is used.