### PR TITLE
fix: ensure empty or devel version valid

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,10 +15,11 @@ func version() string {
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
 			v = bi.Main.Version
-		} else {
+		}
+		if v == "" || v == "(devel)" {
 			// if we can't read a go module version then they're using a git
 			// clone or vendored module so all we can do is report "dev" for
-			// the version
+			// the version to make a valid ApiVersions request
 			v = "dev"
 		}
 	})


### PR DESCRIPTION
As we send the version in our ApiVersionsRequest as the
ClientSoftwareVersion we need to make sure it is considered valid by
Kafka by conforming to their version regex