### PR TITLE
fix: retry ErrOffsetsLoadInProgress errors

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -259,7 +259,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		}
 
 		return c.retryNewSession(ctx, topics, handler, retries, true)
-	case ErrRebalanceInProgress: // retry after backoff
+	case ErrRebalanceInProgress, ErrOffsetsLoadInProgress: // retry after backoff
 		if retries <= 0 {
 			return nil, join.Err
 		}
@@ -312,7 +312,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		}
 
 		return c.retryNewSession(ctx, topics, handler, retries, true)
-	case ErrRebalanceInProgress: // retry after backoff
+	case ErrRebalanceInProgress, ErrOffsetsLoadInProgress: // retry after backoff
 		if retries <= 0 {
 			return nil, groupRequest.Err
 		}


### PR DESCRIPTION
A fix for #2058.

Retry ErrOffsetsLoadInProgress errors during GroupJoin (aka CoordinatorLoadInProgressException).