### PR TITLE
fix(consumer): avoid pushing unrelated responses to paused children

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -944,6 +944,16 @@ func (bc *brokerConsumer) subscriptionConsumer() {
 
 		bc.acks.Add(len(bc.subscriptions))
 		for child := range bc.subscriptions {
+			if _, ok := response.Blocks[child.topic]; !ok {
+				bc.acks.Done()
+				continue
+			}
+
+			if _, ok := response.Blocks[child.topic][child.partition]; !ok {
+				bc.acks.Done()
+				continue
+			}
+
 			child.feeder <- response
 		}
 		bc.acks.Wait()


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/Shopify/sarama/issues/2316).

Signed-off-by: Panos Koutsovasilis <koutsobill@hotmail.com>