### PR TITLE
fix: prevent deadlock between subscription manager and consumer goroutines

### DIFF
--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -325,14 +325,16 @@ func TestConsumerGroupDeadlock(t *testing.T) {
 		if err == nil {
 			break
 		}
-		if err == ErrTopicAlreadyExists || strings.Contains(err.Error(), "is marked for deletion") {
+		if errors.Is(err, ErrTopicAlreadyExists) || strings.Contains(err.Error(), "is marked for deletion") {
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}
 		break
 	}
 	require.NoError(err)
-	defer admin.DeleteTopic(topic)
+	defer func() {
+		_ = admin.DeleteTopic(topic)
+	}()
 
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
Since subscription manager was improved to batch the subscriptions (see https://github.com/Shopify/sarama/pull/2109/commits/dadcd808a5f6c6394e91f6a614818cf8eab732de)
it created a deadlock in the case when new subscription are added after a rebalance.

After a rebalance, the subscription is [stuck](https://github.com/Shopify/sarama/blob/dadcd808a5f6c6394e91f6a614818cf8eab732de/consumer.go#L915) on pushing to the `wait` channel, which is drained only if there are no active subscriptions.
