### PR TITLE
fix: correct bugs in DescribeGroupsResponse

### DIFF
--- a/consumer_group_members_test.go
+++ b/consumer_group_members_test.go
@@ -7,26 +7,46 @@ import (
 )
 
 var (
-	groupMemberMetadata = []byte{
-		0, 1, // Version
+	groupMemberMetadataV0 = []byte{
+		0, 0, // Version
 		0, 0, 0, 2, // Topic array length
 		0, 3, 'o', 'n', 'e', // Topic one
 		0, 3, 't', 'w', 'o', // Topic two
 		0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
 	}
-	groupMemberAssignment = []byte{
-		0, 1, // Version
+	groupMemberAssignmentV0 = []byte{
+		0, 0, // Version
 		0, 0, 0, 1, // Topic array length
 		0, 3, 'o', 'n', 'e', // Topic one
 		0, 0, 0, 3, // Topic one, partition array length
 		0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4, // 0, 2, 4
 		0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
 	}
+
+	// notably it looks like the old 3rdparty bsm/sarama-cluster incorrectly
+	// set V1 in the member metadata when it sent the JoinGroup request so
+	// we need to cope with that one being too short
+	groupMemberMetadataV1Bad = []byte{
+		0, 1, // Version
+		0, 0, 0, 2, // Topic array length
+		0, 3, 'o', 'n', 'e', // Topic one
+		0, 3, 't', 'w', 'o', // Topic two
+		0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
+	}
+
+	groupMemberMetadataV1 = []byte{
+		0, 1, // Version
+		0, 0, 0, 2, // Topic array length
+		0, 3, 'o', 'n', 'e', // Topic one
+		0, 3, 't', 'w', 'o', // Topic two
+		0, 0, 0, 3, 0x01, 0x02, 0x03, // Userdata
+		0, 0, 0, 0, // OwnedPartitions KIP-429
+	}
 )
 
 func TestConsumerGroupMemberMetadata(t *testing.T) {
 	meta := &ConsumerGroupMemberMetadata{
-		Version:  1,
+		Version:  0,
 		Topics:   []string{"one", "two"},
 		UserData: []byte{0x01, 0x02, 0x03},
 	}
@@ -34,8 +54,8 @@ func TestConsumerGroupMemberMetadata(t *testing.T) {
 	buf, err := encode(meta, nil)
 	if err != nil {
 		t.Error("Failed to encode data", err)
-	} else if !bytes.Equal(groupMemberMetadata, buf) {
-		t.Errorf("Encoded data does not match expectation\nexpected: %v\nactual: %v", groupMemberMetadata, buf)
+	} else if !bytes.Equal(groupMemberMetadataV0, buf) {
+		t.Errorf("Encoded data does not match expectation\nexpected: %v\nactual: %v", groupMemberMetadataV0, buf)
 	}
 
 	meta2 := new(ConsumerGroupMemberMetadata)
@@ -47,9 +67,19 @@ func TestConsumerGroupMemberMetadata(t *testing.T) {
 	}
 }
 
+func TestConsumerGroupMemberMetadataV1Decode(t *testing.T) {
+	meta := new(ConsumerGroupMemberMetadata)
+	if err := decode(groupMemberMetadataV1, meta); err != nil {
+		t.Error("Failed to decode V1 data", err)
+	}
+	if err := decode(groupMemberMetadataV1Bad, meta); err != nil {
+		t.Error("Failed to decode V1 'bad' data", err)
+	}
+}
+
 func TestConsumerGroupMemberAssignment(t *testing.T) {
 	amt := &ConsumerGroupMemberAssignment{
-		Version: 1,
+		Version: 0,
 		Topics: map[string][]int32{
 			"one": {0, 2, 4},
 		},
@@ -59,8 +89,8 @@ func TestConsumerGroupMemberAssignment(t *testing.T) {
 	buf, err := encode(amt, nil)
 	if err != nil {
 		t.Error("Failed to encode data", err)
-	} else if !bytes.Equal(groupMemberAssignment, buf) {
-		t.Errorf("Encoded data does not match expectation\nexpected: %v\nactual: %v", groupMemberAssignment, buf)
+	} else if !bytes.Equal(groupMemberAssignmentV0, buf) {
+		t.Errorf("Encoded data does not match expectation\nexpected: %v\nactual: %v", groupMemberAssignmentV0, buf)
 	}
 
 	amt2 := new(ConsumerGroupMemberAssignment)

--- a/describe_groups_response.go
+++ b/describe_groups_response.go
@@ -179,12 +179,18 @@ func (gmd *GroupMemberDescription) decode(pd packetDecoder) (err error) {
 }
 
 func (gmd *GroupMemberDescription) GetMemberAssignment() (*ConsumerGroupMemberAssignment, error) {
+	if len(gmd.MemberAssignment) == 0 {
+		return nil, nil
+	}
 	assignment := new(ConsumerGroupMemberAssignment)
 	err := decode(gmd.MemberAssignment, assignment)
 	return assignment, err
 }
 
 func (gmd *GroupMemberDescription) GetMemberMetadata() (*ConsumerGroupMemberMetadata, error) {
+	if len(gmd.MemberMetadata) == 0 {
+		return nil, nil
+	}
 	metadata := new(ConsumerGroupMemberMetadata)
 	err := decode(gmd.MemberMetadata, metadata)
 	return metadata, err


### PR DESCRIPTION
- support decoding V0 and V1 "ConsumerProtocolSubscription" types in the
  DescribeGroupsResponse member metadata (i.e., the new "OwnedPartition"
  values that may be included by a KIP-429 consumer)
- add workaround for the legacy bsm/sarama-cluster client which
  incorrectly set V1 in its JoinGroup request, but doesn't include the
  new V1+ fields!
  https://github.com/bsm/sarama-cluster/blob/d5779253526cc8a3129a0e5d7cc429f4b4473ab4/consumer.go#L644-L648
- also guard GetMemberAssignment and GetMemberMetadata from panic'ing
  when the fields are empty, which they will be in certain scenarios
  such as non-stable groups or clients without any assigned
  topicpartitions