### PR TITLE
fix: zstd decoder does not appropriately closed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ coverage.txt
 profile.out
 
 simplest-uncommitted-msg-0.1-jar-with-dependencies.jar
+
+# ide
+.idea/*

--- a/consumer.go
+++ b/consumer.go
@@ -119,6 +119,7 @@ func newConsumer(client Client) (Consumer, error) {
 }
 
 func (c *consumer) Close() error {
+	closeZstdDecoder()
 	return c.client.Close()
 }
 

--- a/zstd.go
+++ b/zstd.go
@@ -48,7 +48,5 @@ func zstdDecompress(params ZstdDecoderParams, dst, src []byte) ([]byte, error) {
 }
 
 func zstdCompress(params ZstdEncoderParams, dst, src []byte) ([]byte, error) {
-	encoder := getEncoder(params)
-	defer encoder.Close()
-	return encoder.EncodeAll(src, dst), nil
+	return getEncoder(params).EncodeAll(src, dst), nil
 }

--- a/zstd.go
+++ b/zstd.go
@@ -42,11 +42,18 @@ func getDecoder(params ZstdDecoderParams) *zstd.Decoder {
 }
 
 func zstdDecompress(params ZstdDecoderParams, dst, src []byte) ([]byte, error) {
-	decoder := getDecoder(params)
-	defer decoder.Close()
-	return decoder.DecodeAll(src, dst)
+	return getDecoder(params).DecodeAll(src, dst)
 }
 
 func zstdCompress(params ZstdEncoderParams, dst, src []byte) ([]byte, error) {
 	return getEncoder(params).EncodeAll(src, dst), nil
+}
+
+func closeZstdDecoder() {
+	zstdDecMap.Range(func(key, value interface{}) bool {
+		if decoder, ok := value.(*zstd.Decoder); ok {
+			decoder.Close()
+		}
+		return true
+	})
 }

--- a/zstd.go
+++ b/zstd.go
@@ -42,9 +42,13 @@ func getDecoder(params ZstdDecoderParams) *zstd.Decoder {
 }
 
 func zstdDecompress(params ZstdDecoderParams, dst, src []byte) ([]byte, error) {
-	return getDecoder(params).DecodeAll(src, dst)
+	decoder := getDecoder(params)
+	defer decoder.Close()
+	return decoder.DecodeAll(src, dst)
 }
 
 func zstdCompress(params ZstdEncoderParams, dst, src []byte) ([]byte, error) {
-	return getEncoder(params).EncodeAll(src, dst), nil
+	encoder := getEncoder(params)
+	defer encoder.Close()
+	return encoder.EncodeAll(src, dst), nil
 }


### PR DESCRIPTION
Our service use sarama as kafka produce, when we try to bump to v1.30.0, our CI found potential goroutine leak.

Please take the following as reference:
https://github.com/pingcap/ticdc/pull/3508
https://github.com/klauspost/compress/issues/451