### PR TITLE
chore: add release notes configuration

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,40 @@
+changelog:
+  exclude:
+    labels:
+    - ignore-for-release
+    - invalid
+    - no-changelog
+    - skip-changelog
+  categories:
+  - title: ":rotating_light: Breaking Changes"
+    labels:
+    - breaking
+  - title: ":tada: New Features / Improvements"
+    labels:
+    - enhancement
+    - feature
+    - feat
+  - title: ":bug: Fixes"
+    labels:
+    - bug
+    - bugfix
+    - fix
+    - regression
+  - title: ":package: Dependency updates"
+    labels:
+    - dependencies
+    - deps
+  - title: ":wrench: Maintenance"
+    labels:
+    - build
+    - chore
+    - ci
+    - housekeeping
+    - internal
+  - title: ":memo: Documentation"
+    labels:
+    - documentation
+    - docs
+  - title: ":heavy_plus_sign: Other Changes"
+    labels:
+    - "*"


### PR DESCRIPTION
Add some customisation around the new automatically generated releases
notes in the releases UI

https://github.blog/2021-10-04-beta-github-releases-improving-release-experience/
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configuration