### PR TITLE
fix: TestRecordBatchDecoding failing sporadically

### DIFF
--- a/record_test.go
+++ b/record_test.go
@@ -11,236 +11,243 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-var recordBatchTestCases = []struct {
+func recordBatchTestCases() []struct {
 	name         string
 	batch        RecordBatch
 	encoded      []byte
-	oldGoEncoded []byte // used in case of gzipped content for go versions prior to 1.8
-}{
-	{
-		name: "empty record",
-		batch: RecordBatch{
-			Version:        2,
-			FirstTimestamp: time.Unix(0, 0),
-			MaxTimestamp:   time.Unix(0, 0),
-			Records:        []*Record{},
+	oldGoEncoded []byte
+} {
+	return []struct {
+		name         string
+		batch        RecordBatch
+		encoded      []byte
+		oldGoEncoded []byte // used in case of gzipped content for go versions prior to 1.8
+	}{
+		{
+			name: "empty record",
+			batch: RecordBatch{
+				Version:        2,
+				FirstTimestamp: time.Unix(0, 0),
+				MaxTimestamp:   time.Unix(0, 0),
+				Records:        []*Record{},
+			},
+			encoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 49, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,                // Version
+				89, 95, 183, 221, // CRC
+				0, 0, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 0, 0, 0, 0, 0, 0, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 0, // Number of Records
+			},
 		},
-		encoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 49, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,                // Version
-			89, 95, 183, 221, // CRC
-			0, 0, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 0, 0, 0, 0, 0, 0, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 0, // Number of Records
+		{
+			name: "control batch",
+			batch: RecordBatch{
+				Version:        2,
+				Control:        true,
+				FirstTimestamp: time.Unix(0, 0),
+				MaxTimestamp:   time.Unix(0, 0),
+				Records:        []*Record{},
+			},
+			encoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 49, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,               // Version
+				81, 46, 67, 217, // CRC
+				0, 32, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 0, 0, 0, 0, 0, 0, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 0, // Number of Records
+			},
 		},
-	},
-	{
-		name: "control batch",
-		batch: RecordBatch{
-			Version:        2,
-			Control:        true,
-			FirstTimestamp: time.Unix(0, 0),
-			MaxTimestamp:   time.Unix(0, 0),
-			Records:        []*Record{},
-		},
-		encoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 49, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,               // Version
-			81, 46, 67, 217, // CRC
-			0, 32, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 0, 0, 0, 0, 0, 0, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 0, // Number of Records
-		},
-	},
-	{
-		name: "uncompressed record",
-		batch: RecordBatch{
-			Version:         2,
-			FirstTimestamp:  time.Unix(1479847795, 0),
-			MaxTimestamp:    time.Unix(0, 0),
-			LastOffsetDelta: 0,
-			Records: []*Record{{
-				TimestampDelta: 5 * time.Millisecond,
-				Key:            []byte{1, 2, 3, 4},
-				Value:          []byte{5, 6, 7},
-				Headers: []*RecordHeader{{
-					Key:   []byte{8, 9, 10},
-					Value: []byte{11, 12},
+		{
+			name: "uncompressed record",
+			batch: RecordBatch{
+				Version:         2,
+				FirstTimestamp:  time.Unix(1479847795, 0),
+				MaxTimestamp:    time.Unix(0, 0),
+				LastOffsetDelta: 0,
+				Records: []*Record{{
+					TimestampDelta: 5 * time.Millisecond,
+					Key:            []byte{1, 2, 3, 4},
+					Value:          []byte{5, 6, 7},
+					Headers: []*RecordHeader{{
+						Key:   []byte{8, 9, 10},
+						Value: []byte{11, 12},
+					}},
 				}},
-			}},
-			recordsLen: 21,
+				recordsLen: 21,
+			},
+			encoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 70, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,                // Version
+				84, 121, 97, 253, // CRC
+				0, 0, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 1, // Number of Records
+				40, // Record Length
+				0,  // Attributes
+				10, // Timestamp Delta
+				0,  // Offset Delta
+				8,  // Key Length
+				1, 2, 3, 4,
+				6, // Value Length
+				5, 6, 7,
+				2,        // Number of Headers
+				6,        // Header Key Length
+				8, 9, 10, // Header Key
+				4,      // Header Value Length
+				11, 12, // Header Value
+			},
 		},
-		encoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 70, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,                // Version
-			84, 121, 97, 253, // CRC
-			0, 0, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 1, // Number of Records
-			40, // Record Length
-			0,  // Attributes
-			10, // Timestamp Delta
-			0,  // Offset Delta
-			8,  // Key Length
-			1, 2, 3, 4,
-			6, // Value Length
-			5, 6, 7,
-			2,        // Number of Headers
-			6,        // Header Key Length
-			8, 9, 10, // Header Key
-			4,      // Header Value Length
-			11, 12, // Header Value
-		},
-	},
-	{
-		name: "gzipped record",
-		batch: RecordBatch{
-			Version:          2,
-			Codec:            CompressionGZIP,
-			CompressionLevel: CompressionLevelDefault,
-			FirstTimestamp:   time.Unix(1479847795, 0),
-			MaxTimestamp:     time.Unix(0, 0),
-			LastOffsetDelta:  0,
-			Records: []*Record{{
-				TimestampDelta: 5 * time.Millisecond,
-				Key:            []byte{1, 2, 3, 4},
-				Value:          []byte{5, 6, 7},
-				Headers: []*RecordHeader{{
-					Key:   []byte{8, 9, 10},
-					Value: []byte{11, 12},
+		{
+			name: "gzipped record",
+			batch: RecordBatch{
+				Version:          2,
+				Codec:            CompressionGZIP,
+				CompressionLevel: CompressionLevelDefault,
+				FirstTimestamp:   time.Unix(1479847795, 0),
+				MaxTimestamp:     time.Unix(0, 0),
+				LastOffsetDelta:  0,
+				Records: []*Record{{
+					TimestampDelta: 5 * time.Millisecond,
+					Key:            []byte{1, 2, 3, 4},
+					Value:          []byte{5, 6, 7},
+					Headers: []*RecordHeader{{
+						Key:   []byte{8, 9, 10},
+						Value: []byte{11, 12},
+					}},
 				}},
-			}},
-			recordsLen: 21,
+				recordsLen: 21,
+			},
+			encoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 94, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,                  // Version
+				159, 236, 182, 189, // CRC
+				0, 1, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 1, // Number of Records
+				31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 210, 96, 224, 98, 224, 96, 100, 98, 102, 97, 99, 101,
+				99, 103, 98, 227, 224, 228, 98, 225, 230, 1, 4, 0, 0, 255, 255, 173, 201, 88, 103, 21, 0, 0, 0,
+			},
+			oldGoEncoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 94, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,               // Version
+				0, 216, 14, 210, // CRC
+				0, 1, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 1, // Number of Records
+				31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 210, 96, 224, 98, 224, 96, 100, 98, 102, 97, 99, 101,
+				99, 103, 98, 227, 224, 228, 98, 225, 230, 1, 4, 0, 0, 255, 255, 173, 201, 88, 103, 21, 0, 0, 0,
+			},
 		},
-		encoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 94, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,                  // Version
-			159, 236, 182, 189, // CRC
-			0, 1, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 1, // Number of Records
-			31, 139, 8, 0, 0, 0, 0, 0, 0, 255, 210, 96, 224, 98, 224, 96, 100, 98, 102, 97, 99, 101,
-			99, 103, 98, 227, 224, 228, 98, 225, 230, 1, 4, 0, 0, 255, 255, 173, 201, 88, 103, 21, 0, 0, 0,
-		},
-		oldGoEncoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 94, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,               // Version
-			0, 216, 14, 210, // CRC
-			0, 1, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 1, // Number of Records
-			31, 139, 8, 0, 0, 9, 110, 136, 0, 255, 210, 96, 224, 98, 224, 96, 100, 98, 102, 97, 99, 101,
-			99, 103, 98, 227, 224, 228, 98, 225, 230, 1, 4, 0, 0, 255, 255, 173, 201, 88, 103, 21, 0, 0, 0,
-		},
-	},
-	{
-		name: "snappy compressed record",
-		batch: RecordBatch{
-			Version:         2,
-			Codec:           CompressionSnappy,
-			FirstTimestamp:  time.Unix(1479847795, 0),
-			MaxTimestamp:    time.Unix(0, 0),
-			LastOffsetDelta: 0,
-			Records: []*Record{{
-				TimestampDelta: 5 * time.Millisecond,
-				Key:            []byte{1, 2, 3, 4},
-				Value:          []byte{5, 6, 7},
-				Headers: []*RecordHeader{{
-					Key:   []byte{8, 9, 10},
-					Value: []byte{11, 12},
+		{
+			name: "snappy compressed record",
+			batch: RecordBatch{
+				Version:         2,
+				Codec:           CompressionSnappy,
+				FirstTimestamp:  time.Unix(1479847795, 0),
+				MaxTimestamp:    time.Unix(0, 0),
+				LastOffsetDelta: 0,
+				Records: []*Record{{
+					TimestampDelta: 5 * time.Millisecond,
+					Key:            []byte{1, 2, 3, 4},
+					Value:          []byte{5, 6, 7},
+					Headers: []*RecordHeader{{
+						Key:   []byte{8, 9, 10},
+						Value: []byte{11, 12},
+					}},
 				}},
-			}},
-			recordsLen: 21,
+				recordsLen: 21,
+			},
+			encoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 72, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,              // Version
+				21, 0, 159, 97, // CRC
+				0, 2, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 1, // Number of Records
+				21, 80, 40, 0, 10, 0, 8, 1, 2, 3, 4, 6, 5, 6, 7, 2, 6, 8, 9, 10, 4, 11, 12,
+			},
 		},
-		encoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 72, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,              // Version
-			21, 0, 159, 97, // CRC
-			0, 2, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 1, // Number of Records
-			21, 80, 40, 0, 10, 0, 8, 1, 2, 3, 4, 6, 5, 6, 7, 2, 6, 8, 9, 10, 4, 11, 12,
-		},
-	},
-	{
-		name: "lz4 compressed record",
-		batch: RecordBatch{
-			Version:         2,
-			Codec:           CompressionLZ4,
-			FirstTimestamp:  time.Unix(1479847795, 0),
-			MaxTimestamp:    time.Unix(0, 0),
-			LastOffsetDelta: 0,
-			Records: []*Record{{
-				TimestampDelta: 5 * time.Millisecond,
-				Key:            []byte{1, 2, 3, 4},
-				Value:          []byte{5, 6, 7},
-				Headers: []*RecordHeader{{
-					Key:   []byte{8, 9, 10},
-					Value: []byte{11, 12},
+		{
+			name: "lz4 compressed record",
+			batch: RecordBatch{
+				Version:         2,
+				Codec:           CompressionLZ4,
+				FirstTimestamp:  time.Unix(1479847795, 0),
+				MaxTimestamp:    time.Unix(0, 0),
+				LastOffsetDelta: 0,
+				Records: []*Record{{
+					TimestampDelta: 5 * time.Millisecond,
+					Key:            []byte{1, 2, 3, 4},
+					Value:          []byte{5, 6, 7},
+					Headers: []*RecordHeader{{
+						Key:   []byte{8, 9, 10},
+						Value: []byte{11, 12},
+					}},
 				}},
-			}},
-			recordsLen: 21,
+				recordsLen: 21,
+			},
+			encoded: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0, // First Offset
+				0, 0, 0, 89, // Length
+				0, 0, 0, 0, // Partition Leader Epoch
+				2,                 // Version
+				169, 74, 119, 197, // CRC
+				0, 3, // Attributes
+				0, 0, 0, 0, // Last Offset Delta
+				0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
+				0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
+				0, 0, // Producer Epoch
+				0, 0, 0, 0, // First Sequence
+				0, 0, 0, 1, // Number of Records
+				4, 34, 77, 24, 100, 112, 185, 21, 0, 0, 128, 40, 0, 10, 0, 8, 1, 2, 3, 4, 6, 5, 6, 7, 2,
+				6, 8, 9, 10, 4, 11, 12, 0, 0, 0, 0, 12, 59, 239, 146,
+			},
 		},
-		encoded: []byte{
-			0, 0, 0, 0, 0, 0, 0, 0, // First Offset
-			0, 0, 0, 89, // Length
-			0, 0, 0, 0, // Partition Leader Epoch
-			2,                 // Version
-			169, 74, 119, 197, // CRC
-			0, 3, // Attributes
-			0, 0, 0, 0, // Last Offset Delta
-			0, 0, 1, 88, 141, 205, 89, 56, // First Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Max Timestamp
-			0, 0, 0, 0, 0, 0, 0, 0, // Producer ID
-			0, 0, // Producer Epoch
-			0, 0, 0, 0, // First Sequence
-			0, 0, 0, 1, // Number of Records
-			4, 34, 77, 24, 100, 112, 185, 21, 0, 0, 128, 40, 0, 10, 0, 8, 1, 2, 3, 4, 6, 5, 6, 7, 2,
-			6, 8, 9, 10, 4, 11, 12, 0, 0, 0, 0, 12, 59, 239, 146,
-		},
-	},
+	}
 }
 
 func isOldGo(t *testing.T) bool {
@@ -264,7 +271,7 @@ func isOldGo(t *testing.T) bool {
 
 func TestRecordBatchEncoding(t *testing.T) {
 	t.Parallel()
-	for _, tc := range recordBatchTestCases {
+	for _, tc := range recordBatchTestCases() {
 		if tc.oldGoEncoded != nil && isOldGo(t) {
 			testEncodable(t, tc.name, &tc.batch, tc.oldGoEncoded)
 		} else {
@@ -275,13 +282,10 @@ func TestRecordBatchEncoding(t *testing.T) {
 
 func TestRecordBatchDecoding(t *testing.T) {
 	t.Parallel()
-	for _, tc := range recordBatchTestCases {
+	for _, tc := range recordBatchTestCases() {
 		batch := RecordBatch{}
 		testDecodable(t, tc.name, &batch, tc.encoded)
 		for _, r := range batch.Records {
-			r.length = varintLengthField{}
-		}
-		for _, r := range tc.batch.Records {
 			r.length = varintLengthField{}
 		}
 		// The compression level is not restored on decoding. It is not needed


### PR DESCRIPTION
`TestRecordBatchDecoding` was sporadically failing for me on main (6d970c751edfe80a21c91376ce749070541e4352).  This test command normally brings out the failure:

```
go test -p 2  -run 'TestRecordBatch.*' -count 10
--- FAIL: TestRecordBatchDecoding (0.00s)
    record_test.go:291: invalid decode of snappy compressed record
        got {FirstOffset:0 PartitionLeaderEpoch:0 Version:2 Codec:snappy CompressionLevel:0 Control:false LogAppendTime:false LastOffsetDelta:0 FirstTimestamp:2016-11-22 20:49:55 +0000 GMT MaxTimestamp:1970-01-01 01:00:00 +0100 BST ProducerID:0 ProducerEpoch:0 FirstSequence:0 Records:[<*>(0xc00020e0e0){Headers:[<*>(0xc000210090){Key:[8 9 10] Value:[11 12]}] Attributes:0 TimestampDelta:5ms OffsetDelta:0 Key:[1 2 3 4] Value:[5 6 7] length:{startOffset:0 length:0}}] PartialTrailingRecord:false IsTransactional:false compressedRecords:<nil> recordsLen:21}
        wanted {FirstOffset:0 PartitionLeaderEpoch:0 Version:2 Codec:snappy CompressionLevel:0 Control:false LogAppendTime:false LastOffsetDelta:0 FirstTimestamp:2016-11-22 20:49:55 +0000 GMT MaxTimestamp:1970-01-01 01:00:00 +0100 BST ProducerID:0 ProducerEpoch:0 FirstSequence:0 Records:[<*>(0x17b9000){Headers:[<*>(0x17b4680){Key:[8 9 10] Value:[11 12]}] Attributes:0 TimestampDelta:5ms OffsetDelta:0 Key:[1 2 3 4] Value:[5 6 7] length:{startOffset:0 length:20}}] PartialTrailingRecord:false IsTransactional:false compressedRecords:<nil> recordsLen:21}
--- FAIL: TestRecordBatchDecoding (0.00s)
    record_test.go:291: invalid decode of snappy compressed record
        got {FirstOffset:0 PartitionLeaderEpoch:0 Version:2 Codec:snappy CompressionLevel:0 Control:false LogAppendTime:false LastOffsetDelta:0 FirstTimestamp:2016-11-22 20:49:55 +0000 GMT MaxTimestamp:1970-01-01 01:00:00 +0100 BST ProducerID:0 ProducerEpoch:0 FirstSequence:0 Records:[<*>(0xc0001d60e0){Headers:[<*>(0xc000c160c0){Key:[8 9 10] Value:[11 12]}] Attributes:0 TimestampDelta:5ms OffsetDelta:0 Key:[1 2 3 4] Value:[5 6 7] length:{startOffset:0 length:0}}] PartialTrailingRecord:false IsTransactional:false compressedRecords:<nil> recordsLen:21}
        wanted {FirstOffset:0 PartitionLeaderEpoch:0 Version:2 Codec:snappy CompressionLevel:0 Control:false LogAppendTime:false LastOffsetDelta:0 FirstTimestamp:2016-11-22 20:49:55 +0000 GMT MaxTimestamp:1970-01-01 01:00:00 +0100 BST ProducerID:0 ProducerEpoch:0 FirstSequence:0 Records:[<*>(0x17b9000){Headers:[<*>(0x17b4680){Key:[8 9 10] Value:[11 12]}] Attributes:0 TimestampDelta:5ms OffsetDelta:0 Key:[1 2 3 4] Value:[5 6 7] length:{startOffset:0 length:20}}] PartialTrailingRecord:false IsTransactional:false compressedRecords:<nil> recordsLen:21}
FAIL
```

The issues has been brought out by the switch to parallel tests. `TestRecordBatchDecoding` and `TestRecordBatchEncoding` use the same test data - which includes `*Record` references.   If `TestRecordBatchEncoding` races with `TestRecordBatchDecoding`, the action of the `encode()`  causes the mutation of `Record.varintLengthField` within the test data. This  can then cause the test assertions made by `TestRecordBatchDecoding` to fail.