### PR TITLE
chore: confluent platform version bump

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   zookeeper-1:
-    image: 'confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       ZOOKEEPER_SERVER_ID: '1'
@@ -13,7 +13,7 @@ services:
       ZOOKEEPER_SYNC_LIMIT: '5'
       ZOOKEEPER_MAX_CLIENT_CONNS: '0'
   zookeeper-2:
-    image: 'confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       ZOOKEEPER_SERVER_ID: '2'
@@ -25,7 +25,7 @@ services:
       ZOOKEEPER_SYNC_LIMIT: '5'
       ZOOKEEPER_MAX_CLIENT_CONNS: '0'
   zookeeper-3:
-    image: 'confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-zookeeper:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       ZOOKEEPER_SERVER_ID: '3'
@@ -37,7 +37,7 @@ services:
       ZOOKEEPER_SYNC_LIMIT: '5'
       ZOOKEEPER_MAX_CLIENT_CONNS: '0'
   kafka-1:
-    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
@@ -54,7 +54,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
   kafka-2:
-    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
@@ -71,7 +71,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
   kafka-3:
-    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
@@ -88,7 +88,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
   kafka-4:
-    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
@@ -105,7 +105,7 @@ services:
       KAFKA_DELETE_TOPIC_ENABLE: 'true'
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
   kafka-5:
-    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-6.2.0}'
+    image: 'confluentinc/cp-kafka:${CONFLUENT_PLATFORM_VERSION:-7.0.0}'
     restart: always
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'

--- a/functional_test.go
+++ b/functional_test.go
@@ -112,8 +112,8 @@ func prepareDockerTestEnvironment(ctx context.Context, env *testEnvironment) err
 	if version, ok := os.LookupEnv("KAFKA_VERSION"); ok {
 		env.KafkaVersion = version
 	} else {
-		// We have cp-6.1.2 as the default in the docker-compose file, so that's kafka 2.7.1.
-		env.KafkaVersion = "2.7.1"
+		// We have cp-7.0.0 as the default in the docker-compose file, so that's kafka 3.0.0.
+		env.KafkaVersion = "3.0.0"
 	}
 
 	// the mapping of confluent platform docker image versions -> kafka versions can be

--- a/functional_test.go
+++ b/functional_test.go
@@ -121,7 +121,7 @@ func prepareDockerTestEnvironment(ctx context.Context, env *testEnvironment) err
 	var confluentPlatformVersion string
 	switch env.KafkaVersion {
 	case "3.0.0":
-		confluentPlatformVersion = "6.2.0"
+		confluentPlatformVersion = "7.0.0"
 	case "2.8.1":
 		confluentPlatformVersion = "6.2.0"
 	case "2.7.1":


### PR DESCRIPTION
Confluent released their distro of Kafka 3.0 as Confluent 7.0