### PR TITLE
KIP-368 : Allow SASL Connections to Periodically Re-Authenticate

### DIFF
--- a/mockresponses.go
+++ b/mockresponses.go
@@ -1057,9 +1057,10 @@ func (mr *MockListAclsResponse) For(reqBody versionedDecoder) encoderWithHeader 
 }
 
 type MockSaslAuthenticateResponse struct {
-	t             TestReporter
-	kerror        KError
-	saslAuthBytes []byte
+	t                 TestReporter
+	kerror            KError
+	saslAuthBytes     []byte
+	sessionLifetimeMs int64
 }
 
 func NewMockSaslAuthenticateResponse(t TestReporter) *MockSaslAuthenticateResponse {
@@ -1067,9 +1068,12 @@ func NewMockSaslAuthenticateResponse(t TestReporter) *MockSaslAuthenticateRespon
 }
 
 func (msar *MockSaslAuthenticateResponse) For(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*SaslAuthenticateRequest)
 	res := &SaslAuthenticateResponse{}
+	res.Version = req.Version
 	res.Err = msar.kerror
 	res.SaslAuthBytes = msar.saslAuthBytes
+	res.SessionLifetimeMs = msar.sessionLifetimeMs
 	return res
 }
 
@@ -1080,6 +1084,11 @@ func (msar *MockSaslAuthenticateResponse) SetError(kerror KError) *MockSaslAuthe
 
 func (msar *MockSaslAuthenticateResponse) SetAuthBytes(saslAuthBytes []byte) *MockSaslAuthenticateResponse {
 	msar.saslAuthBytes = saslAuthBytes
+	return msar
+}
+
+func (msar *MockSaslAuthenticateResponse) SetSessionLifetimeMs(sessionLifetimeMs int64) *MockSaslAuthenticateResponse {
+	msar.sessionLifetimeMs = sessionLifetimeMs
 	return msar
 }
 

--- a/sasl_authenticate_request.go
+++ b/sasl_authenticate_request.go
@@ -1,6 +1,8 @@
 package sarama
 
 type SaslAuthenticateRequest struct {
+	// Version defines the protocol version to use for encode and decode
+	Version       int16
 	SaslAuthBytes []byte
 }
 
@@ -12,6 +14,7 @@ func (r *SaslAuthenticateRequest) encode(pe packetEncoder) error {
 }
 
 func (r *SaslAuthenticateRequest) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
 	r.SaslAuthBytes, err = pd.getBytes()
 	return err
 }
@@ -21,7 +24,7 @@ func (r *SaslAuthenticateRequest) key() int16 {
 }
 
 func (r *SaslAuthenticateRequest) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *SaslAuthenticateRequest) headerVersion() int16 {
@@ -29,5 +32,10 @@ func (r *SaslAuthenticateRequest) headerVersion() int16 {
 }
 
 func (r *SaslAuthenticateRequest) requiredVersion() KafkaVersion {
-	return V1_0_0_0
+	switch r.Version {
+	case 1:
+		return V2_2_0_0
+	default:
+		return V1_0_0_0
+	}
 }

--- a/sasl_authenticate_request_test.go
+++ b/sasl_authenticate_request_test.go
@@ -11,3 +11,10 @@ func TestSaslAuthenticateRequest(t *testing.T) {
 	request.SaslAuthBytes = []byte(`foo`)
 	testRequest(t, "basic", request, saslAuthenticateRequest)
 }
+
+func TestSaslAuthenticateRequestV1(t *testing.T) {
+	request := new(SaslAuthenticateRequest)
+	request.Version = 1
+	request.SaslAuthBytes = []byte(`foo`)
+	testRequest(t, "basic", request, saslAuthenticateRequest)
+}

--- a/sasl_authenticate_response.go
+++ b/sasl_authenticate_response.go
@@ -1,9 +1,12 @@
 package sarama
 
 type SaslAuthenticateResponse struct {
-	Err           KError
-	ErrorMessage  *string
-	SaslAuthBytes []byte
+	// Version defines the protocol version to use for encode and decode
+	Version           int16
+	Err               KError
+	ErrorMessage      *string
+	SaslAuthBytes     []byte
+	SessionLifetimeMs int64
 }
 
 func (r *SaslAuthenticateResponse) encode(pe packetEncoder) error {
@@ -11,10 +14,17 @@ func (r *SaslAuthenticateResponse) encode(pe packetEncoder) error {
 	if err := pe.putNullableString(r.ErrorMessage); err != nil {
 		return err
 	}
-	return pe.putBytes(r.SaslAuthBytes)
+	if err := pe.putBytes(r.SaslAuthBytes); err != nil {
+		return err
+	}
+	if r.Version > 0 {
+		pe.putInt64(r.SessionLifetimeMs)
+	}
+	return nil
 }
 
 func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) error {
+	r.Version = version
 	kerr, err := pd.getInt16()
 	if err != nil {
 		return err
@@ -26,7 +36,13 @@ func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) error
 		return err
 	}
 
-	r.SaslAuthBytes, err = pd.getBytes()
+	if r.SaslAuthBytes, err = pd.getBytes(); err != nil {
+		return err
+	}
+
+	if version > 0 {
+		r.SessionLifetimeMs, err = pd.getInt64()
+	}
 
 	return err
 }
