### PR TITLE
consumer-group: do not cancel sessions context during rebalance

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -869,7 +869,6 @@ func (s *consumerGroupSession) heartbeatLoop() {
 			retries = s.parent.config.Metadata.Retry.Max
 		case ErrRebalanceInProgress:
 			retries = s.parent.config.Metadata.Retry.Max
-			s.cancel()
 		case ErrUnknownMemberId, ErrIllegalGeneration:
 			return
 		default:


### PR DESCRIPTION
https://github.com/Shopify/sarama/pull/2110 was merged to avoid stopping heatbeats on rebalance. 
However, the change is not as effective as it could be since session context is canceled on rebalance (which results in the recreation of the session in the end).

This patch allows session consumer to continue its life if heartbeat loop detected rebalance event.