### PR TITLE
fix: set HWMO during creation of partitionConsumer (fix incorrect HWMO before first fetch)

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -400,6 +400,9 @@ func (child *partitionConsumer) chooseStartingOffset(offset int64) error {
 	if err != nil {
 		return err
 	}
+
+	child.highWaterMarkOffset = newestOffset
+
 	oldestOffset, err := child.consumer.client.GetOffset(child.topic, child.partition, OffsetOldest)
 	if err != nil {
 		return err

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -57,6 +57,9 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
+	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
+		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
+	}
 	for i := int64(0); i < 10; i++ {
 		select {
 		case message := <-consumer.Messages():
@@ -109,6 +112,9 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
+	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
+		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
+	}
 	assertMessageOffset(t, <-consumer.Messages(), 10)
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewestAfterFetchRequest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewestAfterFetchRequest, hwmo)
@@ -154,6 +160,9 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
+	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
+		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
+	}
 	assertMessageOffset(t, <-consumer.Messages(), int64(7))
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)


### PR DESCRIPTION
Based on https://github.com/Shopify/sarama/pull/2081 , please check the commits separately to get clearer diff.