### PR TITLE
fix: remove "Is your cluster reachable?" from msg

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,7 @@ import (
 
 // ErrOutOfBrokers is the error returned when the client has run out of brokers to talk to because all of them errored
 // or otherwise failed to respond.
-var ErrOutOfBrokers = errors.New("kafka: client has run out of available brokers to talk to (Is your cluster reachable?)")
+var ErrOutOfBrokers = errors.New("kafka: client has run out of available brokers to talk to")
 
 // ErrBrokerNotFound is the error returned when there's no broker found for the requested ID.
 var ErrBrokerNotFound = errors.New("kafka: broker for ID is not found")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/frankban/quicktest v1.14.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jcmturner/gofork v1.0.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/klauspost/compress v1.14.4


### PR DESCRIPTION
Now that we properly wrap and return the underlying broker errors, this part of the message is unnecessary and jarring so lets remove it.