### PR TITLE
fix: set min-go-version to 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - #1912 - @faillefer Support for --delete-offsets for consumer group topic
 
+# Fixes
+
+- #2048 - @troyanov - Set minimum supported go version to 1.16
+
 #### Version 1.28.0 (2021-02-15)
 
 **Note that with this release we change `RoundRobinBalancer` strategy to match Java client behavior. See #1788 for details.**

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You might also want to look at the [Frequently Asked Questions](https://github.c
 Sarama provides a "2 releases + 2 months" compatibility guarantee: we support
 the two latest stable releases of Kafka and Go, and we provide a two month
 grace period for older releases. This means we currently officially support
-Go 1.15 through 1.16, and Kafka 2.7 through 2.8, although older releases are
+Go 1.16, and Kafka 2.7 through 2.8, although older releases are
 still likely to work.
 
 Sarama follows semantic versioning and provides API stability via the gopkg.in service.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/sarama
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.1.6-0.20210914104332-15ea381dcdae


### PR DESCRIPTION
Changes that were introduced in 8ccea19c0cec5d05ed99068d46bf46efc900d24d made it impossible to compile sarama with go 1.15
(which is mentioned as officially supported version in the README file)

`io.Discard` and `io.ReadAll` appeared only in 1.16
https://golang.org/doc/go1.16#ioutil

To address this issue this commit bumps minimal supported go version
defined in go.mod file, to provide a clear message that 1.16 is required

```
> go build
./config.go:678:37: undefined: io.Discard
./decompress.go:43:10: undefined: io.ReadAll
./decompress.go:55:10: undefined: io.ReadAll
./sarama.go:89:29: undefined: io.Discard
note: module requires Go 1.16
```

Also it looks like that support of go 1.15 was also dropped in the CI workflow by https://github.com/Shopify/sarama/commit/974e37b5164ada9943d633b9e95a3c1e6abbdf18 and 1.16 is the min version that is currently being checked https://github.com/Shopify/sarama/blob/main/.github/workflows/ci.yml#L16