### PR TITLE
feat: make `ErrOutOfBrokers` wrap the underlying error that prevented connections to the brokers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ coverage.txt
 profile.out
 
 simplest-uncommitted-msg-0.1-jar-with-dependencies.jar
+
+.idea

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters:
     - dogsled
     # - dupl
     - errcheck
+    - errorlint
     - funlen
     - gochecknoinits
     # - goconst

--- a/admin.go
+++ b/admin.go
@@ -528,7 +528,7 @@ func (ca *clusterAdmin) AlterPartitionReassignments(topic string, assignment [][
 		}
 
 		if len(errs) > 0 {
-			return ErrReassignPartitions{MultiError{&errs}}
+			return Wrap(ErrReassignPartitions, errs...)
 		}
 
 		return nil
@@ -604,7 +604,7 @@ func (ca *clusterAdmin) DeleteRecords(topic string, partitionOffsets map[int32]i
 		}
 	}
 	if len(errs) > 0 {
-		return ErrDeleteRecords{MultiError{&errs}}
+		return Wrap(ErrDeleteRecords, errs...)
 	}
 	// todo since we are dealing with couple of partitions it would be good if we return slice of errors
 	// for each partition instead of one error

--- a/admin_test.go
+++ b/admin_test.go
@@ -639,20 +639,20 @@ func TestClusterAdminDeleteRecordsWithDiffVersion(t *testing.T) {
 	partitionOffset[3] = 1000
 
 	err = admin.DeleteRecords(topicName, partitionOffset)
+	if err == nil {
+		t.Fatal("expected an ErrDeleteRecords")
+	}
+
 	if !strings.HasPrefix(err.Error(), "kafka server: failed to delete records") {
 		t.Fatal(err)
 	}
-	var deleteRecordsError ErrDeleteRecords
-	ok := errors.As(err, &deleteRecordsError)
 
-	if !ok {
+	if !errors.Is(err, ErrDeleteRecords) {
 		t.Fatal(err)
 	}
 
-	for _, err := range *deleteRecordsError.Errors {
-		if !errors.Is(err, ErrUnsupportedVersion) {
-			t.Fatal(err)
-		}
+	if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Fatal(err)
 	}
 
 	err = admin.Close()

--- a/admin_test.go
+++ b/admin_test.go
@@ -47,7 +47,7 @@ func TestClusterAdminInvalidController(t *testing.T) {
 		t.Fatal(errors.New("controller not set still cluster admin was created"))
 	}
 
-	if err != ErrControllerNotAvailable {
+	if !errors.Is(err, ErrControllerNotAvailable) {
 		t.Fatal(err)
 	}
 }
@@ -243,7 +243,7 @@ func TestClusterAdminDeleteEmptyTopic(t *testing.T) {
 	}
 
 	err = admin.DeleteTopic("")
-	if err != ErrInvalidTopic {
+	if !errors.Is(err, ErrInvalidTopic) {
 		t.Fatal(err)
 	}
 
@@ -303,7 +303,7 @@ func TestClusterAdminCreatePartitionsWithDiffVersion(t *testing.T) {
 	}
 
 	err = admin.CreatePartitions("my_topic", 3, nil, false)
-	if err != ErrUnsupportedVersion {
+	if !errors.Is(err, ErrUnsupportedVersion) {
 		t.Fatal(err)
 	}
 
@@ -642,14 +642,15 @@ func TestClusterAdminDeleteRecordsWithDiffVersion(t *testing.T) {
 	if !strings.HasPrefix(err.Error(), "kafka server: failed to delete records") {
 		t.Fatal(err)
 	}
-	deleteRecordsError, ok := err.(ErrDeleteRecords)
+	var deleteRecordsError ErrDeleteRecords
+	ok := errors.As(err, &deleteRecordsError)
 
 	if !ok {
 		t.Fatal(err)
 	}
 
 	for _, err := range *deleteRecordsError.Errors {
-		if err != ErrUnsupportedVersion {
+		if !errors.Is(err, ErrUnsupportedVersion) {
 			t.Fatal(err)
 		}
 	}
@@ -1547,7 +1548,7 @@ func TestDeleteOffset(t *testing.T) {
 	handlerMap["DeleteOffsetsRequest"] = NewMockDeleteOffsetRequest(t).SetDeletedOffset(ErrNotCoordinatorForConsumer, topic, partition, ErrNoError)
 	seedBroker.SetHandlerByMap(handlerMap)
 	err = admin.DeleteConsumerGroupOffset(group, topic, partition)
-	if err != ErrNotCoordinatorForConsumer {
+	if !errors.Is(err, ErrNotCoordinatorForConsumer) {
 		t.Fatalf("DeleteConsumerGroupOffset should have failed with error %v", ErrNotCoordinatorForConsumer)
 	}
 
@@ -1555,7 +1556,7 @@ func TestDeleteOffset(t *testing.T) {
 	handlerMap["DeleteOffsetsRequest"] = NewMockDeleteOffsetRequest(t).SetDeletedOffset(ErrNoError, topic, partition, ErrGroupSubscribedToTopic)
 	seedBroker.SetHandlerByMap(handlerMap)
 	err = admin.DeleteConsumerGroupOffset(group, topic, partition)
-	if err != ErrGroupSubscribedToTopic {
+	if !errors.Is(err, ErrGroupSubscribedToTopic) {
 		t.Fatalf("DeleteConsumerGroupOffset should have failed with error %v", ErrGroupSubscribedToTopic)
 	}
 }
@@ -1643,7 +1644,7 @@ func TestDescribeLogDirs(t *testing.T) {
 		t.Fatalf("Expected log dirs for broker %v to be returned, but it did not, got %v", seedBroker.BrokerID(), len(logDirs))
 	}
 	logDirsBroker := logDirs[0]
-	if logDirsBroker.ErrorCode != ErrNoError {
+	if !errors.Is(logDirsBroker.ErrorCode, ErrNoError) {
 		t.Fatalf("Expected no error for broker %v, but it was %v", seedBroker.BrokerID(), logDirsBroker.ErrorCode)
 	}
 	if logDirsBroker.Path != "/tmp/logs" {

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -740,7 +740,7 @@ func TestAsyncProducerOutOfRetries(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		select {
 		case msg := <-producer.Errors():
-			if msg.Err != ErrNotLeaderForPartition {
+			if !errors.Is(msg.Err, ErrNotLeaderForPartition) {
 				t.Error(msg.Err)
 			}
 		case <-producer.Successes():
@@ -916,7 +916,7 @@ func TestAsyncProducerRetryShutdown(t *testing.T) {
 	time.Sleep(5 * time.Millisecond) // let the shutdown goroutine kick in
 
 	producer.Input() <- &ProducerMessage{Topic: "FOO"}
-	if err := <-producer.Errors(); err.Err != ErrShuttingDown {
+	if err := <-producer.Errors(); !errors.Is(err.Err, ErrShuttingDown) {
 		t.Error(err)
 	}
 
@@ -1454,6 +1454,14 @@ func TestAsyncProducerInterceptors(t *testing.T) {
 			t.Parallel()
 			testProducerInterceptor(t, tt.interceptors, tt.expectationFn)
 		})
+	}
+}
+
+func TestProducerError(t *testing.T) {
+	t.Parallel()
+	err := ProducerError{Err: ErrOutOfBrokers}
+	if !errors.Is(err, ErrOutOfBrokers) {
+		t.Error("unexpected errors.Is")
 	}
 }
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -188,7 +188,7 @@ func TestBrokerFailedRequest(t *testing.T) {
 			}
 			err = broker.Close()
 			if err != nil {
-				if tt.stopBroker && err == ErrNotConnected {
+				if tt.stopBroker && errors.Is(err, ErrNotConnected) {
 					// We expect the broker to not close properly
 					return
 				}
@@ -331,8 +331,8 @@ func TestSASLOAuthBearer(t *testing.T) {
 
 			err = broker.authenticateViaSASL()
 
-			if test.expectedBrokerError != ErrNoError {
-				if test.expectedBrokerError != err {
+			if !errors.Is(test.expectedBrokerError, ErrNoError) {
+				if !errors.Is(err, test.expectedBrokerError) {
 					t.Errorf("[%d]:[%s] Expected %s auth error, got %s\n", i, test.name, test.expectedBrokerError, err)
 				}
 			} else if test.expectClientErr && err == nil {
@@ -432,10 +432,10 @@ func TestSASLSCRAMSHAXXX(t *testing.T) {
 			mockSASLAuthResponse := NewMockSaslAuthenticateResponse(t).SetAuthBytes([]byte(test.scramChallengeResp))
 			mockSASLHandshakeResponse := NewMockSaslHandshakeResponse(t).SetEnabledMechanisms([]string{SASLTypeSCRAMSHA256, SASLTypeSCRAMSHA512})
 
-			if test.mockSASLAuthErr != ErrNoError {
+			if !errors.Is(test.mockSASLAuthErr, ErrNoError) {
 				mockSASLAuthResponse = mockSASLAuthResponse.SetError(test.mockSASLAuthErr)
 			}
-			if test.mockHandshakeErr != ErrNoError {
+			if !errors.Is(test.mockHandshakeErr, ErrNoError) {
 				mockSASLHandshakeResponse = mockSASLHandshakeResponse.SetError(test.mockHandshakeErr)
 			}
 
@@ -466,12 +466,12 @@ func TestSASLSCRAMSHAXXX(t *testing.T) {
 
 			err = broker.authenticateViaSASL()
 
-			if test.mockSASLAuthErr != ErrNoError {
-				if test.mockSASLAuthErr != err {
+			if !errors.Is(test.mockSASLAuthErr, ErrNoError) {
+				if !errors.Is(err, test.mockSASLAuthErr) {
 					t.Errorf("[%d]:[%s] Expected %s SASL authentication error, got %s\n", i, test.name, test.mockHandshakeErr, err)
 				}
-			} else if test.mockHandshakeErr != ErrNoError {
-				if test.mockHandshakeErr != err {
+			} else if !errors.Is(test.mockHandshakeErr, ErrNoError) {
+				if !errors.Is(err, test.mockHandshakeErr) {
 					t.Errorf("[%d]:[%s] Expected %s handshake error, got %s\n", i, test.name, test.mockHandshakeErr, err)
 				}
 			} else if test.expectClientErr && err == nil {
@@ -527,14 +527,14 @@ func TestSASLPlainAuth(t *testing.T) {
 			mockSASLAuthResponse := NewMockSaslAuthenticateResponse(t).
 				SetAuthBytes([]byte(`response_payload`))
 
-			if test.mockAuthErr != ErrNoError {
+			if !errors.Is(test.mockAuthErr, ErrNoError) {
 				mockSASLAuthResponse = mockSASLAuthResponse.SetError(test.mockAuthErr)
 			}
 
 			mockSASLHandshakeResponse := NewMockSaslHandshakeResponse(t).
 				SetEnabledMechanisms([]string{SASLTypePlaintext})
 
-			if test.mockHandshakeErr != ErrNoError {
+			if !errors.Is(test.mockHandshakeErr, ErrNoError) {
 				mockSASLHandshakeResponse = mockSASLHandshakeResponse.SetError(test.mockHandshakeErr)
 			}
 
@@ -595,12 +595,12 @@ func TestSASLPlainAuth(t *testing.T) {
 				}
 			}
 
-			if test.mockAuthErr != ErrNoError {
-				if test.mockAuthErr != err {
+			if !errors.Is(test.mockAuthErr, ErrNoError) {
+				if !errors.Is(err, test.mockAuthErr) {
 					t.Errorf("[%d]:[%s] Expected %s auth error, got %s\n", i, test.name, test.mockAuthErr, err)
 				}
-			} else if test.mockHandshakeErr != ErrNoError {
-				if test.mockHandshakeErr != err {
+			} else if !errors.Is(test.mockHandshakeErr, ErrNoError) {
+				if !errors.Is(err, test.mockHandshakeErr) {
 					t.Errorf("[%d]:[%s] Expected %s handshake error, got %s\n", i, test.name, test.mockHandshakeErr, err)
 				}
 			} else if test.expectClientErr && err == nil {

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -95,7 +96,7 @@ func TestClientDoesntCachePartitionsForTopicsWithErrors(t *testing.T) {
 
 	partitions, err := client.Partitions("unknown")
 
-	if err != ErrUnknownTopicOrPartition {
+	if !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("Expected ErrUnknownTopicOrPartition, found", err)
 	}
 	if partitions != nil {
@@ -114,7 +115,7 @@ func TestClientDoesntCachePartitionsForTopicsWithErrors(t *testing.T) {
 
 	// Should not use cache for unknown topic
 	partitions, err = client.Partitions("unknown")
-	if err != ErrUnknownTopicOrPartition {
+	if !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("Expected ErrUnknownTopicOrPartition, found", err)
 	}
 	if partitions != nil {
@@ -381,7 +382,7 @@ func TestClientReceivingUnknownTopicWithBackoffFunc(t *testing.T) {
 	seedBroker.Returns(metadataUnknownTopic)
 	seedBroker.Returns(metadataUnknownTopic)
 
-	if err := client.RefreshMetadata("new_topic"); err != ErrUnknownTopicOrPartition {
+	if err := client.RefreshMetadata("new_topic"); !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("ErrUnknownTopicOrPartition expected, got", err)
 	}
 
@@ -414,7 +415,7 @@ func TestClientReceivingUnknownTopic(t *testing.T) {
 	seedBroker.Returns(metadataUnknownTopic)
 	seedBroker.Returns(metadataUnknownTopic)
 
-	if err := client.RefreshMetadata("new_topic"); err != ErrUnknownTopicOrPartition {
+	if err := client.RefreshMetadata("new_topic"); !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("ErrUnknownTopicOrPartition expected, got", err)
 	}
 
@@ -423,7 +424,7 @@ func TestClientReceivingUnknownTopic(t *testing.T) {
 	seedBroker.Returns(metadataUnknownTopic)
 	seedBroker.Returns(metadataUnknownTopic)
 
-	if _, err = client.Leader("new_topic", 1); err != ErrUnknownTopicOrPartition {
+	if _, err = client.Leader("new_topic", 1); !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("Expected ErrUnknownTopicOrPartition, got", err)
 	}
 
@@ -478,7 +479,7 @@ func TestClientReceivingPartialMetadata(t *testing.T) {
 
 	// Still no leader for the partition, so asking for it should return an error.
 	_, err = client.Leader("new_topic", 1)
-	if err != ErrLeaderNotAvailable {
+	if !errors.Is(err, ErrLeaderNotAvailable) {
 		t.Error("Expected ErrLeaderNotAvailable, got", err)
 	}
 
@@ -620,7 +621,7 @@ func TestClientGetBroker(t *testing.T) {
 		t.Error(err)
 	}
 	_, err = client.Broker(leader.BrokerID())
-	if err != ErrBrokerNotFound {
+	if !errors.Is(err, ErrBrokerNotFound) {
 		t.Errorf("Expected Broker(brokerID) to return %v found %v", ErrBrokerNotFound, err)
 	}
 }
@@ -726,7 +727,7 @@ func TestClientController(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer safeClose(t, client2)
-		if _, err = client2.Controller(); err != ErrUnsupportedVersion {
+		if _, err = client2.Controller(); !errors.Is(err, ErrUnsupportedVersion) {
 			t.Errorf("Expected Controller() to return %s, found %s", ErrUnsupportedVersion, err)
 		}
 	})
@@ -807,7 +808,7 @@ func TestClientMetadataTimeout(t *testing.T) {
 				if err == nil {
 					t.Fatal("Expected failed RefreshMetadata, got nil")
 				}
-				if err != ErrOutOfBrokers {
+				if !errors.Is(err, ErrOutOfBrokers) {
 					t.Error("Expected failed RefreshMetadata with ErrOutOfBrokers, got:", err)
 				}
 			case <-time.After(maxRefreshDuration):

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -22,7 +23,9 @@ func TestInvalidClientIDConfigValidates(t *testing.T) {
 	t.Parallel()
 	config := NewTestConfig()
 	config.ClientID = "foo:bar"
-	if err := config.Validate(); string(err.(ConfigurationError)) != "ClientID is invalid" {
+	err := config.Validate()
+	var target ConfigurationError
+	if !errors.As(err, &target) || string(target) != "ClientID is invalid" {
 		t.Error("Expected invalid ClientID, got ", err)
 	}
 }
@@ -31,7 +34,9 @@ func TestEmptyClientIDConfigValidates(t *testing.T) {
 	t.Parallel()
 	config := NewTestConfig()
 	config.ClientID = ""
-	if err := config.Validate(); string(err.(ConfigurationError)) != "ClientID is invalid" {
+	err := config.Validate()
+	var target ConfigurationError
+	if !errors.As(err, &target) || string(target) != "ClientID is invalid" {
 		t.Error("Expected invalid ClientID, got ", err)
 	}
 }
@@ -232,7 +237,9 @@ func TestNetConfigValidates(t *testing.T) {
 	for i, test := range tests {
 		c := NewTestConfig()
 		test.cfg(c)
-		if err := c.Validate(); string(err.(ConfigurationError)) != test.err {
+		err := c.Validate()
+		var target ConfigurationError
+		if !errors.As(err, &target) || string(target) != test.err {
 			t.Errorf("[%d]:[%s] Expected %s, Got %s\n", i, test.name, test.err, err)
 		}
 	}
@@ -271,7 +278,9 @@ func TestMetadataConfigValidates(t *testing.T) {
 	for i, test := range tests {
 		c := NewTestConfig()
 		test.cfg(c)
-		if err := c.Validate(); string(err.(ConfigurationError)) != test.err {
+		err := c.Validate()
+		var target ConfigurationError
+		if !errors.As(err, &target) || string(target) != test.err {
 			t.Errorf("[%d]:[%s] Expected %s, Got %s\n", i, test.name, test.err, err)
 		}
 	}
@@ -296,7 +305,9 @@ func TestAdminConfigValidates(t *testing.T) {
 	for i, test := range tests {
 		c := NewTestConfig()
 		test.cfg(c)
-		if err := c.Validate(); string(err.(ConfigurationError)) != test.err {
+		err := c.Validate()
+		var target ConfigurationError
+		if !errors.As(err, &target) || string(target) != test.err {
 			t.Errorf("[%d]:[%s] Expected %s, Got %s\n", i, test.name, test.err, err)
 		}
 	}
@@ -426,7 +437,9 @@ func TestProducerConfigValidates(t *testing.T) {
 	for i, test := range tests {
 		c := NewTestConfig()
 		test.cfg(c)
-		if err := c.Validate(); string(err.(ConfigurationError)) != test.err {
+		err := c.Validate()
+		var target ConfigurationError
+		if !errors.As(err, &target) || string(target) != test.err {
 			t.Errorf("[%d]:[%s] Expected %s, Got %s\n", i, test.name, test.err, err)
 		}
 	}
@@ -460,7 +473,9 @@ func TestConsumerConfigValidates(t *testing.T) {
 	for i, test := range tests {
 		c := NewTestConfig()
 		test.cfg(c)
-		if err := c.Validate(); string(err.(ConfigurationError)) != test.err {
+		err := c.Validate()
+		var target ConfigurationError
+		if !errors.As(err, &target) || string(target) != test.err {
 			t.Errorf("[%d]:[%s] Expected %s, Got %s\n", i, test.name, test.err, err)
 		}
 	}
@@ -470,7 +485,9 @@ func TestLZ4ConfigValidation(t *testing.T) {
 	t.Parallel()
 	config := NewTestConfig()
 	config.Producer.Compression = CompressionLZ4
-	if err := config.Validate(); string(err.(ConfigurationError)) != "lz4 compression requires Version >= V0_10_0_0" {
+	err := config.Validate()
+	var target ConfigurationError
+	if !errors.As(err, &target) || string(target) != "lz4 compression requires Version >= V0_10_0_0" {
 		t.Error("Expected invalid lz4/kafka version error, got ", err)
 	}
 	config.Version = V0_10_0_0
@@ -483,7 +500,9 @@ func TestZstdConfigValidation(t *testing.T) {
 	t.Parallel()
 	config := NewTestConfig()
 	config.Producer.Compression = CompressionZSTD
-	if err := config.Validate(); string(err.(ConfigurationError)) != "zstd compression requires Version >= V2_1_0_0" {
+	err := config.Validate()
+	var target ConfigurationError
+	if !errors.As(err, &target) || string(target) != "zstd compression requires Version >= V2_1_0_0" {
 		t.Error("Expected invalid zstd/kafka version error, got ", err)
 	}
 	config.Version = V2_1_0_0

--- a/consumer_group_members.go
+++ b/consumer_group_members.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "errors"
+
 // ConsumerGroupMemberMetadata holds the metadata for consumer group
 // https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
 type ConsumerGroupMemberMetadata struct {
@@ -41,7 +43,7 @@ func (m *ConsumerGroupMemberMetadata) decode(pd packetDecoder) (err error) {
 			// permit missing data here in case of misbehaving 3rd party
 			// clients who incorrectly marked the member metadata as V1 in
 			// their JoinGroup request
-			if err == ErrInsufficientData {
+			if errors.Is(err, ErrInsufficientData) {
 				return nil
 			}
 			return err

--- a/consumer_metadata_response_test.go
+++ b/consumer_metadata_response_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 var (
 	consumerMetadataResponseError = []byte{
@@ -28,7 +31,7 @@ func TestConsumerMetadataResponseError(t *testing.T) {
 		t.Error("could not decode: ", err)
 	}
 
-	if decodedResp.Err != ErrOffsetsLoadInProgress {
+	if !errors.Is(decodedResp.Err, ErrOffsetsLoadInProgress) {
 		t.Errorf("got %s, want %s", decodedResp.Err, ErrOffsetsLoadInProgress)
 	}
 }

--- a/create_partitions_response.go
+++ b/create_partitions_response.go
@@ -84,6 +84,10 @@ func (t *TopicPartitionError) Error() string {
 	return text
 }
 
+func (t *TopicPartitionError) Unwrap() error {
+	return t.Err
+}
+
 func (t *TopicPartitionError) encode(pe packetEncoder) error {
 	pe.putInt16(int16(t.Err))
 

--- a/create_partitions_response_test.go
+++ b/create_partitions_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -57,6 +58,10 @@ func TestTopicPartitionError(t *testing.T) {
 	// Assert that TopicPartitionError satisfies error interface
 	var err error = &TopicPartitionError{
 		Err: ErrTopicAuthorizationFailed,
+	}
+
+	if !errors.Is(err, ErrTopicAuthorizationFailed) {
+		t.Errorf("unexpected errors.Is")
 	}
 
 	got := err.Error()

--- a/create_topics_response.go
+++ b/create_topics_response.go
@@ -98,6 +98,10 @@ func (t *TopicError) Error() string {
 	return text
 }
 
+func (t *TopicError) Unwrap() error {
+	return t.Err
+}
+
 func (t *TopicError) encode(pe packetEncoder, version int16) error {
 	pe.putInt16(int16(t.Err))
 

--- a/create_topics_response_test.go
+++ b/create_topics_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -57,6 +58,10 @@ func TestTopicError(t *testing.T) {
 	// Assert that TopicError satisfies error interface
 	var err error = &TopicError{
 		Err: ErrTopicAuthorizationFailed,
+	}
+
+	if !errors.Is(err, ErrTopicAuthorizationFailed) {
+		t.Errorf("unexpected errors.Is")
 	}
 
 	got := err.Error()

--- a/delete_groups_response_test.go
+++ b/delete_groups_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -43,7 +44,7 @@ func TestDeleteGroupsResponse(t *testing.T) {
 	if response.ThrottleTime != 0 {
 		t.Error("Expected no violation")
 	}
-	if response.GroupErrorCodes["foo"] != ErrClusterAuthorizationFailed {
+	if !errors.Is(response.GroupErrorCodes["foo"], ErrClusterAuthorizationFailed) {
 		t.Error("Expected error ErrClusterAuthorizationFailed, found:", response.GroupErrorCodes["foo"])
 	}
 
@@ -52,7 +53,7 @@ func TestDeleteGroupsResponse(t *testing.T) {
 	if response.ThrottleTime != 0 {
 		t.Error("Expected no violation")
 	}
-	if response.GroupErrorCodes["foo"] != ErrNoError {
+	if !errors.Is(response.GroupErrorCodes["foo"], ErrNoError) {
 		t.Error("Expected error ErrClusterAuthorizationFailed, found:", response.GroupErrorCodes["foo"])
 	}
 }

--- a/describe_groups_response_test.go
+++ b/describe_groups_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -51,7 +52,7 @@ func TestDescribeGroupsResponse(t *testing.T) {
 	}
 
 	group0 := response.Groups[0]
-	if group0.Err != ErrNoError {
+	if !errors.Is(group0.Err, ErrNoError) {
 		t.Error("Unxpected groups[0].Err, found", group0.Err)
 	}
 	if group0.GroupId != "foo" {
@@ -83,7 +84,7 @@ func TestDescribeGroupsResponse(t *testing.T) {
 	}
 
 	group1 := response.Groups[1]
-	if group1.Err != ErrGroupAuthorizationFailed {
+	if !errors.Is(group1.Err, ErrGroupAuthorizationFailed) {
 		t.Error("Unxpected groups[1].Err, found", group0.Err)
 	}
 	if len(group1.Members) != 0 {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,65 @@
+package sarama
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestSentinelWithWrappedError(t *testing.T) {
+	t.Parallel()
+	myNetError := &net.OpError{Op: "mock", Err: errors.New("op error")}
+	error := Wrap(ErrOutOfBrokers, myNetError)
+
+	expected := fmt.Sprintf("%s: 1 error occurred:\n\t* %s\n\n", ErrOutOfBrokers, myNetError)
+	actual := error.Error()
+	if actual != expected {
+		t.Errorf("unexpected value '%s' vs '%v'", expected, actual)
+	}
+
+	if !errors.Is(error, ErrOutOfBrokers) {
+		t.Error("errors.Is unexpected result")
+	}
+
+	if !errors.Is(error, myNetError) {
+		t.Error("errors.Is unexpected result")
+	}
+
+	var opError *net.OpError
+	if !errors.As(error, &opError) {
+		t.Error("errors.As unexpected result")
+	} else if opError != myNetError {
+		t.Error("errors.As wrong value")
+	}
+
+	unwrapped := errors.Unwrap(error)
+	if errors.Is(unwrapped, ErrOutOfBrokers) || !errors.Is(unwrapped, myNetError) {
+		t.Errorf("unexpected unwrapped value %v vs %vs", error, unwrapped)
+	}
+}
+
+func TestSentinelWithMultipleWrappedErrors(t *testing.T) {
+	t.Parallel()
+	myNetError := &net.OpError{}
+	myAddrError := &net.AddrError{}
+
+	error := Wrap(ErrOutOfBrokers, myNetError, myAddrError)
+
+	if !errors.Is(error, ErrOutOfBrokers) {
+		t.Error("errors.Is unexpected result")
+	}
+
+	if !errors.Is(error, myNetError) {
+		t.Error("errors.Is unexpected result")
+	}
+
+	if !errors.Is(error, myAddrError) {
+		t.Error("errors.Is unexpected result")
+	}
+
+	unwrapped := errors.Unwrap(error)
+	if errors.Is(unwrapped, ErrOutOfBrokers) || !errors.Is(unwrapped, myNetError) || !errors.Is(unwrapped, myAddrError) {
+		t.Errorf("unwrapped value unexpected result")
+	}
+}

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"sort"
 	"time"
 )
@@ -112,7 +113,7 @@ func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error)
 		records := &Records{}
 		if err := records.decode(recordsDecoder); err != nil {
 			// If we have at least one decoded records, this is not an error
-			if err == ErrInsufficientData {
+			if errors.Is(err, ErrInsufficientData) {
 				if len(b.RecordsSet) == 0 {
 					b.Partial = true
 				}

--- a/fetch_response_test.go
+++ b/fetch_response_test.go
@@ -2,6 +2,7 @@ package sarama
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 )
 
@@ -228,7 +229,7 @@ func TestOneMessageFetchResponse(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrOffsetOutOfRange {
+	if !errors.Is(block.Err, ErrOffsetOutOfRange) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {
@@ -285,7 +286,7 @@ func TestOverflowMessageFetchResponse(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrOffsetOutOfRange {
+	if !errors.Is(block.Err, ErrOffsetOutOfRange) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {
@@ -346,7 +347,7 @@ func TestOneRecordFetchResponse(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrOffsetOutOfRange {
+	if !errors.Is(block.Err, ErrOffsetOutOfRange) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {
@@ -396,7 +397,7 @@ func TestPartailFetchResponse(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrNoError {
+	if !errors.Is(block.Err, ErrNoError) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {
@@ -439,7 +440,7 @@ func TestEmptyRecordsFetchResponse(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrNoError {
+	if !errors.Is(block.Err, ErrNoError) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {
@@ -485,7 +486,7 @@ func TestOneMessageFetchResponseV4(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrOffsetOutOfRange {
+	if !errors.Is(block.Err, ErrOffsetOutOfRange) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {
@@ -552,7 +553,7 @@ func TestPreferredReplicaFetchResponseV11(t *testing.T) {
 	if block == nil {
 		t.Fatal("GetBlock didn't return block.")
 	}
-	if block.Err != ErrOffsetOutOfRange {
+	if !errors.Is(block.Err, ErrOffsetOutOfRange) {
 		t.Error("Decoding didn't produce correct error code.")
 	}
 	if block.HighWaterMarkOffset != 0x10101010 {

--- a/functional_client_test.go
+++ b/functional_client_test.go
@@ -4,6 +4,7 @@
 package sarama
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ func TestFuncConnectionFailure(t *testing.T) {
 	config.Metadata.Retry.Max = 1
 
 	_, err := NewClient([]string{FunctionalTestEnv.KafkaBrokerAddrs[0]}, config)
-	if err != ErrOutOfBrokers {
+	if !errors.Is(err, ErrOutOfBrokers) {
 		t.Fatal("Expected returned error to be ErrOutOfBrokers, but was: ", err)
 	}
 }
@@ -37,15 +38,15 @@ func TestFuncClientMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := client.RefreshMetadata("unknown_topic"); err != ErrUnknownTopicOrPartition {
+	if err := client.RefreshMetadata("unknown_topic"); !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("Expected ErrUnknownTopicOrPartition, got", err)
 	}
 
-	if _, err := client.Leader("unknown_topic", 0); err != ErrUnknownTopicOrPartition {
+	if _, err := client.Leader("unknown_topic", 0); !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("Expected ErrUnknownTopicOrPartition, got", err)
 	}
 
-	if _, err := client.Replicas("invalid/topic", 0); err != ErrUnknownTopicOrPartition && err != ErrInvalidTopic {
+	if _, err := client.Replicas("invalid/topic", 0); !errors.Is(err, ErrUnknownTopicOrPartition) && !errors.Is(err, ErrInvalidTopic) {
 		t.Error("Expected ErrUnknownTopicOrPartition or ErrInvalidTopic, got", err)
 	}
 

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -5,6 +5,7 @@ package sarama
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -529,7 +530,7 @@ func (m *testFuncConsumerGroupMember) loop(topics []string) {
 		// set state to pre-consume
 		atomic.StoreInt32(&m.state, 1)
 
-		if err := m.Consume(ctx, topics, m); err == ErrClosedConsumerGroup {
+		if err := m.Consume(ctx, topics, m); errors.Is(err, ErrClosedConsumerGroup) {
 			return
 		} else if err != nil {
 			m.mu.Lock()

--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -4,6 +4,7 @@
 package sarama
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -25,11 +26,11 @@ func TestFuncConsumerOffsetOutOfRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := consumer.ConsumePartition("test.1", 0, -10); err != ErrOffsetOutOfRange {
+	if _, err := consumer.ConsumePartition("test.1", 0, -10); !errors.Is(err, ErrOffsetOutOfRange) {
 		t.Error("Expected ErrOffsetOutOfRange, got:", err)
 	}
 
-	if _, err := consumer.ConsumePartition("test.1", 0, math.MaxInt64); err != ErrOffsetOutOfRange {
+	if _, err := consumer.ConsumePartition("test.1", 0, math.MaxInt64); !errors.Is(err, ErrOffsetOutOfRange) {
 		t.Error("Expected ErrOffsetOutOfRange, got:", err)
 	}
 

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -4,6 +4,7 @@
 package sarama
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -97,7 +98,7 @@ func TestFuncProducingToInvalidTopic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); err != ErrUnknownTopicOrPartition && err != ErrInvalidTopic {
+	if _, _, err := producer.SendMessage(&ProducerMessage{Topic: "in/valid"}); !errors.Is(err, ErrUnknownTopicOrPartition) && !errors.Is(err, ErrInvalidTopic) {
 		t.Error("Expected ErrUnknownTopicOrPartition, found", err)
 	}
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -5,6 +5,7 @@ package sarama
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -377,11 +378,11 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 }
 
 func isTopicNotExistsErrorOrOk(err KError) bool {
-	return err == ErrUnknownTopicOrPartition || err == ErrInvalidTopic || err == ErrNoError
+	return errors.Is(err, ErrUnknownTopicOrPartition) || errors.Is(err, ErrInvalidTopic) || errors.Is(err, ErrNoError)
 }
 
 func isTopicExistsErrorOrOk(err KError) bool {
-	return err == ErrTopicAlreadyExists || err == ErrNoError
+	return errors.Is(err, ErrTopicAlreadyExists) || errors.Is(err, ErrNoError)
 }
 
 func checkKafkaVersion(t testing.TB, requiredVersion string) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/frankban/quicktest v1.14.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jcmturner/gofork v1.0.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/klauspost/compress v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,10 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=

--- a/heartbeat_response_test.go
+++ b/heartbeat_response_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 var heartbeatResponseNoError = []byte{
 	0x00, 0x00,
@@ -10,7 +13,7 @@ func TestHeartbeatResponse(t *testing.T) {
 	t.Parallel()
 	response := new(HeartbeatResponse)
 	testVersionDecodable(t, "no error", response, heartbeatResponseNoError, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding error failed: no error expected but found", response.Err)
 	}
 }

--- a/join_group_response_test.go
+++ b/join_group_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -61,7 +62,7 @@ func TestJoinGroupResponseV0(t *testing.T) {
 
 	response = new(JoinGroupResponse)
 	testVersionDecodable(t, "no error", response, joinGroupResponseV0_NoError, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding Err failed: no error expected but found", response.Err)
 	}
 	if response.GenerationId != 66051 {
@@ -79,7 +80,7 @@ func TestJoinGroupResponseV0(t *testing.T) {
 
 	response = new(JoinGroupResponse)
 	testVersionDecodable(t, "with error", response, joinGroupResponseV0_WithError, 0)
-	if response.Err != ErrInconsistentGroupProtocol {
+	if !errors.Is(response.Err, ErrInconsistentGroupProtocol) {
 		t.Error("Decoding Err failed: ErrInconsistentGroupProtocol expected but found", response.Err)
 	}
 	if response.GenerationId != 0 {
@@ -97,7 +98,7 @@ func TestJoinGroupResponseV0(t *testing.T) {
 
 	response = new(JoinGroupResponse)
 	testVersionDecodable(t, "with error", response, joinGroupResponseV0_Leader, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding Err failed: ErrNoError expected but found", response.Err)
 	}
 	if response.GenerationId != 66051 {
@@ -121,7 +122,7 @@ func TestJoinGroupResponseV1(t *testing.T) {
 	t.Parallel()
 	response := new(JoinGroupResponse)
 	testVersionDecodable(t, "no error", response, joinGroupResponseV1, 1)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding Err failed: no error expected but found", response.Err)
 	}
 	if response.GenerationId != 66051 {
@@ -151,7 +152,7 @@ func TestJoinGroupResponseV2(t *testing.T) {
 	if response.ThrottleTime != 100 {
 		t.Error("Decoding ThrottleTime failed, found:", response.ThrottleTime)
 	}
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding Err failed: no error expected but found", response.Err)
 	}
 	if response.GenerationId != 66051 {

--- a/leave_group_response_test.go
+++ b/leave_group_response_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 var (
 	leaveGroupResponseNoError   = []byte{0x00, 0x00}
@@ -13,13 +16,13 @@ func TestLeaveGroupResponse(t *testing.T) {
 
 	response = new(LeaveGroupResponse)
 	testVersionDecodable(t, "no error", response, leaveGroupResponseNoError, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding error failed: no error expected but found", response.Err)
 	}
 
 	response = new(LeaveGroupResponse)
 	testVersionDecodable(t, "with error", response, leaveGroupResponseWithError, 0)
-	if response.Err != ErrUnknownMemberId {
+	if !errors.Is(response.Err, ErrUnknownMemberId) {
 		t.Error("Decoding error failed: ErrUnknownMemberId expected but found", response.Err)
 	}
 }

--- a/list_groups_response_test.go
+++ b/list_groups_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func TestListGroupsResponse(t *testing.T) {
 
 	response = new(ListGroupsResponse)
 	testVersionDecodable(t, "no error", response, listGroupsResponseEmpty, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Expected no gerror, found:", response.Err)
 	}
 	if len(response.Groups) != 0 {
@@ -38,7 +39,7 @@ func TestListGroupsResponse(t *testing.T) {
 
 	response = new(ListGroupsResponse)
 	testVersionDecodable(t, "no error", response, listGroupsResponseError, 0)
-	if response.Err != ErrClusterAuthorizationFailed {
+	if !errors.Is(response.Err, ErrClusterAuthorizationFailed) {
 		t.Error("Expected no gerror, found:", response.Err)
 	}
 	if len(response.Groups) != 0 {
@@ -47,7 +48,7 @@ func TestListGroupsResponse(t *testing.T) {
 
 	response = new(ListGroupsResponse)
 	testVersionDecodable(t, "no error", response, listGroupsResponseWithConsumer, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Expected no gerror, found:", response.Err)
 	}
 	if len(response.Groups) != 1 {

--- a/message_set.go
+++ b/message_set.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "errors"
+
 type MessageBlock struct {
 	Offset int64
 	Msg    *Message
@@ -70,7 +72,7 @@ func (ms *MessageSet) decode(pd packetDecoder) (err error) {
 	for pd.remaining() > 0 {
 		magic, err := magicValue(pd)
 		if err != nil {
-			if err == ErrInsufficientData {
+			if errors.Is(err, ErrInsufficientData) {
 				ms.PartialTrailingMessage = true
 				return nil
 			}
@@ -83,10 +85,9 @@ func (ms *MessageSet) decode(pd packetDecoder) (err error) {
 
 		msb := new(MessageBlock)
 		err = msb.decode(pd)
-		switch err {
-		case nil:
+		if err == nil {
 			ms.Messages = append(ms.Messages, msb)
-		case ErrInsufficientData:
+		} else if errors.Is(err, ErrInsufficientData) {
 			// As an optimization the server is allowed to return a partial message at the
 			// end of the message set. Clients should handle this case. So we just ignore such things.
 			if msb.Offset == -1 {
@@ -96,7 +97,7 @@ func (ms *MessageSet) decode(pd packetDecoder) (err error) {
 				ms.PartialTrailingMessage = true
 			}
 			return nil
-		default:
+		} else {
 			return err
 		}
 	}

--- a/metadata_response_test.go
+++ b/metadata_response_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 var (
 	emptyMetadataResponseV0 = []byte{
@@ -161,7 +164,7 @@ func TestMetadataResponseWithTopicsV0(t *testing.T) {
 		t.Fatal("Decoding produced", len(response.Topics), "topics where there were two!")
 	}
 
-	if response.Topics[0].Err != ErrNoError {
+	if !errors.Is(response.Topics[0].Err, ErrNoError) {
 		t.Error("Decoding produced invalid topic 0 error.")
 	}
 
@@ -173,7 +176,7 @@ func TestMetadataResponseWithTopicsV0(t *testing.T) {
 		t.Fatal("Decoding produced invalid partition count for topic 0.")
 	}
 
-	if response.Topics[0].Partitions[0].Err != ErrInvalidMessageSize {
+	if !errors.Is(response.Topics[0].Partitions[0].Err, ErrInvalidMessageSize) {
 		t.Error("Decoding produced invalid topic 0 partition 0 error.")
 	}
 
@@ -198,7 +201,7 @@ func TestMetadataResponseWithTopicsV0(t *testing.T) {
 		t.Error("Decoding produced invalid topic 0 partition 0 isr length.")
 	}
 
-	if response.Topics[1].Err != ErrNoError {
+	if !errors.Is(response.Topics[1].Err, ErrNoError) {
 		t.Error("Decoding produced invalid topic 1 error.")
 	}
 

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -3,6 +3,7 @@ package sarama
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -359,9 +360,10 @@ func (b *MockBroker) defaultRequestHandler(req *request) (res encoderWithHeader)
 
 func (b *MockBroker) serverError(err error) {
 	isConnectionClosedError := false
-	if _, ok := err.(*net.OpError); ok {
+	opError := &net.OpError{}
+	if errors.As(err, &opError) {
 		isConnectionClosedError = true
-	} else if err == io.EOF {
+	} else if errors.Is(err, io.EOF) {
 		isConnectionClosedError = true
 	} else if err.Error() == "use of closed network connection" {
 		isConnectionClosedError = true

--- a/mocks/async_producer.go
+++ b/mocks/async_producer.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/Shopify/sarama"
@@ -78,7 +79,7 @@ func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
 							mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
 						}
 					}
-					if expectation.Result == errProduceSuccess {
+					if errors.Is(expectation.Result, errProduceSuccess) {
 						mp.lastOffset++
 						if config.Producer.Return.Successes {
 							msg.Offset = mp.lastOffset

--- a/mocks/async_producer_test.go
+++ b/mocks/async_producer_test.go
@@ -68,7 +68,7 @@ func TestProducerReturnsExpectationsToChannels(t *testing.T) {
 		t.Error("Expected message 2 to be returned second")
 	}
 
-	if err1.Msg.Topic != "test 3" || err1.Err != sarama.ErrOutOfBrokers {
+	if err1.Msg.Topic != "test 3" || !errors.Is(err1, sarama.ErrOutOfBrokers) {
 		t.Error("Expected message 3 to be returned as error")
 	}
 

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -44,7 +44,7 @@ func messageValueChecker(f ValueChecker) MessageChecker {
 	return func(msg *sarama.ProducerMessage) error {
 		val, err := msg.Value.Encode()
 		if err != nil {
-			return fmt.Errorf("Input message encoding failed: %s", err.Error())
+			return fmt.Errorf("Input message encoding failed: %w", err)
 		}
 		return f(val)
 	}

--- a/mocks/sync_producer.go
+++ b/mocks/sync_producer.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/Shopify/sarama"
@@ -68,7 +69,7 @@ func (sp *SyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int3
 				return -1, -1, errCheck
 			}
 		}
-		if expectation.Result == errProduceSuccess {
+		if errors.Is(expectation.Result, errProduceSuccess) {
 			sp.lastOffset++
 			msg.Offset = sp.lastOffset
 			return 0, msg.Offset, nil
@@ -106,7 +107,7 @@ func (sp *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
 					return errCheck
 				}
 			}
-			if expectation.Result != errProduceSuccess {
+			if !errors.Is(expectation.Result, errProduceSuccess) {
 				return expectation.Result
 			}
 			sp.lastOffset++

--- a/mocks/sync_producer_test.go
+++ b/mocks/sync_producer_test.go
@@ -48,7 +48,7 @@ func TestSyncProducerReturnsExpectationsToSendMessage(t *testing.T) {
 	}
 
 	_, _, err = sp.SendMessage(msg)
-	if err != sarama.ErrOutOfBrokers {
+	if !errors.Is(err, sarama.ErrOutOfBrokers) {
 		t.Errorf("The third message should not have been produced successfully")
 	}
 
@@ -89,7 +89,7 @@ func TestSyncProducerWithTooFewExpectations(t *testing.T) {
 	if _, _, err := sp.SendMessage(msg); err != nil {
 		t.Error("No error expected on first SendMessage call", err)
 	}
-	if _, _, err := sp.SendMessage(msg); err != errOutOfExpectations {
+	if _, _, err := sp.SendMessage(msg); !errors.Is(err, errOutOfExpectations) {
 		t.Error("errOutOfExpectations expected on second SendMessage call, found:", err)
 	}
 

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -90,7 +91,7 @@ func TestNewOffsetManager(t *testing.T) {
 	safeClose(t, testClient)
 
 	_, err = NewOffsetManagerFromClient("group", testClient)
-	if err != ErrClosedClient {
+	if !errors.Is(err, ErrClosedClient) {
 		t.Errorf("Error expected for closed client; actual value: %v", err)
 	}
 }

--- a/offset_response_test.go
+++ b/offset_response_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 var (
 	emptyOffsetResponse = []byte{
@@ -72,7 +75,7 @@ func TestNormalOffsetResponse(t *testing.T) {
 		t.Fatal("Decoding produced", len(response.Blocks["z"]), "partitions for topic 'z' where there was one.")
 	}
 
-	if response.Blocks["z"][2].Err != ErrNoError {
+	if !errors.Is(response.Blocks["z"][2].Err, ErrNoError) {
 		t.Fatal("Decoding produced invalid error for topic z partition 2.")
 	}
 
@@ -103,7 +106,7 @@ func TestNormalOffsetResponseV1(t *testing.T) {
 		t.Fatal("Decoding produced", len(response.Blocks["z"]), "partitions for topic 'z' where there was one.")
 	}
 
-	if response.Blocks["z"][2].Err != ErrNoError {
+	if !errors.Is(response.Blocks["z"][2].Err, ErrNoError) {
 		t.Fatal("Decoding produced invalid error for topic z partition 2.")
 	}
 

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -87,7 +88,7 @@ func TestProduceResponseDecode(t *testing.T) {
 		if block == nil {
 			t.Error("Decoding did not produce a block for foo/1")
 		} else {
-			if block.Err != ErrInvalidMessage {
+			if !errors.Is(block.Err, ErrInvalidMessage) {
 				t.Error("Decoding failed for foo/1/Err, got:", int16(block.Err))
 			}
 			if block.Offset != 255 {
@@ -149,7 +150,8 @@ func TestProduceResponseEncodeInvalidTimestamp(t *testing.T) {
 	if err == nil {
 		t.Error("Expecting error, got nil")
 	}
-	if _, ok := err.(PacketEncodingError); !ok {
+	target := PacketEncodingError{}
+	if !errors.As(err, &target) {
 		t.Error("Expecting PacketEncodingError, got:", err)
 	}
 }

--- a/record_batch.go
+++ b/record_batch.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"fmt"
 	"time"
 )
@@ -167,7 +168,7 @@ func (b *RecordBatch) decode(pd packetDecoder) (err error) {
 	bufSize := int(batchLen) - recordBatchOverhead
 	recBuffer, err := pd.getRawBytes(bufSize)
 	if err != nil {
-		if err == ErrInsufficientData {
+		if errors.Is(err, ErrInsufficientData) {
 			b.PartialTrailingRecord = true
 			b.Records = nil
 			return nil
@@ -186,7 +187,7 @@ func (b *RecordBatch) decode(pd packetDecoder) (err error) {
 
 	b.recordsLen = len(recBuffer)
 	err = decode(recBuffer, recordsArray(b.Records))
-	if err == ErrInsufficientData {
+	if errors.Is(err, ErrInsufficientData) {
 		b.PartialTrailingRecord = true
 		b.Records = nil
 		return nil

--- a/sasl_handshake_response_test.go
+++ b/sasl_handshake_response_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 var saslHandshakeResponse = []byte{
 	0x00, 0x00,
@@ -12,7 +15,7 @@ func TestSaslHandshakeResponse(t *testing.T) {
 	t.Parallel()
 	response := new(SaslHandshakeResponse)
 	testVersionDecodable(t, "no error", response, saslHandshakeResponse, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding error failed: no error expected but found", response.Err)
 	}
 	if response.EnabledMechanisms[0] != "foo" {

--- a/sync_group_response_test.go
+++ b/sync_group_response_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -23,7 +24,7 @@ func TestSyncGroupResponse(t *testing.T) {
 
 	response = new(SyncGroupResponse)
 	testVersionDecodable(t, "no error", response, syncGroupResponseNoError, 0)
-	if response.Err != ErrNoError {
+	if !errors.Is(response.Err, ErrNoError) {
 		t.Error("Decoding Err failed: no error expected but found", response.Err)
 	}
 	if !reflect.DeepEqual(response.MemberAssignment, []byte{0x01, 0x02, 0x03}) {
@@ -32,7 +33,7 @@ func TestSyncGroupResponse(t *testing.T) {
 
 	response = new(SyncGroupResponse)
 	testVersionDecodable(t, "no error", response, syncGroupResponseWithError, 0)
-	if response.Err != ErrRebalanceInProgress {
+	if !errors.Is(response.Err, ErrRebalanceInProgress) {
 		t.Error("Decoding Err failed: ErrRebalanceInProgress expected but found", response.Err)
 	}
 	if !reflect.DeepEqual(response.MemberAssignment, []byte{}) {

--- a/sync_producer_test.go
+++ b/sync_producer_test.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"errors"
 	"log"
 	"sync"
 	"testing"
@@ -175,7 +176,7 @@ func TestSyncProducerToNonExistingTopic(t *testing.T) {
 	broker.Returns(metadataResponse)
 
 	_, _, err = producer.SendMessage(&ProducerMessage{Topic: "unknown"})
-	if err != ErrUnknownTopicOrPartition {
+	if !errors.Is(err, ErrUnknownTopicOrPartition) {
 		t.Error("Uxpected ErrUnknownTopicOrPartition, found:", err)
 	}
 
@@ -208,7 +209,7 @@ func TestSyncProducerRecoveryWithRetriesDisabled(t *testing.T) {
 	prodNotLeader.AddTopicPartition("my_topic", 0, ErrNotLeaderForPartition)
 	leader1.Returns(prodNotLeader)
 	_, _, err = producer.SendMessage(&ProducerMessage{Topic: "my_topic", Value: StringEncoder(TestMessage)})
-	if err != ErrNotLeaderForPartition {
+	if !errors.Is(err, ErrNotLeaderForPartition) {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
With this change, the user of Sarama is required to use Go 1.13's `errors.Is` etc (rather then `==`) when forming conditionals returned by this library.