### PR TITLE
fix: prevent RefreshController leaking controller

### DIFF
--- a/client.go
+++ b/client.go
@@ -533,7 +533,10 @@ func (client *client) Controller() (*Broker, error) {
 func (client *client) deregisterController() {
 	client.lock.Lock()
 	defer client.lock.Unlock()
-	delete(client.brokers, client.controllerID)
+	if controller, ok := client.brokers[client.controllerID]; ok {
+		_ = controller.Close()
+		delete(client.brokers, client.controllerID)
+	}
 }
 
 // RefreshController retrieves the cluster controller from fresh metadata


### PR DESCRIPTION
As exposed by #2202, the `RefreshController` API leaks the broker that was in the controller role.