### PR TITLE
fix: prevent AsyncProducer retryBatch from leaking 

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1064,6 +1064,7 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	}
 	bp := p.getBrokerProducer(leader)
 	bp.output <- produceSet
+	p.unrefBrokerProducer(leader, bp)
 }
 
 func (bp *brokerProducer) handleError(sent *produceSet, err error) {


### PR DESCRIPTION
retryBatch caused the brokerRefs count to be incremented (getBrokerProducer), but it is never decremented again, so the
goroutines related to the brokerProducer are leaked.

This is the final goroutine leak discovered by #2202.

```
./tests -test.run ^TestAsyncProducerIdempotentRetryCheckBatch$
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 54 in state select, with github.com/Shopify/sarama.(*brokerProducer).run on top of the stack:
goroutine 54 [select]:
github.com/Shopify/sarama.(*brokerProducer).run(0xc0002883c0)
	/Users/kwall/src/sarama/async_producer.go:807 +0x19a
github.com/Shopify/sarama.withRecover(0x0)
	/Users/kwall/src/sarama/utils.go:43 +0x3e
created by github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer
	/Users/kwall/src/sarama/async_producer.go:692 +0x25b

 Goroutine 55 in state chan receive, with github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func1 on top of the stack:
goroutine 55 [chan receive]:
github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func1()
	/Users/kwall/src/sarama/async_producer.go:699 +0x65
github.com/Shopify/sarama.withRecover(0x0)
	/Users/kwall/src/sarama/utils.go:43 +0x3e
created by github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer
	/Users/kwall/src/sarama/async_producer.go:695 +0x32f

 Goroutine 56 in state chan receive, with github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func2 on top of the stack:
goroutine 56 [chan receive]:
github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func2()
	/Users/kwall/src/sarama/async_producer.go:745 +0xcc
github.com/Shopify/sarama.withRecover(0x0)
	/Users/kwall/src/sarama/utils.go:43 +0x3e
created by github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer
	/Users/kwall/src/sarama/async_producer.go:741 +0x3c7

 Goroutine 62 in state select, with github.com/Shopify/sarama.(*brokerProducer).run on top of the stack:
goroutine 62 [select]:
github.com/Shopify/sarama.(*brokerProducer).run(0xc0002889c0)
	/Users/kwall/src/sarama/async_producer.go:807 +0x19a
github.com/Shopify/sarama.withRecover(0x0)
	/Users/kwall/src/sarama/utils.go:43 +0x3e
created by github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer
	/Users/kwall/src/sarama/async_producer.go:692 +0x25b

 Goroutine 63 in state chan receive, with github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func1 on top of the stack:
goroutine 63 [chan receive]:
github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func1()
	/Users/kwall/src/sarama/async_producer.go:699 +0x65
github.com/Shopify/sarama.withRecover(0x0)
	/Users/kwall/src/sarama/utils.go:43 +0x3e
created by github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer
	/Users/kwall/src/sarama/async_producer.go:695 +0x32f

 Goroutine 64 in state chan receive, with github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func2 on top of the stack:
goroutine 64 [chan receive]:
github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer.func2()
	/Users/kwall/src/sarama/async_producer.go:745 +0xcc
github.com/Shopify/sarama.withRecover(0x0)
	/Users/kwall/src/sarama/utils.go:43 +0x3e
created by github.com/Shopify/sarama.(*asyncProducer).newBrokerProducer
	/Users/kwall/src/sarama/async_producer.go:741 +0x3c7
]


```