### PR TITLE
Fix DescribeLogDirs hang in admin client

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1050,12 +1050,12 @@ func (ca *clusterAdmin) DescribeLogDirs(brokerIds []int32) (allLogDirs map[int32
 	wg := sync.WaitGroup{}
 
 	for _, b := range brokerIds {
-		wg.Add(1)
 		broker, err := ca.findBroker(b)
 		if err != nil {
 			Logger.Printf("Unable to find broker with ID = %v\n", b)
 			continue
 		}
+		wg.Add(1)
 		go func(b *Broker, conf *Config) {
 			defer wg.Done()
 			_ = b.Open(conf) // Ensure that broker is opened


### PR DESCRIPTION
This fixes a goroutine/waitgroup bug in the admin client. If an unknown broker ID is passed to `DescribeLogDirs`, it will hang forever.

It's a bug with waitgroups, where a waitgroup can be incremented without an associated decrement leading to an infinite wait. I think it's simple enough that it can be fixed with just visual inspection, but I included a test case just to be sure.

It's tricky to get a codebase into this scenario, but has occurred in our systems a few times. In summary, two goroutines using a shared `sarama.Client`:

* One goroutine does various things to get a list of (then valid) broker IDs
* Another goroutine runs a `PartitionConsumer`
* A broker goes offline
* The consumer goroutine, as part of its `PartitionConsumer` error recovery, eventually calls `RefreshMetadata`, updating the internal `brokers` list in the `Client` to remove the broker that's offline.
* The first goroutine calls `DescribeLogDirs` with the original broker list, which still includes the dead broker
* `DescribeLogDirs`
    * increments a waitgroup
    * calls `findBroker`, which doesn't find the dead broker in `client.Brokers()`
    * logs the error then `continue`s the loop without firing off a goroutine with a `wg.Done()` to decrement
    * the final `wg.Wait()` hangs.

This was noted in the original PR introducing this admin API call (https://github.com/Shopify/sarama/pull/1646#discussion_r399593272), but the bug occurs before any network IO is involved.