### PR TITLE
chore: add kafka 3.1.1 to the version matrix

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.18.x]
-        kafka-version: [2.8.1, 3.0.1, 3.1.0, 3.2.0]
+        kafka-version: [2.8.1, 3.0.1, 3.1.1, 3.2.0]
     env:
       DEBUG: true
       GOFLAGS: -trimpath

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -19,7 +19,7 @@ RUN cd /etc/java/java-11-openjdk/*/conf/security \
 ARG KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 RUN mkdir -p "/opt/kafka-2.8.1" && chmod a+rw /opt/kafka-2.8.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.8.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.8.1"
 RUN mkdir -p "/opt/kafka-3.0.1" && chmod a+rw /opt/kafka-3.0.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.0.1"
-RUN mkdir -p "/opt/kafka-3.1.0" && chmod a+rw /opt/kafka-3.1.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.0"
+RUN mkdir -p "/opt/kafka-3.1.1" && chmod a+rw /opt/kafka-3.1.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.1"
 RUN mkdir -p "/opt/kafka-3.2.0" && chmod a+rw /opt/kafka-3.2.0 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.2.0.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.2.0"
 
 COPY entrypoint.sh /

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.0}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29091'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-1:9091,LISTENER_LOCAL://localhost:29091'
@@ -61,7 +61,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.0}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29092'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-2:9091,LISTENER_LOCAL://localhost:29092'
@@ -82,7 +82,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.0}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29093'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-3:9091,LISTENER_LOCAL://localhost:29093'
@@ -103,7 +103,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.0}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29094'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-4:9091,LISTENER_LOCAL://localhost:29094'
@@ -124,7 +124,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.0}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29095'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-5:9091,LISTENER_LOCAL://localhost:29095'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KAFKA_VERSION="${KAFKA_VERSION:-3.1.0}"
+KAFKA_VERSION="${KAFKA_VERSION:-3.1.1}"
 KAFKA_HOME="/opt/kafka-${KAFKA_VERSION}"
 
 if [ ! -d "${KAFKA_HOME}" ]; then

--- a/functional_test.go
+++ b/functional_test.go
@@ -135,7 +135,7 @@ func prepareDockerTestEnvironment(ctx context.Context, env *testEnvironment) err
 	if version, ok := os.LookupEnv("KAFKA_VERSION"); ok {
 		env.KafkaVersion = version
 	} else {
-		env.KafkaVersion = "3.1.0"
+		env.KafkaVersion = "3.1.1"
 	}
 
 	c := exec.Command("docker-compose", "up", "-d")

--- a/utils.go
+++ b/utils.go
@@ -182,6 +182,7 @@ var (
 	V3_0_0_0  = newKafkaVersion(3, 0, 0, 0)
 	V3_0_1_0  = newKafkaVersion(3, 0, 1, 0)
 	V3_1_0_0  = newKafkaVersion(3, 1, 0, 0)
+	V3_1_0_1  = newKafkaVersion(3, 1, 0, 1)
 	V3_2_0_0  = newKafkaVersion(3, 2, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
@@ -228,6 +229,7 @@ var (
 		V3_0_0_0,
 		V3_0_1_0,
 		V3_1_0_0,
+		V3_1_0_1,
 		V3_2_0_0,
 	}
 	MinVersion     = V0_8_2_0
@@ -250,7 +252,7 @@ var (
 		V2_7_1_0,
 		V2_8_1_0,
 		V3_0_1_0,
-		V3_1_0_0,
+		V3_1_0_1,
 		V3_2_0_0,
 	}
 )

--- a/utils_test.go
+++ b/utils_test.go
@@ -73,6 +73,8 @@ func TestVersionParsing(t *testing.T) {
 		"3.0.0",
 		"3.0.1",
 		"3.1.0",
+		"3.1.1",
+		"3.2.0",
 	}
 	for _, s := range validVersions {
 		v, err := ParseKafkaVersion(s)


### PR DESCRIPTION
Bump default fvt version to 3.1.1 as well.