### PR TITLE
fix: make default MaxWaitTime 500ms

### DIFF
--- a/config.go
+++ b/config.go
@@ -483,7 +483,7 @@ func NewConfig() *Config {
 	c.Consumer.Fetch.Min = 1
 	c.Consumer.Fetch.Default = 1024 * 1024
 	c.Consumer.Retry.Backoff = 2 * time.Second
-	c.Consumer.MaxWaitTime = 250 * time.Millisecond
+	c.Consumer.MaxWaitTime = 500 * time.Millisecond
 	c.Consumer.MaxProcessingTime = 100 * time.Millisecond
 	c.Consumer.Return.Errors = false
 	c.Consumer.Offsets.AutoCommit.Enable = true


### PR DESCRIPTION
Both the official Java client and librdkafka default to using a default
of 500ms for the fetch.max.wait.ms to avoid excessive network usage for
low throughput topics. Updating Sarama to do the same.