### PR TITLE
fix: prevent RefreshBrokers leaking old brokers 

### DIFF
--- a/client.go
+++ b/client.go
@@ -459,6 +459,14 @@ func (client *client) RefreshBrokers(addrs []string) error {
 		delete(client.brokers, broker.ID())
 	}
 
+	for _, broker := range client.seedBrokers {
+		_ = broker.Close()
+	}
+
+	for _, broker := range client.deadSeeds {
+		_ = broker.Close()
+	}
+
 	client.seedBrokers = nil
 	client.deadSeeds = nil
 

--- a/client_test.go
+++ b/client_test.go
@@ -528,11 +528,11 @@ func TestClientRefreshBrokers(t *testing.T) {
 	initialSeed.Returns(metadataResponse1)
 
 	c, err := NewClient([]string{initialSeed.Addr()}, NewTestConfig())
-	client := c.(*client)
-
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer c.Close()
+	client := c.(*client)
 
 	if len(client.Brokers()) != 2 {
 		t.Error("Meta broker is not 2")


### PR DESCRIPTION
#2202 exposes a goroutine test in the client's `RefreshBrokers` API. 

On analysis I see that `RefreshBrokers` implementations leak the original seed brokers and the test itself was leaking a client.  This PR resolves both issues.