### PR TITLE
fix: potential data race on a global variable

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,11 +1,17 @@
 package sarama
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"sync"
+)
 
-var v string
+var (
+	v     string
+	vOnce sync.Once
+)
 
 func version() string {
-	if v == "" {
+	vOnce.Do(func() {
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
 			v = bi.Main.Version
@@ -15,6 +21,6 @@ func version() string {
 			// the version
 			v = "dev"
 		}
-	}
+	})
 	return v
 }


### PR DESCRIPTION
Running `go test -race` on some integration tests with Sarama trigger a data race warning:

```
WARNING: DATA RACE
Read at 0x0001052f7940 by goroutine 11:
  github.com/Shopify/sarama.version()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/version.go:8 +0x34
  github.com/Shopify/sarama.(*Broker).Open.func1.1()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/broker.go:183 +0x44
  github.com/Shopify/sarama.(*Broker).Open.func1()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/broker.go:245 +0x1368
  github.com/Shopify/sarama.withRecover()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/utils.go:43 +0x54
```
```
Previous write at 0x0001052f7940 by goroutine 12:
  github.com/Shopify/sarama.version()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/version.go:16 +0xec
  github.com/Shopify/sarama.(*Broker).Open.func1.1()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/broker.go:183 +0x44
  github.com/Shopify/sarama.(*Broker).Open.func1()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/broker.go:245 +0x1368
  github.com/Shopify/sarama.withRecover()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/utils.go:43 +0x54
```

<details><summary>The traces from the goroutines</summary>
<p>


```
Goroutine 11 (running) created at:
  github.com/Shopify/sarama.(*Broker).Open()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/broker.go:172 +0x300
  github.com/Shopify/sarama.(*client).any()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:686 +0xf8
  github.com/Shopify/sarama.(*client).tryRefreshMetadata()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:879 +0xbc
  github.com/Shopify/sarama.(*client).RefreshMetadata()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:489 +0x1d8
  github.com/Shopify/sarama.NewClient()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:170 +0x438
[...]
```
```
Goroutine 12 (running) created at:
  github.com/Shopify/sarama.(*Broker).Open()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/broker.go:172 +0x300
  github.com/Shopify/sarama.(*client).any()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:686 +0xf8
  github.com/Shopify/sarama.(*client).tryRefreshMetadata()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:879 +0xbc
  github.com/Shopify/sarama.(*client).RefreshMetadata()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:489 +0x1d8
  github.com/Shopify/sarama.NewClient()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/client.go:170 +0x438
  github.com/Shopify/sarama.NewConsumerGroup()
      /Users/pior/pkg/mod/github.com/!shopify/sarama@v1.32.0/consumer_group.go:97 +0x48
[...]
```

</p>
</details> 

This is the code lazily populating the version from the Go module info:
https://github.com/Shopify/sarama/blob/3f90bc71bae993d5cbb08dfbb06cd10a88969d42/version.go#L7-L20

## Solution

I'm proposing to protect this global variable with a [sync.Once](https://pkg.go.dev/sync#Once)