### PR TITLE
KIP-345: support static membership

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -141,6 +141,11 @@ type ClusterAdmin interface {
 	// locally cached value if it's available.
 	Controller() (*Broker, error)
 
+	// Remove members from the consumer group by given member identities.
+	// This operation is supported by brokers with version 2.3 or higher
+	// This is for static membership feature. KIP-345
+	RemoveMemberFromConsumerGroup(groupId string, groupInstanceIds []string) (*LeaveGroupResponse, error)
+
 	// Close shuts down the admin and closes underlying client.
 	Close() error
 }
@@ -900,9 +905,13 @@ func (ca *clusterAdmin) DescribeConsumerGroups(groups []string) (result []*Group
 	}
 
 	for broker, brokerGroups := range groupsPerBroker {
-		response, err := broker.DescribeGroups(&DescribeGroupsRequest{
+		describeReq := &DescribeGroupsRequest{
 			Groups: brokerGroups,
-		})
+		}
+		if ca.conf.Version.IsAtLeast(V2_3_0_0) {
+			describeReq.Version = 4
+		}
+		response, err := broker.DescribeGroups(describeReq)
 		if err != nil {
 			return nil, err
 		}
@@ -1195,4 +1204,22 @@ func (ca *clusterAdmin) AlterClientQuotas(entity []QuotaEntityComponent, op Clie
 	}
 
 	return nil
+}
+
+func (ca *clusterAdmin) RemoveMemberFromConsumerGroup(groupId string, groupInstanceIds []string) (*LeaveGroupResponse, error) {
+	controller, err := ca.client.Coordinator(groupId)
+	if err != nil {
+		return nil, err
+	}
+	request := &LeaveGroupRequest{
+		Version: 3,
+		GroupId: groupId,
+	}
+	for _, instanceId := range groupInstanceIds {
+		groupInstanceId := instanceId
+		request.Members = append(request.Members, MemberIdentity{
+			GroupInstanceId: &groupInstanceId,
+		})
+	}
+	return controller.LeaveGroup(request)
 }

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -79,11 +79,12 @@ type ConsumerGroup interface {
 type consumerGroup struct {
 	client Client
 
-	config   *Config
-	consumer Consumer
-	groupID  string
-	memberID string
-	errors   chan error
+	config          *Config
+	consumer        Consumer
+	groupID         string
+	groupInstanceId *string
+	memberID        string
+	errors          chan error
 
 	lock      sync.Mutex
 	closed    chan none
@@ -127,7 +128,7 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		return nil, err
 	}
 
-	return &consumerGroup{
+	cg := &consumerGroup{
 		client:   client,
 		consumer: consumer,
 		config:   config,
@@ -135,7 +136,11 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		errors:   make(chan error, config.ChannelBufferSize),
 		closed:   make(chan none),
 		userData: config.Consumer.Group.Member.UserData,
-	}, nil
+	}
+	if client.Config().Consumer.Group.InstanceId != "" && config.Version.IsAtLeast(V2_3_0_0) {
+		cg.groupInstanceId = &client.Config().Consumer.Group.InstanceId
+	}
+	return cg, nil
 }
 
 // Errors implements ConsumerGroup.
@@ -300,6 +305,16 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			return nil, join.Err
 		}
 		return c.retryNewSession(ctx, topics, handler, retries, true)
+	case ErrMemberIdRequired:
+		// from JoinGroupRequest v4, if client start with empty member id,
+		// it need to get member id from response and send another join request to join group
+		c.memberID = join.MemberId
+		return c.retryNewSession(ctx, topics, handler, retries+1 /*keep retry time*/, false)
+	case ErrFencedInstancedId:
+		if c.groupInstanceId != nil {
+			Logger.Printf("JoinGroup failed: group instance id %s has been fenced\n", *c.groupInstanceId)
+		}
+		return nil, join.Err
 	default:
 		return nil, join.Err
 	}
@@ -348,6 +363,11 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			return nil, groupRequest.Err
 		}
 		return c.retryNewSession(ctx, topics, handler, retries, true)
+	case ErrFencedInstancedId:
+		if c.groupInstanceId != nil {
+			Logger.Printf("JoinGroup failed: group instance id %s has been fenced\n", *c.groupInstanceId)
+		}
+		return nil, groupRequest.Err
 	default:
 		return nil, groupRequest.Err
 	}
@@ -389,6 +409,10 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 		req.Version = 1
 		req.RebalanceTimeout = int32(c.config.Consumer.Group.Rebalance.Timeout / time.Millisecond)
 	}
