### PR TITLE
chore: bump functional test timeout to 12m

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -1,36 +1,23 @@
 ---
-name: CI
+name: FVT
 on: [push, pull_request]
 jobs:
-  lint:
-    name: Linting with Go ${{ matrix.go-version }}
+  fvt:
+    name: Test with Kafka ${{ matrix.kafka-version }}
     runs-on: ubuntu-latest
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x, 1.18.x]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: golangci-lint
-      env:
-        GOFLAGS: -tags=functional
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.45.2
-  test:
-    name: Unit Testing with Go ${{ matrix.go-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.17.x, 1.18.x]
+        go-version: [1.18.x]
+        kafka-version: [2.8.1, 3.0.1, 3.1.0]
     env:
       DEBUG: true
       GOFLAGS: -trimpath
+      KAFKA_VERSION: ${{ matrix.kafka-version }}
     steps:
     - uses: actions/checkout@v2
     - name: Setup Go
@@ -51,5 +38,5 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Test (Unit)
-      run: make test
+    - name: Test (Functional)
+      run: make test_functional

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: fmt get update test lint
 
 GO       := go
 GOBUILD  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG)
-GOTEST   := $(GO) test -v -race -timeout 10m -coverprofile=profile.out -covermode=atomic
+GOTEST   := $(GO) test -v -race -coverprofile=profile.out -covermode=atomic
 
 FILES    := $(shell find . -name '*.go' -type f -not -name '*.pb.go' -not -name '*_generated.go' -not -name '*_test.go')
 TESTS    := $(shell find . -name '*.go' -type f -not -name '*.pb.go' -not -name '*_generated.go' -name '*_test.go')
@@ -24,8 +24,8 @@ lint:
 	GOFLAGS="-tags=functional" golangci-lint run
 
 test:
-	$(GOTEST) ./...
+	$(GOTEST) -timeout 2m ./...
 
 .PHONY: test_functional
 test_functional:
-	$(GOTEST) -tags=functional ./...
+	$(GOTEST) -timeout 12m -tags=functional ./...

--- a/utils.go
+++ b/utils.go
@@ -180,6 +180,7 @@ var (
 	V2_8_0_0  = newKafkaVersion(2, 8, 0, 0)
 	V2_8_1_0  = newKafkaVersion(2, 8, 1, 0)
 	V3_0_0_0  = newKafkaVersion(3, 0, 0, 0)
+	V3_0_1_0  = newKafkaVersion(3, 0, 1, 0)
 	V3_1_0_0  = newKafkaVersion(3, 1, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
@@ -224,6 +225,7 @@ var (
 		V2_8_0_0,
 		V2_8_1_0,
 		V3_0_0_0,
+		V3_0_1_0,
 		V3_1_0_0,
 	}
 	MinVersion     = V0_8_2_0

--- a/utils_test.go
+++ b/utils_test.go
@@ -71,6 +71,7 @@ func TestVersionParsing(t *testing.T) {
 		"2.8.0",
 		"2.8.1",
 		"3.0.0",
+		"3.0.1",
 		"3.1.0",
 	}
 	for _, s := range validVersions {


### PR DESCRIPTION
use separate 2m timeout for standard unittests