### PR TITLE
fix: stuck on the batch with zero records length

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -629,6 +629,10 @@ func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*Consu
 					child.fetchSize = child.conf.Consumer.Fetch.Max
 				}
 			}
+		} else if block.LastRecordsBatchOffset != nil && *block.LastRecordsBatchOffset < block.HighWaterMarkOffset {
+			// check last record offset to avoid stuck if high watermark was not reached
+			Logger.Printf("consumer/broker/%d received batch with zero records but high watermark was not reached, topic %s, partition %d, offset %d\n", child.broker.broker.ID(), child.topic, child.partition, *block.LastRecordsBatchOffset)
+			child.offset = *block.LastRecordsBatchOffset + 1
 		}
 
 		return nil, nil

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -30,15 +30,16 @@ func (t *AbortedTransaction) encode(pe packetEncoder) (err error) {
 }
 
 type FetchResponseBlock struct {
-	Err                  KError
-	HighWaterMarkOffset  int64
-	LastStableOffset     int64
-	LogStartOffset       int64
-	AbortedTransactions  []*AbortedTransaction
-	PreferredReadReplica int32
-	Records              *Records // deprecated: use FetchResponseBlock.RecordsSet
-	RecordsSet           []*Records
-	Partial              bool
+	Err                    KError
+	HighWaterMarkOffset    int64
+	LastStableOffset       int64
+	LastRecordsBatchOffset *int64
+	LogStartOffset         int64
+	AbortedTransactions    []*AbortedTransaction
+	PreferredReadReplica   int32
+	Records                *Records // deprecated: use FetchResponseBlock.RecordsSet
+	RecordsSet             []*Records
+	Partial                bool
 }
 
 func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error) {
@@ -115,6 +116,11 @@ func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error)
 				}
 				break
 			}
+			return err
+		}
+
+		b.LastRecordsBatchOffset, err = records.recordsOffset()
+		if err != nil {
 			return err
 		}
 

--- a/records.go
+++ b/records.go
@@ -183,6 +183,21 @@ func (r *Records) isOverflow() (bool, error) {
 	return false, fmt.Errorf("unknown records type: %v", r.recordsType)
 }
 
+func (r *Records) recordsOffset() (*int64, error) {
+	switch r.recordsType {
+	case unknownRecords:
+		return nil, nil
+	case legacyRecords:
+		return nil, nil
+	case defaultRecords:
+		if r.RecordBatch == nil {
+			return nil, nil
+		}
+		return &r.RecordBatch.FirstOffset, nil
+	}
+	return nil, fmt.Errorf("unknown records type: %v", r.recordsType)
+}
+
 func magicValue(pd packetDecoder) (int8, error) {
 	return pd.peekInt8(magicOffset)
 }

--- a/records_test.go
+++ b/records_test.go
@@ -72,12 +72,20 @@ func TestLegacyRecords(t *testing.T) {
 	if c {
 		t.Errorf("MessageSet can't be a control batch")
 	}
+	f, err := r.recordsOffset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f != nil {
+		t.Errorf("RecordBatch record offset is invalid")
+	}
 }
 
 func TestDefaultRecords(t *testing.T) {
 	batch := &RecordBatch{
 		IsTransactional: true,
 		Version:         2,
+		FirstOffset:     1,
 		Records: []*Record{
 			{
 				Value: []byte{1},
@@ -140,5 +148,12 @@ func TestDefaultRecords(t *testing.T) {
 	}
 	if c {
 		t.Errorf("RecordBatch shouldn't be a control batch")
+	}
+	f, err := r.recordsOffset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f == nil || *f != 1 {
+		t.Errorf("RecordBatch record offset is invalid")
 	}
 }


### PR DESCRIPTION
#2053 
Sometimes in rare cases of corruption or other reason, Kafka can return batches with zero records even if a high watermark was not reached. In this case, sarama just tries to reread this batch again and again and is stuck. There is no resolution in this case except skipping this batch.
librdkafka can handle these cases skipping with a warning.