### PR TITLE
Fix deadlock introduced in #2109

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -912,7 +912,11 @@ func (bc *brokerConsumer) subscriptionManager() {
 				"consumer/broker/%d accumulated %d new subscriptions\n",
 				bc.broker.ID(), len(partitionConsumers))
 
-			bc.wait <- none{}
+			select {
+				case bc.wait <- none{}:
+				default:
+			}
+
 			bc.newSubscriptions <- partitionConsumers
 
 			// clear out the batch


### PR DESCRIPTION
In the before times (Feb 2020), we submitted this issue asking for feedback prior to submitting a PR:
https://github.com/Shopify/sarama/issues/1608

In January of this year, some aspects of the fix were merged through #2109. We noticed, however, that a fix for a deadlock issue we found after about a year of running #1608 in heavy production did not make its way into #2109. 

This was quite a while ago, so I do not recall the details of how exactly we recreated the issue but I definitely recall identifying hanging workers that printed "consumer/broker/%d accumulated %d new subscriptions" but not the expected subsequent logs. I also imagine that at the time I implemented this fix I tracked down the precise scenario where bc.wait would block and cause a deadlock... but I don't have this explanation at hand. Do with this PR what you will :) 

