### PR TITLE
Backport: Fix a potential data race on a global variable

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,11 +1,17 @@
 package sarama
 
-import "runtime/debug"
+import (
+	"runtime/debug"
+	"sync"
+)
 
-var v string
+var (
+	v     string
+	vOnce sync.Once
+)
 
 func version() string {
-	if v == "" {
+	vOnce.Do(func() {
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
 			v = bi.Main.Version
@@ -15,6 +21,6 @@ func version() string {
 			// the version
 			v = "dev"
 		}
-	}
+	})
 	return v
 }


### PR DESCRIPTION
Re-apply the same fix as https://github.com/Shopify/sarama/pull/2171 on v1.30.1