### PR TITLE
Validate the `Config` when creating a mock producer/consumer

### DIFF
--- a/mocks/async_producer.go
+++ b/mocks/async_producer.go
@@ -30,11 +30,14 @@ type AsyncProducer struct {
 
 // NewAsyncProducer instantiates a new Producer mock. The t argument should
 // be the *testing.T instance of your test method. An error will be written to it if
-// an expectation is violated. The config argument is used to determine whether it
-// should ack successes on the Successes channel and to handle partitioning.
+// an expectation is violated. The config argument is validated and used to determine
+// whether it should ack successes on the Successes channel and handle partitioning.
 func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
 	if config == nil {
 		config = sarama.NewConfig()
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Invalid mock configuration provided: %s", err.Error())
 	}
 	mp := &AsyncProducer{
 		t:               t,

--- a/mocks/async_producer_test.go
+++ b/mocks/async_producer_test.go
@@ -247,3 +247,18 @@ func (brokePartitioner) Partition(msg *sarama.ProducerMessage, n int32) (int32, 
 }
 
 func (brokePartitioner) RequiresConsistency() bool { return false }
+
+func TestProducerWithInvalidConfiguration(t *testing.T) {
+	trm := newTestReporterMock()
+	config := NewTestConfig()
+	config.ClientID = "not a valid client ID"
+	mp := NewAsyncProducer(trm, config)
+	if err := mp.Close(); err != nil {
+		t.Error(err)
+	}
+	if len(trm.errors) != 1 {
+		t.Error("Expected to report a single error")
+	} else if !strings.Contains(trm.errors[0], "ClientID is invalid") {
+		t.Errorf("Unexpected error: %s", trm.errors[0])
+	}
+}

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -20,10 +20,14 @@ type Consumer struct {
 
 // NewConsumer returns a new mock Consumer instance. The t argument should
 // be the *testing.T instance of your test method. An error will be written to it if
-// an expectation is violated. The config argument can be set to nil.
+// an expectation is violated. The config argument can be set to nil; if it is
+// non-nil it is validated.
 func NewConsumer(t ErrorReporter, config *sarama.Config) *Consumer {
 	if config == nil {
 		config = sarama.NewConfig()
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Invalid mock configuration provided: %s", err.Error())
 	}
 
 	c := &Consumer{

--- a/mocks/consumer_test.go
+++ b/mocks/consumer_test.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"errors"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Shopify/sarama"
@@ -393,5 +394,21 @@ func TestConsumerOffsetsAreManagedCorrectlyWithSpecifiedOffset(t *testing.T) {
 
 	if len(trm.errors) != 0 {
 		t.Errorf("Expected to not report any errors, found: %v", trm.errors)
+	}
+}
+
+func TestConsumerInvalidConfiguration(t *testing.T) {
+	trm := newTestReporterMock()
+	config := NewTestConfig()
+	config.ClientID = "not a valid client ID"
+	consumer := NewConsumer(trm, config)
+	if err := consumer.Close(); err != nil {
+		t.Error(err)
+	}
+
+	if len(trm.errors) != 1 {
+		t.Error("Expected to report a single error")
+	} else if !strings.Contains(trm.errors[0], "ClientID is invalid") {
+		t.Errorf("Unexpected error: %s", trm.errors[0])
 	}
 }

--- a/mocks/sync_producer.go
+++ b/mocks/sync_producer.go
@@ -28,10 +28,14 @@ type SyncProducer struct {
 
 // NewSyncProducer instantiates a new SyncProducer mock. The t argument should
 // be the *testing.T instance of your test method. An error will be written to it if
-// an expectation is violated. The config argument is used to handle partitioning.
+// an expectation is violated. The config argument is validated and used to handle
+// partitioning.
 func NewSyncProducer(t ErrorReporter, config *sarama.Config) *SyncProducer {
 	if config == nil {
 		config = sarama.NewConfig()
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Invalid mock configuration provided: %s", err.Error())
 	}
 	return &SyncProducer{
 		t:               t,

--- a/mocks/sync_producer_test.go
+++ b/mocks/sync_producer_test.go
@@ -352,3 +352,19 @@ func (f faultyEncoder) Encode() ([]byte, error) {
 func (f faultyEncoder) Length() int {
 	return len(f)
 }
+
+func TestSyncProducerInvalidConfiguration(t *testing.T) {
+	trm := newTestReporterMock()
+	config := NewTestConfig()
+	config.ClientID = "not a valid client ID"
+	mp := NewSyncProducer(trm, config)
+	if err := mp.Close(); err != nil {
+		t.Error(err)
+	}
+
+	if len(trm.errors) != 1 {
+		t.Error("Expected to report a single error")
+	} else if !strings.Contains(trm.errors[0], "ClientID is invalid") {
+		t.Errorf("Unexpected error: %s", trm.errors[0])
+	}
+}


### PR DESCRIPTION
Normally this happens during creation of the `Client`, but for mock
interfaces there is no `Client`.