### PR TITLE
retract v1.31.0 and v1.32.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/Shopify/sarama
 
 go 1.16
 
+retract [v1.31.0, v1.31.2] // https://github.com/Shopify/sarama/issues/2129
+
 require (
 	github.com/Shopify/toxiproxy/v2 v2.3.0
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
This should be released as v1.32.2 to avoid users to upgrade to these faulty versions until https://github.com/Shopify/sarama/pull/2133 is merged.

refs #2129

https://go.dev/ref/mod#go-mod-file-retract