### PR TITLE
Remediate a number go-routine leaks (mainly test issues)

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -149,7 +149,11 @@ func NewClusterAdmin(addrs []string, conf *Config) (ClusterAdmin, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewClusterAdminFromClient(client)
+	admin, err := NewClusterAdminFromClient(client)
+	if err != nil {
+		client.Close()
+	}
+	return admin, err
 }
 
 // NewClusterAdminFromClient creates a new ClusterAdmin using the given client.

--- a/admin_test.go
+++ b/admin_test.go
@@ -1498,6 +1498,7 @@ func TestDeleteConsumerGroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer admin.Close()
 
 	err = admin.DeleteConsumerGroup(group)
 	if err != nil {
@@ -1537,6 +1538,7 @@ func TestDeleteOffset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteConsumerGroupOffset failed with error %v", err)
 	}
+	defer admin.Close()
 
 	// Test Error
 	handlerMap["DeleteOffsetsRequest"] = NewMockDeleteOffsetRequest(t).SetDeletedOffset(ErrNotCoordinatorForConsumer, topic, partition, ErrNoError)
@@ -1577,6 +1579,7 @@ func TestRefreshMetaDataWithDifferentController(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer client.Close()
 
 	ca := clusterAdmin{client: client, conf: config}
 

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1157,6 +1157,7 @@ func TestConsumeMessagesTrackLeader(t *testing.T) {
 
 	safeClose(t, pConsumer)
 	safeClose(t, consumer)
+	safeClose(t, client)
 	leader1.Close()
 	leader2.Close()
 }

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -553,6 +553,7 @@ func TestAbortPartitionOffsetManager(t *testing.T) {
 
 	// Response to refresh coordinator request
 	newCoordinator := NewMockBroker(t, 3)
+	defer newCoordinator.Close()
 	broker.Returns(&ConsumerMetadataResponse{
 		CoordinatorID:   newCoordinator.BrokerID(),
 		CoordinatorHost: "127.0.0.1",


### PR DESCRIPTION
- NewClusterAdmin would leak a Client if Controller could not be found
- unclosed MockBroker and Client leaks in unit tests