### PR TITLE
producer: ensure that the management message (fin) is never "leaked"

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -843,7 +843,6 @@ func (bp *brokerProducer) run() {
 			if msg.flags&fin == fin {
 				// New broker producer that was caught up by the retry loop
 				bp.parent.retryMessage(msg, ErrShuttingDown)
-				delete(bp.currentRetries[msg.Topic], msg.Partition)
 				Logger.Printf("producer/broker/%d state change to [dying-%d] on %s/%d\n",
 					bp.broker.ID(), msg.retries, msg.Topic, msg.Partition)
 				continue

--- a/async_producer.go
+++ b/async_producer.go
@@ -843,7 +843,7 @@ func (bp *brokerProducer) run() {
 			if msg.flags&fin == fin {
 				// New broker producer that was caught up by the retry loop
 				bp.parent.retryMessage(msg, ErrShuttingDown)
-				Logger.Printf("producer/broker/%d state change to [dying-%d] on %s/%d\n",
+				DebugLogger.Printf("producer/broker/%d state change to [dying-%d] on %s/%d\n",
 					bp.broker.ID(), msg.retries, msg.Topic, msg.Partition)
 				continue
 			}

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -824,7 +824,7 @@ func TestAsyncProducerBrokerRestart(t *testing.T) {
 
 	wg.Wait()
 
-	expectResultsWithTimeout(t, producer, 40, 00, 10*time.Second)
+	expectResultsWithTimeout(t, producer, 40, 0, 10*time.Second)
 
 	seedBroker.Close()
 	leader.Close()

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -731,7 +731,8 @@ func TestAsyncProducerMultipleRetriesWithConcurrentRequests(t *testing.T) {
 }
 
 func TestAsyncProducerBrokerRestart(t *testing.T) {
-	Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
+	// Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
+
 	seedBroker := NewMockBroker(t, 1)
 	leader := NewMockBroker(t, 2)
 

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -61,7 +61,7 @@ func closeProducerWithTimeout(t *testing.T, p AsyncProducer, timeout time.Durati
 }
 
 func closeProducer(t *testing.T, p AsyncProducer) {
-	closeProducerWithTimeout(t, p, time.Hour)
+	closeProducerWithTimeout(t, p, 5*time.Minute)
 }
 
 func expectResultsWithTimeout(t *testing.T, p AsyncProducer, successes, errors int, timeout time.Duration) {
@@ -101,7 +101,7 @@ func expectResultsWithTimeout(t *testing.T, p AsyncProducer, successes, errors i
 }
 
 func expectResults(t *testing.T, p AsyncProducer, successes, errors int) {
-	expectResultsWithTimeout(t, p, successes, errors, time.Hour)
+	expectResultsWithTimeout(t, p, successes, errors, 5*time.Minute)
 }
 
 type testPartitioner chan *int32

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -779,7 +779,7 @@ func TestAsyncProducerBrokerRestart(t *testing.T) {
 	})
 
 	config := NewTestConfig()
-	config.Producer.Retry.Backoff = time.Second
+	config.Producer.Retry.Backoff = 250 * time.Millisecond
 	config.Producer.Flush.MaxMessages = 1
 	config.Producer.Return.Errors = true
 	config.Producer.Return.Successes = true

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -750,7 +750,7 @@ func TestAsyncProducerBrokerRestart(t *testing.T) {
 
 	var emptyValues int32 = 0
 
-	produceRequestTest := func(req *request) {
+	countRecordsWithEmptyValue := func(req *request) {
 		preq := req.body.(*ProduceRequest)
 		if batch := preq.records["my_topic"][0].RecordBatch; batch != nil {
 			for _, record := range batch.Records {
@@ -769,7 +769,7 @@ func TestAsyncProducerBrokerRestart(t *testing.T) {
 	}
 
 	leader.setHandler(func(req *request) (res encoderWithHeader) {
-		produceRequestTest(req)
+		countRecordsWithEmptyValue(req)
 
 		time.Sleep(50 * time.Millisecond)
 
@@ -815,7 +815,7 @@ func TestAsyncProducerBrokerRestart(t *testing.T) {
 	leader = NewMockBroker(t, 2)
 	leaderLock.Unlock()
 	leader.setHandler(func(req *request) (res encoderWithHeader) {
-		produceRequestTest(req)
+		countRecordsWithEmptyValue(req)
 
 		prodSuccess := new(ProduceResponse)
 		prodSuccess.AddTopicPartition("my_topic", 0, ErrNoError)


### PR DESCRIPTION
Since async producer now support multiple inflight messages
thanks to https://github.com/Shopify/sarama/pull/1686 and https://github.com/Shopify/sarama/pull/2094, it now may "leak"
the "fin" internal management message to Kafka (and to the client)
when broker producer is reconnecting to Kafka broker and retries
multiple inflight messages at the same time.

Steps to reproduce: start async producer and restart Kafka broker (potentially multiple times). 
This trigger leader update and retires current broker producer.
There's a chance that newly created broker producer is used to retry an
inflight message so it is also marked as "dying" but it does not contain
any explicit errors.
This results in a "fin" message to be sent to Kafka and reported as successful
operation to the client.

Versions affected: `v1.31.0` and above.

Sarama logs of the event (with the patch applied):
```
[Sarama] 2022/03/16 09:54:31 producer/broker/10001 starting up
[Sarama] 2022/03/16 09:54:31 producer/broker/10001 state change to [open] on my-topic/26
[Sarama] 2022/03/16 09:54:31 producer/leader/my-topic/26 selected broker 10001
[Sarama] 2022/03/16 09:54:31 producer/leader/my-topic/26 state change to [flushing-1]
[Sarama] 2022/03/16 09:54:31 producer/leader/my-topic/26 state change to [normal]
[Sarama] 2022/03/16 09:54:31 producer/leader/my-topic/26 state change to [retrying-1]
[Sarama] 2022/03/16 09:54:31 producer/broker/10001 state change to [dying-1] on my-topic/26
[Sarama] 2022/03/16 09:54:31 producer/leader/my-topic/26 abandoning broker 10001
[Sarama] 2022/03/16 09:54:31 producer/broker/10001 input chan closed
[Sarama] 2022/03/16 09:54:33 producer/broker/10001 state change to [open] on my-topic/26
[Sarama] 2022/03/16 09:54:33 producer/leader/my-topic/26 selected broker 10001
[Sarama] 2022/03/16 09:54:33 producer/leader/my-topic/26 state change to [flushing-1]
[Sarama] 2022/03/16 09:54:33 producer/leader/my-topic/26 state change to [normal]
```

Kafka version: `2.7.1`
Go version: `1.17.7`

Kafka producer config:
```
cfg.Producer.Retry.Backoff = 2 * time.Second
cfg.Producer.Return.Successes = true
cfg.Producer.Return.Errors = true
cfg.Producer.Flush.Messages = 1000
cfg.Producer.Flush.Frequency = 100 * time.Millisecond
cfg.ChannelBufferSize = 1024
```