### PR TITLE
fix: return underlying sasl error message

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package sarama
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -63,8 +64,23 @@ var ErrReassignPartitions = errors.New("failed to reassign partitions for topic"
 // ErrDeleteRecords is the type of error returned when fail to delete the required records
 var ErrDeleteRecords = errors.New("kafka server: failed to delete records")
 
-// The formatter used to format multierrors
-var MultiErrorFormat multierror.ErrorFormatFunc
+// MultiErrorFormat specifies the formatter applied to format multierrors. The
+// default implementation is a consensed version of the hashicorp/go-multierror
+// default one
+var MultiErrorFormat multierror.ErrorFormatFunc = func(es []error) string {
+	if len(es) == 1 {
+		return es[0].Error()
+	}
+
+	points := make([]string, len(es))
+	for i, err := range es {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	return fmt.Sprintf(
+		"%d errors occurred:\n\t%s\n",
+		len(es), strings.Join(points, "\n\t"))
+}
 
 type sentinelError struct {
 	sentinel error

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 )
 
-func TestSentinelWithWrappedError(t *testing.T) {
+func TestSentinelWithSingleWrappedError(t *testing.T) {
 	t.Parallel()
 	myNetError := &net.OpError{Op: "mock", Err: errors.New("op error")}
 	error := Wrap(ErrOutOfBrokers, myNetError)
 
-	expected := fmt.Sprintf("%s: 1 error occurred:\n\t* %s\n\n", ErrOutOfBrokers, myNetError)
+	expected := fmt.Sprintf("%s: %s", ErrOutOfBrokers, myNetError)
 	actual := error.Error()
 	if actual != expected {
 		t.Errorf("unexpected value '%s' vs '%v'", expected, actual)


### PR DESCRIPTION
The SASL Authentication response message from Kafka has an additional field which can contain a description of why the authentication failed. Currently we drop this in Sarama and just return a generic message based on the kError code.