### PR TITLE
logger: fix debug logs' formatting directives

### DIFF
--- a/sarama.go
+++ b/sarama.go
@@ -116,13 +116,13 @@ type StdLogger interface {
 type debugLogger struct{}
 
 func (d *debugLogger) Print(v ...interface{}) {
-	Logger.Print(v)
+	Logger.Print(v...)
 }
 func (d *debugLogger) Printf(format string, v ...interface{}) {
-	Logger.Printf(format, v)
+	Logger.Printf(format, v...)
 }
 func (d *debugLogger) Println(v ...interface{}) {
-	Logger.Println(v)
+	Logger.Println(v...)
 }
 
 // DebugLogger is the instance of a StdLogger that Sarama writes more verbose


### PR DESCRIPTION
Default DebugLogger had broken Printf directives -
for DebugLogger.Printf(fmt,A,B,C) it called Logger.Printf(fmt,[A B C]),
which resulted in logs like
```
client/coordinator coordinator for consumergroup [topicname
%!s(int32=1) host:9094] is #%!d(MISSING) (%!s(MISSING))
```

This commit fixes value passing for Printf.