+	if c.groupInstanceId != nil {
+		req.Version = 5
+		req.GroupInstanceId = c.groupInstanceId
+	}
 
 	meta := &ConsumerGroupMemberMetadata{
 		Topics:   topics,
@@ -409,6 +433,10 @@ func (c *consumerGroup) syncGroupRequest(coordinator *Broker, plan BalanceStrate
 		GenerationId: generationID,
 	}
 	strategy := c.config.Consumer.Group.Rebalance.Strategy
+	if c.groupInstanceId != nil {
+		req.Version = 3
+		req.GroupInstanceId = c.groupInstanceId
+	}
 	for memberID, topics := range plan {
 		assignment := &ConsumerGroupMemberAssignment{Topics: topics}
 		userDataBytes, err := strategy.AssignmentData(memberID, topics, generationID)
@@ -428,6 +456,10 @@ func (c *consumerGroup) heartbeatRequest(coordinator *Broker, memberID string, g
 		GroupId:      c.groupID,
 		MemberId:     memberID,
 		GenerationId: generationID,
+	}
+	if c.groupInstanceId != nil {
+		req.Version = 3
+		req.GroupInstanceId = c.groupInstanceId
 	}
 
 	return coordinator.Heartbeat(req)
@@ -466,25 +498,32 @@ func (c *consumerGroup) leave() error {
 		return err
 	}
 
-	resp, err := coordinator.LeaveGroup(&LeaveGroupRequest{
-		GroupId:  c.groupID,
-		MemberId: c.memberID,
-	})
-	if err != nil {
-		_ = coordinator.Close()
-		return err
-	}
+	// KIP-345 if groupInstanceId is set, don not leave group when consumer closed.
+	// Since we do not discover ApiVersion for brokers, LeaveGroupRequest still use the old version request for now
+	if c.groupInstanceId == nil {
+		resp, err := coordinator.LeaveGroup(&LeaveGroupRequest{
+			GroupId:  c.groupID,
+			MemberId: c.memberID,
+		})
+		if err != nil {
+			_ = coordinator.Close()
+			return err
+		}
 
-	// Unset memberID
-	c.memberID = ""
+		// Unset memberID
+		c.memberID = ""
 
-	// Check response
-	switch resp.Err {
-	case ErrRebalanceInProgress, ErrUnknownMemberId, ErrNoError:
-		return nil
-	default:
-		return resp.Err
+		// Check response
+		switch resp.Err {
+		case ErrRebalanceInProgress, ErrUnknownMemberId, ErrNoError:
+			return nil
+		default:
+			return resp.Err
+		}
+	} else {
+		c.memberID = ""
 	}
+	return nil
 }
 
 func (c *consumerGroup) handleError(err error, topic string, partition int32) {
@@ -628,14 +667,14 @@ type consumerGroupSession struct {
 }
 
 func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims map[string][]int32, memberID string, generationID int32, handler ConsumerGroupHandler) (*consumerGroupSession, error) {
+	// init context
+	ctx, cancel := context.WithCancel(ctx)
+
 	// init offset manager
-	offsets, err := newOffsetManagerFromClient(parent.groupID, memberID, generationID, parent.client)
+	offsets, err := newOffsetManagerFromClient(parent.groupID, memberID, generationID, parent.client, cancel)
 	if err != nil {
 		return nil, err
 	}
-
-	// init context
-	ctx, cancel := context.WithCancel(ctx)
 
 	// init session
 	sess := &consumerGroupSession{
@@ -861,6 +900,12 @@ func (s *consumerGroupSession) heartbeatLoop() {
 			retries = s.parent.config.Metadata.Retry.Max
 			s.cancel()
 		case ErrUnknownMemberId, ErrIllegalGeneration:
+			return
+		case ErrFencedInstancedId:
+			if s.parent.groupInstanceId != nil {
+				Logger.Printf("JoinGroup failed: group instance id %s has been fenced\n", *s.parent.groupInstanceId)
+			}
+			s.parent.handleError(resp.Err, "", -1)
 			return
 		default:
 			s.parent.handleError(resp.Err, "", -1)

--- a/describe_groups_request_test.go
+++ b/describe_groups_request_test.go
@@ -5,19 +5,19 @@ import "testing"
 var (
 	emptyDescribeGroupsRequest = []byte{0, 0, 0, 0}
 
-	singleDescribeGroupsRequest = []byte{
+	singleDescribeGroupsRequestV0 = []byte{
 		0, 0, 0, 1, // 1 group
 		0, 3, 'f', 'o', 'o', // group name: foo
 	}
 
-	doubleDescribeGroupsRequest = []byte{
+	doubleDescribeGroupsRequestV0 = []byte{
 		0, 0, 0, 2, // 2 groups
 		0, 3, 'f', 'o', 'o', // group name: foo
 		0, 3, 'b', 'a', 'r', // group name: foo
 	}
 )
 
-func TestDescribeGroupsRequest(t *testing.T) {
+func TestDescribeGroupsRequestV0(t *testing.T) {
 	var request *DescribeGroupsRequest
 
 	request = new(DescribeGroupsRequest)
@@ -25,10 +25,47 @@ func TestDescribeGroupsRequest(t *testing.T) {
 
 	request = new(DescribeGroupsRequest)
 	request.AddGroup("foo")
-	testRequest(t, "one group", request, singleDescribeGroupsRequest)
+	testRequest(t, "one group", request, singleDescribeGroupsRequestV0)
 
 	request = new(DescribeGroupsRequest)
 	request.AddGroup("foo")
 	request.AddGroup("bar")
-	testRequest(t, "two groups", request, doubleDescribeGroupsRequest)
+	testRequest(t, "two groups", request, doubleDescribeGroupsRequestV0)
+}
+
+var (
+	emptyDescribeGroupsRequestV3 = []byte{0, 0, 0, 0, 0}
+
+	singleDescribeGroupsRequestV3 = []byte{
+		0, 0, 0, 1, // 1 group
+		0, 3, 'f', 'o', 'o', // group name: foo
+		0,
+	}
+
+	doubleDescribeGroupsRequestV3 = []byte{
+		0, 0, 0, 2, // 2 groups
+		0, 3, 'f', 'o', 'o', // group name: foo
+		0, 3, 'b', 'a', 'r', // group name: foo
+		1,
+	}
+)
+
+func TestDescribeGroupsRequestV3(t *testing.T) {
+	var request *DescribeGroupsRequest
+
+	request = new(DescribeGroupsRequest)
+	request.Version = 3
+	testRequest(t, "no groups", request, emptyDescribeGroupsRequestV3)
+
+	request = new(DescribeGroupsRequest)
+	request.Version = 3
+	request.AddGroup("foo")
+	testRequest(t, "one group", request, singleDescribeGroupsRequestV3)
+
+	request = new(DescribeGroupsRequest)
+	request.Version = 3
+	request.AddGroup("foo")
+	request.AddGroup("bar")
+	request.IncludeAuthorizedOperations = true
+	testRequest(t, "two groups", request, doubleDescribeGroupsRequestV3)
 }

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -339,14 +339,15 @@ func (s *testFuncConsumerGroupSink) Close() map[string][]string {
 
 type testFuncConsumerGroupMember struct {
 	ConsumerGroup
-	clientID    string
-	claims      map[string]int
-	state       int32
-	handlers    int32
-	errs        []error
-	maxMessages int32
-	isCapped    bool
-	sink        *testFuncConsumerGroupSink
+	clientID     string
+	claims       map[string]int
+	generationId int32
+	state        int32
+	handlers     int32
+	errs         []error
+	maxMessages  int32
+	isCapped     bool
+	sink         *testFuncConsumerGroupSink
 
 	t  *testing.T
 	mu sync.RWMutex
@@ -457,6 +458,9 @@ func (m *testFuncConsumerGroupMember) Setup(s ConsumerGroupSession) error {
 	m.mu.Lock()
 	m.claims = claims
 	m.mu.Unlock()
+
+	// store generationID
+	atomic.StoreInt32(&m.generationId, s.GenerationID())
 
 	// enter post-setup state
 	atomic.StoreInt32(&m.state, 2)

--- a/functional_consumer_staticmembership_test.go
+++ b/functional_consumer_staticmembership_test.go
@@ -1,0 +1,239 @@
+//go:build functional
+// +build functional
+
+package sarama
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func TestFuncConsumerGroupStaticMembership_Basic(t *testing.T) {
+	checkKafkaVersion(t, "2.3.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+	groupID := testFuncConsumerGroupID(t)
+
+	t.Helper()
+
+	config1 := NewTestConfig()
+	config1.ClientID = "M1"
+	config1.Version = V2_3_0_0
+	config1.Consumer.Offsets.Initial = OffsetNewest
+	config1.Consumer.Group.InstanceId = "Instance1"
+	m1 := runTestFuncConsumerGroupMemberWithConfig(t, config1, groupID, 100, nil, "test.4")
+	defer m1.Close()
+
+	config2 := NewTestConfig()
+	config2.ClientID = "M2"
+	config2.Version = V2_3_0_0
+	config2.Consumer.Offsets.Initial = OffsetNewest
+	config2.Consumer.Group.InstanceId = "Instance2"
+	m2 := runTestFuncConsumerGroupMemberWithConfig(t, config2, groupID, 100, nil, "test.4")
+	defer m2.Close()
+
+	m1.WaitForState(2)
+	m2.WaitForState(2)
+
+	err := testFuncConsumerGroupProduceMessage("test.4", 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	admin, err := NewClusterAdmin(FunctionalTestEnv.KafkaBrokerAddrs, config1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := admin.DescribeConsumerGroups([]string{groupID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res) != 1 {
+		t.Errorf("group description should be only 1, got %v\n", len(res))
+	}
+	if len(res[0].Members) != 2 {
+		t.Errorf("should have 2 members in group , got %v\n", len(res[0].Members))
+	}
+
+	m1.WaitForState(4)
+	m2.WaitForState(4)
+
+	m1.AssertCleanShutdown()
+	m2.AssertCleanShutdown()
+}
+
+func TestFuncConsumerGroupStaticMembership_RejoinAndLeave(t *testing.T) {
+	checkKafkaVersion(t, "2.3.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+	groupID := testFuncConsumerGroupID(t)
+
+	t.Helper()
+
+	config1 := NewTestConfig()
+	config1.ClientID = "M1"
+	config1.Version = V2_3_0_0
+	config1.Consumer.Offsets.Initial = OffsetNewest
+	config1.Consumer.Group.InstanceId = "Instance1"
+	m1 := runTestFuncConsumerGroupMemberWithConfig(t, config1, groupID, math.MaxInt32, nil, "test.4")
+	defer m1.Close()
+
+	config2 := NewTestConfig()
+	config2.ClientID = "M2"
+	config2.Version = V2_3_0_0
+	config2.Consumer.Offsets.Initial = OffsetNewest
+	config2.Consumer.Group.InstanceId = "Instance2"
+	m2 := runTestFuncConsumerGroupMemberWithConfig(t, config2, groupID, math.MaxInt32, nil, "test.4")
+	defer m2.Close()
+
+	m1.WaitForState(2)
+	m2.WaitForState(2)
+
+	admin, err := NewClusterAdmin(FunctionalTestEnv.KafkaBrokerAddrs, config1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res1, err := admin.DescribeConsumerGroups([]string{groupID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res1) != 1 {
+		t.Errorf("group description should be only 1, got %v\n", len(res1))
+	}
+	if len(res1[0].Members) != 2 {
+		t.Errorf("should have 2 members in group , got %v\n", len(res1[0].Members))
+	}
+
+	generationId1 := m1.generationId
+
+	// shut down m2, membership should not change (we didn't leave group when close)
+	m2.AssertCleanShutdown()
+
+	res2, err := admin.DescribeConsumerGroups([]string{groupID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(res1, res2) {
+		res1Bytes, _ := json.Marshal(res1)
+		res2Bytes, _ := json.Marshal(res2)
+		t.Errorf("group description be the same before %s, after %s", res1Bytes, res2Bytes)
+	}
+
+	generationId2 := atomic.LoadInt32(&m1.generationId)
+	if generationId2 != generationId1 {
+		t.Errorf("m1 generation should not increase expect %v, actual %v", generationId1, generationId2)
+	}
+
+	// m2 rejoin, should generate a new memberId, no re-balance happens
+	m2 = runTestFuncConsumerGroupMemberWithConfig(t, config2, groupID, math.MaxInt32, nil, "test.4")
+	m2.WaitForState(2)
+	m1.WaitForState(2)
+
+	res3, err := admin.DescribeConsumerGroups([]string{groupID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res3) != 1 {
+		t.Errorf("group description should be only 1, got %v\n", len(res3))
+	}
+	if len(res3[0].Members) != 2 {
+		t.Errorf("should have 2 members in group , got %v\n", len(res3[0].Members))
+	}
+
+	generationId3 := atomic.LoadInt32(&m1.generationId)
+	if generationId3 != generationId1 {
+		t.Errorf("m1 generation should not increase expect %v, actual %v", generationId1, generationId2)
+	}
+
+	m2.AssertCleanShutdown()
+	removeResp, err := admin.RemoveMemberFromConsumerGroup(groupID, []string{config2.Consumer.Group.InstanceId})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removeResp.Err != ErrNoError {
+		t.Errorf("remove %s from consumer group failed %v", config2.Consumer.Group.InstanceId, removeResp.Err)
+	}
+	m1.WaitForHandlers(4)
+
+	generationId4 := atomic.LoadInt32(&m1.generationId)
+	if generationId4 == generationId1 {
+		t.Errorf("m1 generation should increase expect %v, actual %v", generationId1, generationId2)
+	}
+}
+
+func TestFuncConsumerGroupStaticMembership_Fenced(t *testing.T) {
+	checkKafkaVersion(t, "2.3.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+	groupID := testFuncConsumerGroupID(t)
+
+	t.Helper()
+
+	config1 := NewTestConfig()
+	config1.ClientID = "M1"
+	config1.Version = V2_3_0_0
+	config1.Consumer.Offsets.Initial = OffsetNewest
+	config1.Consumer.Group.InstanceId = "Instance1"
+	m1 := runTestFuncConsumerGroupMemberWithConfig(t, config1, groupID, math.MaxInt32, nil, "test.4")
+	defer m1.Close()
+
+	config2 := NewTestConfig()
+	config2.ClientID = "M2"
+	config2.Version = V2_3_0_0
+	config2.Consumer.Offsets.Initial = OffsetNewest
+	config2.Consumer.Group.InstanceId = "Instance2"
+	m2 := runTestFuncConsumerGroupMemberWithConfig(t, config2, groupID, math.MaxInt32, nil, "test.4")
+	defer m2.Close()
+
+	m1.WaitForState(2)
+	m2.WaitForState(2)
+
+	config3 := NewTestConfig()
+	config3.ClientID = "M3"
+	config3.Version = V2_3_0_0
+	config3.Consumer.Offsets.Initial = OffsetNewest
+	config3.Consumer.Group.InstanceId = "Instance2" // same instance id as config2
+
+	m3 := runTestFuncConsumerGroupMemberWithConfig(t, config3, groupID, math.MaxInt32, nil, "test.4")
+	defer m3.Close()
+
+	m3.WaitForState(2)
+
+	m2.WaitForState(4)
+	if len(m2.errs) < 1 {
+		t.Errorf("expect m2 to be fenced by group instanced id, but got no err")
+	}
+	if !errors.Is(m2.errs[0], ErrFencedInstancedId) {
+		t.Errorf("expect m2 to be fenced by group instanced id, but got wrong err %v", m2.errs[0])
+	}
+
+	m1.AssertCleanShutdown()
+	m3.AssertCleanShutdown()
+}
+
+// --------------------------------------------------------------------
+
+func testFuncConsumerGroupProduceMessage(topic string, count int) error {
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, NewTestConfig())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	producer, err := NewAsyncProducerFromClient(client)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < count; i++ {
+		producer.Input() <- &ProducerMessage{Topic: topic, Value: ByteEncoder([]byte("testdata"))}
+	}
+	return producer.Close()
+}

--- a/heartbeat_request_test.go
+++ b/heartbeat_request_test.go
@@ -1,17 +1,81 @@
 package sarama
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-var basicHeartbeatRequest = []byte{
-	0, 3, 'f', 'o', 'o', // Group ID
-	0x00, 0x01, 0x02, 0x03, // Generatiuon ID
-	0, 3, 'b', 'a', 'z', // Member ID
-}
+var (
+	basicHeartbeatRequestV0 = []byte{
+		0, 3, 'f', 'o', 'o', // Group ID
+		0x00, 0x01, 0x02, 0x03, // Generatiuon ID
+		0, 3, 'b', 'a', 'z', // Member ID
+	}
+
+	basicHeartbeatRequestV3_GID = []byte{
+		0, 3, 'f', 'o', 'o', // Group ID
+		0x00, 0x01, 0x02, 0x03, // Generatiuon ID
+		0, 3, 'b', 'a', 'z', // Member ID
+		0, 3, 'g', 'i', 'd', // Group Instance ID
+	}
+	basicHeartbeatRequestV3_NOGID = []byte{
+		0, 3, 'f', 'o', 'o', // Group ID
+		0x00, 0x01, 0x02, 0x03, // Generatiuon ID
+		0, 3, 'b', 'a', 'z', // Member ID
+		255, 255, // Group Instance ID
+	}
+)
 
 func TestHeartbeatRequest(t *testing.T) {
-	request := new(HeartbeatRequest)
-	request.GroupId = "foo"
-	request.GenerationId = 66051
-	request.MemberId = "baz"
-	testRequest(t, "basic", request, basicHeartbeatRequest)
+	groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *HeartbeatRequest
+	}{
+		{
+			"v0_basic",
+			0,
+			basicHeartbeatRequestV0,
+			&HeartbeatRequest{
+				Version:      0,
+				GroupId:      "foo",
+				GenerationId: 0x00010203,
+				MemberId:     "baz",
+			},
+		},
+		{
+			"v3_basic",
+			3,
+			basicHeartbeatRequestV3_GID,
+			&HeartbeatRequest{
+				Version:         3,
+				GroupId:         "foo",
+				GenerationId:    0x00010203,
+				MemberId:        "baz",
+				GroupInstanceId: &groupInstanceId,
+			},
+		},
+		{
+			"v3_basic",
+			3,
+			basicHeartbeatRequestV3_NOGID,
+			&HeartbeatRequest{
+				Version:         3,
+				GroupId:         "foo",
+				GenerationId:    0x00010203,
+				MemberId:        "baz",
+				GroupInstanceId: nil,
+			},
+		},
+	}
+	for _, c := range tests {
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
+		request := new(HeartbeatRequest)
+		testVersionDecodable(t, c.CaseName, request, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, request) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, request)
+		}
+	}
 }

--- a/heartbeat_response.go
+++ b/heartbeat_response.go
@@ -1,15 +1,27 @@
 package sarama
 
 type HeartbeatResponse struct {
-	Err KError
+	Version      int16
+	ThrottleTime int32
+	Err          KError
 }
 
 func (r *HeartbeatResponse) encode(pe packetEncoder) error {
+	if r.Version >= 1 {
+		pe.putInt32(r.ThrottleTime)
+	}
 	pe.putInt16(int16(r.Err))
 	return nil
 }
 
 func (r *HeartbeatResponse) decode(pd packetDecoder, version int16) error {
+	var err error
+	r.Version = version
+	if r.Version >= 1 {
+		if r.ThrottleTime, err = pd.getInt32(); err != nil {
+			return err
+		}
+	}
 	kerr, err := pd.getInt16()
 	if err != nil {
 		return err
@@ -24,7 +36,7 @@ func (r *HeartbeatResponse) key() int16 {
 }
 
 func (r *HeartbeatResponse) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *HeartbeatResponse) headerVersion() int16 {
@@ -32,5 +44,9 @@ func (r *HeartbeatResponse) headerVersion() int16 {
 }
 
 func (r *HeartbeatResponse) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1, 2, 3:
+		return V2_3_0_0
+	}
 	return V0_9_0_0
 }

--- a/heartbeat_response_test.go
+++ b/heartbeat_response_test.go
@@ -1,18 +1,67 @@
 package sarama
 
 import (
-	"errors"
+	"reflect"
 	"testing"
 )
 
-var heartbeatResponseNoError = []byte{
-	0x00, 0x00,
-}
+var (
+	heartbeatResponseNoError_V0 = []byte{
+		0x00, 0x00,
+	}
+	heartbeatResponseNoError_V1 = []byte{
+		0, 0, 0, 100,
+		0, 0,
+	}
+	heartbeatResponseError_V1 = []byte{
+		0, 0, 0, 100,
+		0, byte(ErrFencedInstancedId),
+	}
+)
 
 func TestHeartbeatResponse(t *testing.T) {
-	response := new(HeartbeatResponse)
-	testVersionDecodable(t, "no error", response, heartbeatResponseNoError, 0)
-	if !errors.Is(response.Err, ErrNoError) {
-		t.Error("Decoding error failed: no error expected but found", response.Err)
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *HeartbeatResponse
+	}{
+		{
+			"v0_noErr",
+			0,
+			heartbeatResponseNoError_V0,
+			&HeartbeatResponse{
+				Version: 0,
+				Err:     ErrNoError,
+			},
+		},
+		{
+			"v1_noErr",
+			1,
+			heartbeatResponseNoError_V1,
+			&HeartbeatResponse{
+				Version:      1,
+				Err:          ErrNoError,
+				ThrottleTime: 100,
+			},
+		},
+		{
+			"v1_Err",
+			1,
+			heartbeatResponseError_V1,
+			&HeartbeatResponse{
+				Version:      1,
+				Err:          ErrFencedInstancedId,
+				ThrottleTime: 100,
+			},
+		},
+	}
+	for _, c := range tests {
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
+		response := new(HeartbeatResponse)
+		testVersionDecodable(t, c.CaseName, response, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, response) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, response)
+		}
 	}
 }

--- a/join_group_request_test.go
+++ b/join_group_request_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 var (
 	joinGroupRequestV0_NoProtocols = []byte{
@@ -80,4 +83,59 @@ func TestJoinGroupRequestV1(t *testing.T) {
 	request.GroupProtocols = make(map[string][]byte)
 	request.GroupProtocols["one"] = []byte{0x01, 0x02, 0x03}
 	testRequestDecode(t, "V1", request, packet)
+}
+
+var (
+	joinGroupRequestV5 = []byte{
+		0, 9, 'T', 'e', 's', 't', 'G', 'r', 'o', 'u', 'p', // Group ID
+		0, 0, 0, 100, // Session timeout
+		0, 0, 0, 200, // Rebalance timeout
+		0, 11, 'O', 'n', 'e', 'P', 'r', 'o', 't', 'o', 'c', 'o', 'l', // Member ID
+		0, 3, 'g', 'i', 'd', // GroupInstanceId
+		0, 8, 'c', 'o', 'n', 's', 'u', 'm', 'e', 'r', // Protocol Type
+		0, 0, 0, 1, // 1 group protocol
+		0, 3, 'o', 'n', 'e', // Protocol name
+		0, 0, 0, 3, 0x01, 0x02, 0x03, // protocol metadata
+	}
+)
+
+func TestJoinGroupRequestV3plus(t *testing.T) {
+	groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *JoinGroupRequest
+	}{
+		{
+			"v5",
+			5,
+			joinGroupRequestV5,
+			&JoinGroupRequest{
+				Version:          5,
+				GroupId:          "TestGroup",
+				SessionTimeout:   100,
+				RebalanceTimeout: 200,
+				MemberId:         "OneProtocol",
+				GroupInstanceId:  &groupInstanceId,
+				ProtocolType:     "consumer",
+				GroupProtocols: map[string][]byte{
+					"one": {1, 2, 3},
+				},
+				OrderedGroupProtocols: []*GroupProtocol{
+					{Name: "one", Metadata: []byte{1, 2, 3}},
+				},
+			},
+		},
+	}
+	for _, c := range tests {
+		request := new(JoinGroupRequest)
+		testVersionDecodable(t, c.CaseName, request, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, request) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, request)
+		}
+		// This is to avoid error check "cannot specify both GroupProtocols and OrderedGroupProtocols on JoinGroupRequest"
+		c.Message.GroupProtocols = nil
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
+	}
 }

--- a/join_group_response.go
+++ b/join_group_response.go
@@ -8,17 +8,23 @@ type JoinGroupResponse struct {
 	GroupProtocol string
 	LeaderId      string
 	MemberId      string
-	Members       map[string][]byte
+	Members       []GroupMember
+}
+
+type GroupMember struct {
+	MemberId        string
+	GroupInstanceId *string
+	Metadata        []byte
 }
 
 func (r *JoinGroupResponse) GetMembers() (map[string]ConsumerGroupMemberMetadata, error) {
 	members := make(map[string]ConsumerGroupMemberMetadata, len(r.Members))
-	for id, bin := range r.Members {
+	for _, member := range r.Members {
 		meta := new(ConsumerGroupMemberMetadata)
-		if err := decode(bin, meta); err != nil {
+		if err := decode(member.Metadata, meta); err != nil {
 			return nil, err
 		}
-		members[id] = *meta
+		members[member.MemberId] = *meta
 	}
 	return members, nil
 }
@@ -44,12 +50,16 @@ func (r *JoinGroupResponse) encode(pe packetEncoder) error {
 		return err
 	}
 
-	for memberId, memberMetadata := range r.Members {
-		if err := pe.putString(memberId); err != nil {
+	for _, member := range r.Members {
+		if err := pe.putString(member.MemberId); err != nil {
 			return err
 		}
-
-		if err := pe.putBytes(memberMetadata); err != nil {
+		if r.Version >= 5 {
+			if err := pe.putNullableString(member.GroupInstanceId); err != nil {
+				return err
+			}
+		}
+		if err := pe.putBytes(member.Metadata); err != nil {
 			return err
 		}
 	}
@@ -97,11 +107,19 @@ func (r *JoinGroupResponse) decode(pd packetDecoder, version int16) (err error) 
 		return nil
 	}
 
-	r.Members = make(map[string][]byte)
+	r.Members = make([]GroupMember, n)
 	for i := 0; i < n; i++ {
 		memberId, err := pd.getString()
 		if err != nil {
 			return err
+		}
+
+		var groupInstanceId *string = nil
+		if r.Version >= 5 {
+			groupInstanceId, err = pd.getNullableString()
+			if err != nil {
+				return err
+			}
 		}
 
 		memberMetadata, err := pd.getBytes()
@@ -109,7 +127,7 @@ func (r *JoinGroupResponse) decode(pd packetDecoder, version int16) (err error) 
 			return err
 		}
 
-		r.Members[memberId] = memberMetadata
+		r.Members[i] = GroupMember{MemberId: memberId, GroupInstanceId: groupInstanceId, Metadata: memberMetadata}
 	}
 
 	return nil
@@ -129,6 +147,8 @@ func (r *JoinGroupResponse) headerVersion() int16 {
 
 func (r *JoinGroupResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 3, 4, 5:
+		return V2_3_0_0
 	case 2:
 		return V0_11_0_0
 	case 1:

--- a/leave_group_request_test.go
+++ b/leave_group_request_test.go
@@ -1,15 +1,63 @@
 package sarama
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-var basicLeaveGroupRequest = []byte{
-	0, 3, 'f', 'o', 'o',
-	0, 3, 'b', 'a', 'r',
-}
+var (
+	basicLeaveGroupRequestV0 = []byte{
+		0, 3, 'f', 'o', 'o',
+		0, 3, 'b', 'a', 'r',
+	}
+	basicLeaveGroupRequestV3 = []byte{
+		0, 3, 'f', 'o', 'o',
+		0, 0, 0, 2, // Two Member
+		0, 4, 'm', 'i', 'd', '1', // MemberId
+		255, 255, // GroupInstanceId  nil
+		0, 4, 'm', 'i', 'd', '2', // MemberId
+		0, 3, 'g', 'i', 'd', // GroupInstanceId
+	}
+)
 
 func TestLeaveGroupRequest(t *testing.T) {
-	request := new(LeaveGroupRequest)
-	request.GroupId = "foo"
-	request.MemberId = "bar"
-	testRequest(t, "basic", request, basicLeaveGroupRequest)
+	groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *LeaveGroupRequest
+	}{
+		{
+			"v0",
+			0,
+			basicLeaveGroupRequestV0,
+			&LeaveGroupRequest{
+				Version:  0,
+				GroupId:  "foo",
+				MemberId: "bar",
+			},
+		},
+		{
+			"v3",
+			3,
+			basicLeaveGroupRequestV3,
+			&LeaveGroupRequest{
+				Version: 3,
+				GroupId: "foo",
+				Members: []MemberIdentity{
+					{"mid1", nil},
+					{"mid2", &groupInstanceId},
+				},
+			},
+		},
+	}
+	for _, c := range tests {
+		request := new(LeaveGroupRequest)
+		testVersionDecodable(t, c.CaseName, request, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, request) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, request)
+		}
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
+	}
 }

--- a/leave_group_response.go
+++ b/leave_group_response.go
@@ -1,20 +1,72 @@
 package sarama
 
+type MemberResponse struct {
+	MemberId        string
+	GroupInstanceId *string
+	Err             KError
+}
 type LeaveGroupResponse struct {
-	Err KError
+	Version      int16
+	ThrottleTime int32
+	Err          KError
+	Members      []MemberResponse
 }
 
 func (r *LeaveGroupResponse) encode(pe packetEncoder) error {
+	if r.Version >= 1 {
+		pe.putInt32(r.ThrottleTime)
+	}
 	pe.putInt16(int16(r.Err))
+	if r.Version >= 3 {
+		if err := pe.putArrayLength(len(r.Members)); err != nil {
+			return err
+		}
+		for _, member := range r.Members {
+			if err := pe.putString(member.MemberId); err != nil {
+				return err
+			}
+			if err := pe.putNullableString(member.GroupInstanceId); err != nil {
+				return err
+			}
+			pe.putInt16(int16(member.Err))
+		}
+	}
 	return nil
 }
 
 func (r *LeaveGroupResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
+	if r.Version >= 1 {
+		if r.ThrottleTime, err = pd.getInt32(); err != nil {
+			return err
+		}
+	}
 	kerr, err := pd.getInt16()
 	if err != nil {
 		return err
 	}
 	r.Err = KError(kerr)
+
+	if r.Version >= 3 {
+		membersLen, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		r.Members = make([]MemberResponse, membersLen)
+		for i := 0; i < len(r.Members); i++ {
+			if r.Members[i].MemberId, err = pd.getString(); err != nil {
+				return err
+			}
+			if r.Members[i].GroupInstanceId, err = pd.getNullableString(); err != nil {
+				return err
+			}
+			if memberErr, err := pd.getInt16(); err != nil {
+				return err
+			} else {
+				r.Members[i].Err = KError(memberErr)
+			}
+		}
+	}
 
 	return nil
 }
@@ -24,7 +76,7 @@ func (r *LeaveGroupResponse) key() int16 {
 }
 
 func (r *LeaveGroupResponse) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *LeaveGroupResponse) headerVersion() int16 {
@@ -32,5 +84,9 @@ func (r *LeaveGroupResponse) headerVersion() int16 {
 }
 
 func (r *LeaveGroupResponse) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1, 2, 3:
+		return V2_3_0_0
+	}
 	return V0_9_0_0
 }

--- a/leave_group_response_test.go
+++ b/leave_group_response_test.go
@@ -1,27 +1,87 @@
 package sarama
 
 import (
-	"errors"
+	"reflect"
 	"testing"
 )
 
 var (
-	leaveGroupResponseNoError   = []byte{0x00, 0x00}
-	leaveGroupResponseWithError = []byte{0, 25}
+	leaveGroupResponseV0NoError   = []byte{0x00, 0x00}
+	leaveGroupResponseV0WithError = []byte{0, 25}
+	leaveGroupResponseV1NoError   = []byte{
+		0, 0, 0, 100, // ThrottleTime
+		0x00, 0x00, // Err
+	}
+	leaveGroupResponseV3NoError = []byte{
+		0, 0, 0, 100, // ThrottleTime
+		0x00, 0x00, // Err
+		0, 0, 0, 2, // Two Members
+		0, 4, 'm', 'i', 'd', '1', // MemberId
+		255, 255, // GroupInstanceId
+		0, 0, // Err
+		0, 4, 'm', 'i', 'd', '2', // MemberId
+		0, 3, 'g', 'i', 'd', // GroupInstanceId
+		0, 25, // Err
+	}
 )
 
 func TestLeaveGroupResponse(t *testing.T) {
-	var response *LeaveGroupResponse
-
-	response = new(LeaveGroupResponse)
-	testVersionDecodable(t, "no error", response, leaveGroupResponseNoError, 0)
-	if !errors.Is(response.Err, ErrNoError) {
-		t.Error("Decoding error failed: no error expected but found", response.Err)
+	groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *LeaveGroupResponse
+	}{
+		{
+			"v0-noErr",
+			0,
+			leaveGroupResponseV0NoError,
+			&LeaveGroupResponse{
+				Version: 0,
+				Err:     ErrNoError,
+			},
+		},
+		{
+			"v0-Err",
+			0,
+			leaveGroupResponseV0WithError,
+			&LeaveGroupResponse{
+				Version: 0,
+				Err:     ErrUnknownMemberId,
+			},
+		},
+		{
+			"v1-noErr",
+			1,
+			leaveGroupResponseV1NoError,
+			&LeaveGroupResponse{
+				Version:      1,
+				ThrottleTime: 100,
+				Err:          ErrNoError,
+			},
+		},
+		{
+			"v3",
+			3,
+			leaveGroupResponseV3NoError,
+			&LeaveGroupResponse{
+				Version:      3,
+				ThrottleTime: 100,
+				Err:          ErrNoError,
+				Members: []MemberResponse{
+					{"mid1", nil, ErrNoError},
+					{"mid2", &groupInstanceId, ErrUnknownMemberId},
+				},
+			},
+		},
 	}
-
-	response = new(LeaveGroupResponse)
-	testVersionDecodable(t, "with error", response, leaveGroupResponseWithError, 0)
-	if !errors.Is(response.Err, ErrUnknownMemberId) {
-		t.Error("Decoding error failed: ErrUnknownMemberId expected but found", response.Err)
+	for _, c := range tests {
+		response := new(LeaveGroupResponse)
+		testVersionDecodable(t, c.CaseName, response, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, response) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, response)
+		}
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
 	}
 }

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -1189,13 +1189,13 @@ type MockJoinGroupResponse struct {
 	GroupProtocol string
 	LeaderId      string
 	MemberId      string
-	Members       map[string][]byte
+	Members       []GroupMember
 }
 
 func NewMockJoinGroupResponse(t TestReporter) *MockJoinGroupResponse {
 	return &MockJoinGroupResponse{
 		t:       t,
-		Members: make(map[string][]byte),
+		Members: make([]GroupMember, 0),
 	}
 }
 
@@ -1249,7 +1249,7 @@ func (m *MockJoinGroupResponse) SetMember(id string, meta *ConsumerGroupMemberMe
 	if err != nil {
 		panic(fmt.Sprintf("error encoding member metadata: %v", err))
 	}
-	m.Members[id] = bin
+	m.Members = append(m.Members, GroupMember{MemberId: id, Metadata: bin})
 	return m
 }
 

--- a/offset_commit_request_test.go
+++ b/offset_commit_request_test.go
@@ -2,6 +2,7 @@ package sarama
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -69,7 +70,7 @@ func TestOffsetCommitRequestV0(t *testing.T) {
 	request.ConsumerGroup = "foobar"
 	testRequest(t, "no blocks v0", request, offsetCommitRequestNoBlocksV0)
 
-	request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, "metadata")
+	request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, 0, "metadata")
 	testRequest(t, "one block v0", request, offsetCommitRequestOneBlockV0)
 }
 
@@ -81,7 +82,7 @@ func TestOffsetCommitRequestV1(t *testing.T) {
 	request.Version = 1
 	testRequest(t, "no blocks v1", request, offsetCommitRequestNoBlocksV1)
 
-	request.AddBlock("topic", 0x5221, 0xDEADBEEF, ReceiveTime, "metadata")
+	request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, ReceiveTime, "metadata")
 	testRequest(t, "one block v1", request, offsetCommitRequestOneBlockV1)
 }
 
@@ -95,7 +96,114 @@ func TestOffsetCommitRequestV2ToV4(t *testing.T) {
 		request.Version = int16(version)
 		testRequest(t, fmt.Sprintf("no blocks v%d", version), request, offsetCommitRequestNoBlocksV2)
 
-		request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, "metadata")
+		request.AddBlock("topic", 0x5221, 0xDEADBEEF, 0, 0, "metadata")
 		testRequest(t, fmt.Sprintf("one block v%d", version), request, offsetCommitRequestOneBlockV2)
+	}
+}
+
+var (
+	offsetCommitRequestOneBlockV5 = []byte{
+		0, 3, 'f', 'o', 'o', // GroupId
+		0x00, 0x00, 0x00, 0x01, // GenerationId
+		0, 3, 'm', 'i', 'd', // MemberId
+		0, 0, 0, 1, // One Topic
+		0, 5, 't', 'o', 'p', 'i', 'c', // Name
+		0, 0, 0, 1, // One Partition
+		0, 0, 0, 1, // PartitionIndex
+		0, 0, 0, 0, 0, 0, 0, 2, // CommittedOffset
+		0, 4, 'm', 'e', 't', 'a', // CommittedMetadata
+	}
+	offsetCommitRequestOneBlockV6 = []byte{
+		0, 3, 'f', 'o', 'o', // GroupId
+		0x00, 0x00, 0x00, 0x01, // GenerationId
+		0, 3, 'm', 'i', 'd', // MemberId
+		0, 0, 0, 1, // One Topic
+		0, 5, 't', 'o', 'p', 'i', 'c', // Name
+		0, 0, 0, 1, // One Partition
+		0, 0, 0, 1, // PartitionIndex
+		0, 0, 0, 0, 0, 0, 0, 2, // CommittedOffset
+		0, 0, 0, 3, // CommittedEpoch
+		0, 4, 'm', 'e', 't', 'a', // CommittedMetadata
+	}
+	offsetCommitRequestOneBlockV7 = []byte{
+		0, 3, 'f', 'o', 'o', // GroupId
+		0x00, 0x00, 0x00, 0x01, // GenerationId
+		0, 3, 'm', 'i', 'd', // MemberId
+		0, 3, 'g', 'i', 'd', // MemberId
+		0, 0, 0, 1, // One Topic
+		0, 5, 't', 'o', 'p', 'i', 'c', // Name
+		0, 0, 0, 1, // One Partition
+		0, 0, 0, 1, // PartitionIndex
+		0, 0, 0, 0, 0, 0, 0, 2, // CommittedOffset
+		0, 0, 0, 3, // CommittedEpoch
+		0, 4, 'm', 'e', 't', 'a', // CommittedMetadata
+	}
+)
+
+func TestOffsetCommitRequestV5AndPlus(t *testing.T) {
+	groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *OffsetCommitRequest
+	}{
+		{
+			"v5",
+			5,
+			offsetCommitRequestOneBlockV5,
+			&OffsetCommitRequest{
+				Version:                 5,
+				ConsumerGroup:           "foo",
+				ConsumerGroupGeneration: 1,
+				ConsumerID:              "mid",
+				blocks: map[string]map[int32]*offsetCommitRequestBlock{
+					"topic": {
+						1: &offsetCommitRequestBlock{offset: 2, metadata: "meta"},
+					},
+				},
+			},
+		},
+		{
+			"v6",
+			6,
+			offsetCommitRequestOneBlockV6,
+			&OffsetCommitRequest{
+				Version:                 6,
+				ConsumerGroup:           "foo",
+				ConsumerGroupGeneration: 1,
+				ConsumerID:              "mid",
+				blocks: map[string]map[int32]*offsetCommitRequestBlock{
+					"topic": {
+						1: &offsetCommitRequestBlock{offset: 2, metadata: "meta", committedLeaderEpoch: 3},
+					},
+				},
+			},
+		},
+		{
+			"v7",
+			7,
+			offsetCommitRequestOneBlockV7,
+			&OffsetCommitRequest{
+				Version:                 7,
+				ConsumerGroup:           "foo",
+				ConsumerGroupGeneration: 1,
+				ConsumerID:              "mid",
+				GroupInstanceId:         &groupInstanceId,
+				blocks: map[string]map[int32]*offsetCommitRequestBlock{
+					"topic": {
+						1: &offsetCommitRequestBlock{offset: 2, metadata: "meta", committedLeaderEpoch: 3},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range tests {
+		request := new(OffsetCommitRequest)
+		testVersionDecodable(t, c.CaseName, request, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, request) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, request)
+		}
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
 	}
 }

--- a/offset_commit_response.go
+++ b/offset_commit_response.go
@@ -108,6 +108,8 @@ func (r *OffsetCommitResponse) requiredVersion() KafkaVersion {
 		return V0_11_0_0
 	case 4:
 		return V2_0_0_0
+	case 5, 6, 7:
+		return V2_3_0_0
 	default:
 		return MinVersion
 	}

--- a/offset_commit_response_test.go
+++ b/offset_commit_response_test.go
@@ -2,16 +2,83 @@ package sarama
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
-var emptyOffsetCommitResponse = []byte{
-	0x00, 0x00, 0x00, 0x00,
-}
+var (
+	emptyOffsetCommitResponseV0 = []byte{
+		0x00, 0x00, 0x00, 0x00, // Empty topic
+	}
+	noEmptyOffsetCommitResponseV0 = []byte{
+		0, 0, 0, 1, // Topic Len
+		0, 5, 't', 'o', 'p', 'i', 'c', // Name
+		0, 0, 0, 1, // Partition Len
+		0, 0, 0, 3, // PartitionIndex
+		0, 0, // ErrorCode
+	}
+	noEmptyOffsetCommitResponseV3 = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0, 0, 0, 1, // Topic Len
+		0, 5, 't', 'o', 'p', 'i', 'c', // Name
+		0, 0, 0, 1, // Partition Len
+		0, 0, 0, 3, // PartitionIndex
+		0, 0, // ErrorCode
+	}
+)
 
 func TestEmptyOffsetCommitResponse(t *testing.T) {
-	response := OffsetCommitResponse{}
-	testResponse(t, "empty", &response, emptyOffsetCommitResponse)
+	//groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *OffsetCommitResponse
+	}{
+		{
+			"v0-empty",
+			0,
+			emptyOffsetCommitResponseV0,
+			&OffsetCommitResponse{
+				Version: 0,
+			},
+		},
+		{
+			"v0-two-partition",
+			0,
+			noEmptyOffsetCommitResponseV0,
+			&OffsetCommitResponse{
+				Version: 0,
+				Errors: map[string]map[int32]KError{
+					"topic": {
+						3: ErrNoError,
+					},
+				},
+			},
+		},
+		{
+			"v3",
+			3,
+			noEmptyOffsetCommitResponseV3,
+			&OffsetCommitResponse{
+				ThrottleTimeMs: 100,
+				Version:        3,
+				Errors: map[string]map[int32]KError{
+					"topic": {
+						3: ErrNoError,
+					},
+				},
+			},
+		},
+	}
+	for _, c := range tests {
+		response := new(OffsetCommitResponse)
+		testVersionDecodable(t, c.CaseName, response, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, response) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, response)
+		}
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
+	}
 }
 
 func TestNormalOffsetCommitResponse(t *testing.T) {

--- a/sync_group_request_test.go
+++ b/sync_group_request_test.go
@@ -1,6 +1,9 @@
 package sarama
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 var (
 	emptySyncGroupRequest = []byte{
@@ -35,4 +38,50 @@ func TestSyncGroupRequest(t *testing.T) {
 	request.MemberId = "baz"
 	request.AddGroupAssignment("baz", []byte("foo"))
 	testRequest(t, "populated", request, populatedSyncGroupRequest)
+}
+
+var (
+	populatedSyncGroupRequestV3 = []byte{
+		0, 3, 'f', 'o', 'o', // Group ID
+		0x00, 0x01, 0x02, 0x03, // Generation ID
+		0, 3, 'b', 'a', 'z', // Member ID
+		0, 3, 'g', 'i', 'd', // GroupInstance ID
+		0, 0, 0, 1, // one assignment
+		0, 3, 'b', 'a', 'z', // Member ID
+		0, 0, 0, 3, 'f', 'o', 'o', // Member assignment
+	}
+)
+
+func TestSyncGroupRequestV3AndPlus(t *testing.T) {
+	groupInstanceId := "gid"
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *SyncGroupRequest
+	}{
+		{
+			"v3",
+			3,
+			populatedSyncGroupRequestV3,
+			&SyncGroupRequest{
+				Version:         3,
+				GroupId:         "foo",
+				GenerationId:    0x00010203,
+				MemberId:        "baz",
+				GroupInstanceId: &groupInstanceId,
+				GroupAssignments: map[string][]byte{
+					"baz": []byte("foo"),
+				},
+			},
+		},
+	}
+	for _, c := range tests {
+		request := new(SyncGroupRequest)
+		testVersionDecodable(t, c.CaseName, request, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, request) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, request)
+		}
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
+	}
 }

--- a/sync_group_response.go
+++ b/sync_group_response.go
@@ -1,6 +1,8 @@
 package sarama
 
 type SyncGroupResponse struct {
+	Version          int16
+	ThrottleTime     int32
 	Err              KError
 	MemberAssignment []byte
 }
@@ -12,11 +14,20 @@ func (r *SyncGroupResponse) GetMemberAssignment() (*ConsumerGroupMemberAssignmen
 }
 
 func (r *SyncGroupResponse) encode(pe packetEncoder) error {
+	if r.Version >= 1 {
+		pe.putInt32(r.ThrottleTime)
+	}
 	pe.putInt16(int16(r.Err))
 	return pe.putBytes(r.MemberAssignment)
 }
 
 func (r *SyncGroupResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
+	if r.Version >= 1 {
+		if r.ThrottleTime, err = pd.getInt32(); err != nil {
+			return err
+		}
+	}
 	kerr, err := pd.getInt16()
 	if err != nil {
 		return err
@@ -33,7 +44,7 @@ func (r *SyncGroupResponse) key() int16 {
 }
 
 func (r *SyncGroupResponse) version() int16 {
-	return 0
+	return r.Version
 }
 
 func (r *SyncGroupResponse) headerVersion() int16 {
@@ -41,5 +52,9 @@ func (r *SyncGroupResponse) headerVersion() int16 {
 }
 
 func (r *SyncGroupResponse) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1, 2, 3:
+		return V2_3_0_0
+	}
 	return V0_9_0_0
 }

--- a/sync_group_response_test.go
+++ b/sync_group_response_test.go
@@ -1,41 +1,73 @@
 package sarama
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 )
 
 var (
-	syncGroupResponseNoError = []byte{
+	syncGroupResponseV0NoError = []byte{
 		0x00, 0x00, // No error
 		0, 0, 0, 3, 0x01, 0x02, 0x03, // Member assignment data
 	}
 
-	syncGroupResponseWithError = []byte{
+	syncGroupResponseV0WithError = []byte{
 		0, 27, // ErrRebalanceInProgress
 		0, 0, 0, 0, // No member assignment data
+	}
+
+	syncGroupResponseV1NoError = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0x00, 0x00, // No error
+		0, 0, 0, 3, 0x01, 0x02, 0x03, // Member assignment data
 	}
 )
 
 func TestSyncGroupResponse(t *testing.T) {
-	var response *SyncGroupResponse
-
-	response = new(SyncGroupResponse)
-	testVersionDecodable(t, "no error", response, syncGroupResponseNoError, 0)
-	if !errors.Is(response.Err, ErrNoError) {
-		t.Error("Decoding Err failed: no error expected but found", response.Err)
+	tests := []struct {
+		CaseName     string
+		Version      int16
+		MessageBytes []byte
+		Message      *SyncGroupResponse
+	}{
+		{
+			"v0-noErr",
+			0,
+			syncGroupResponseV0NoError,
+			&SyncGroupResponse{
+				Version:          0,
+				Err:              ErrNoError,
+				MemberAssignment: []byte{1, 2, 3},
+			},
+		},
+		{
+			"v0-Err",
+			0,
+			syncGroupResponseV0WithError,
+			&SyncGroupResponse{
+				Version:          0,
+				Err:              ErrRebalanceInProgress,
+				MemberAssignment: []byte{},
+			},
+		},
+		{
+			"v1-noErr",
+			1,
+			syncGroupResponseV1NoError,
+			&SyncGroupResponse{
+				ThrottleTime:     100,
+				Version:          1,
+				Err:              ErrNoError,
+				MemberAssignment: []byte{1, 2, 3},
+			},
+		},
 	}
-	if !reflect.DeepEqual(response.MemberAssignment, []byte{0x01, 0x02, 0x03}) {
-		t.Error("Decoding MemberAssignment failed, found:", response.MemberAssignment)
-	}
-
-	response = new(SyncGroupResponse)
-	testVersionDecodable(t, "no error", response, syncGroupResponseWithError, 0)
-	if !errors.Is(response.Err, ErrRebalanceInProgress) {
-		t.Error("Decoding Err failed: ErrRebalanceInProgress expected but found", response.Err)
-	}
-	if !reflect.DeepEqual(response.MemberAssignment, []byte{}) {
-		t.Error("Decoding MemberAssignment failed, found:", response.MemberAssignment)
+	for _, c := range tests {
+		response := new(SyncGroupResponse)
+		testVersionDecodable(t, c.CaseName, response, c.MessageBytes, c.Version)
+		if !reflect.DeepEqual(c.Message, response) {
+			t.Errorf("case %s decode failed, expected:%+v got %+v", c.CaseName, c.Message, response)
+		}
+		testEncodable(t, c.CaseName, c.Message, c.MessageBytes)
 	}
 }


### PR DESCRIPTION
Hi this is the impl for kip-345 static membership, pls help to take a look.
* update joingroup/syncgroup/heartbeat/commitoffset request
* donot leavegroup if staticmembership is enabled
* with ut&functional test
* added logic for [KIP-394](https://cwiki.apache.org/confluence/display/KAFKA/KIP-394%3A+Require+member.id+for+initial+join+group+request) if static membership is enabled. because we update the joingroup.