@@ -36,7 +52,7 @@ func (r *SaslAuthenticateResponse) key() int16 {
 }
 
 func (r *SaslAuthenticateResponse) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *SaslAuthenticateResponse) headerVersion() int16 {
@@ -44,5 +60,10 @@ func (r *SaslAuthenticateResponse) headerVersion() int16 {
 }
 
 func (r *SaslAuthenticateResponse) requiredVersion() KafkaVersion {
-	return V1_0_0_0
+	switch r.Version {
+	case 1:
+		return V2_2_0_0
+	default:
+		return V1_0_0_0
+	}
 }

--- a/sasl_authenticate_response_test.go
+++ b/sasl_authenticate_response_test.go
@@ -2,11 +2,19 @@ package sarama
 
 import "testing"
 
-var saslAuthenticatResponseErr = []byte{
-	0, 58,
-	0, 3, 'e', 'r', 'r',
-	0, 0, 0, 3, 'm', 's', 'g',
-}
+var (
+	saslAuthenticateResponseErr = []byte{
+		0, 58,
+		0, 3, 'e', 'r', 'r',
+		0, 0, 0, 3, 'm', 's', 'g',
+	}
+	saslAuthenticateResponseErrV1 = []byte{
+		0, 58,
+		0, 3, 'e', 'r', 'r',
+		0, 0, 0, 3, 'm', 's', 'g',
+		0, 0, 0, 0, 0, 0, 0, 1,
+	}
+)
 
 func TestSaslAuthenticateResponse(t *testing.T) {
 	response := new(SaslAuthenticateResponse)
@@ -15,5 +23,17 @@ func TestSaslAuthenticateResponse(t *testing.T) {
 	response.ErrorMessage = &msg
 	response.SaslAuthBytes = []byte(`msg`)
 
-	testResponse(t, "authenticate response", response, saslAuthenticatResponseErr)
+	testResponse(t, "authenticate response", response, saslAuthenticateResponseErr)
+}
+
+func TestSaslAuthenticateResponseV1(t *testing.T) {
+	response := new(SaslAuthenticateResponse)
+	response.Err = ErrSASLAuthenticationFailed
+	msg := "err"
+	response.Version = 1
+	response.ErrorMessage = &msg
+	response.SaslAuthBytes = []byte(`msg`)
+	response.SessionLifetimeMs = 1
+
+	testResponse(t, "authenticate response", response, saslAuthenticateResponseErrV1)
 }


### PR DESCRIPTION
Proposed fix for #2060.

If the server uses KIP-368, the client will cause itself to reauthenticate by emitting the necessary SASL handshake/authenticate with the next client to server interaction.

```
2022/03/29 18:09:50 Completed pre-auth SASL handshake. Available mechanisms: [PLAIN OAUTHBEARER]
2022/03/29 18:09:50 Session expiration in 299000 ms and session re-authentication on or after 283079 ms
```
