### PR TITLE
feat(consumer): support multiple balance strategies

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -319,6 +319,17 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		return nil, join.Err
 	}
 
+	var strategy BalanceStrategy
+	var ok bool
+	if strategy = c.config.Consumer.Group.Rebalance.Strategy; strategy == nil {
+		strategy, ok = c.findStrategy(join.GroupProtocol, c.config.Consumer.Group.Rebalance.GroupStrategies)
+		if !ok {
+			// this case shouldn't happen in practice, since the leader will choose the protocol
+			// that all the members support
+			return nil, fmt.Errorf("unable to find selected strategy: %s", join.GroupProtocol)
+		}
+	}
+
 	// Prepare distribution plan if we joined as the leader
 	var plan BalanceStrategyPlan
 	var members map[string]ConsumerGroupMemberMetadata
@@ -328,14 +339,14 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			return nil, err
 		}
 
-		plan, err = c.balance(members)
+		plan, err = c.balance(strategy, members)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Sync consumer group
-	groupRequest, err := c.syncGroupRequest(coordinator, members, plan, join.GenerationId)
+	syncGroupResponse, err := c.syncGroupRequest(coordinator, members, plan, join.GenerationId, strategy)
 	if consumerGroupSyncTotal != nil {
 		consumerGroupSyncTotal.Inc(1)
 	}
@@ -346,13 +357,13 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		}
 		return nil, err
 	}
-	if !errors.Is(groupRequest.Err, ErrNoError) {
+	if !errors.Is(syncGroupResponse.Err, ErrNoError) {
 		if consumerGroupSyncFailed != nil {
 			consumerGroupSyncFailed.Inc(1)
 		}
 	}
 
-	switch groupRequest.Err {
+	switch syncGroupResponse.Err {
 	case ErrNoError:
 	case ErrUnknownMemberId, ErrIllegalGeneration:
 		// reset member ID and retry immediately
@@ -361,22 +372,22 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	case ErrNotCoordinatorForConsumer, ErrRebalanceInProgress, ErrOffsetsLoadInProgress:
 		// retry after backoff
 		if retries <= 0 {
-			return nil, groupRequest.Err
+			return nil, syncGroupResponse.Err
 		}
 		return c.retryNewSession(ctx, topics, handler, retries, true)
 	case ErrFencedInstancedId:
 		if c.groupInstanceId != nil {
 			Logger.Printf("JoinGroup failed: group instance id %s has been fenced\n", *c.groupInstanceId)
 		}
-		return nil, groupRequest.Err
+		return nil, syncGroupResponse.Err
 	default:
-		return nil, groupRequest.Err
+		return nil, syncGroupResponse.Err
 	}
 
 	// Retrieve and sort claims
 	var claims map[string][]int32
-	if len(groupRequest.MemberAssignment) > 0 {
-		members, err := groupRequest.GetMemberAssignment()
+	if len(syncGroupResponse.MemberAssignment) > 0 {
+		members, err := syncGroupResponse.GetMemberAssignment()
 		if err != nil {
 			return nil, err
 		}
@@ -419,12 +430,31 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 		Topics:   topics,
 		UserData: c.userData,
 	}
-	strategy := c.config.Consumer.Group.Rebalance.Strategy
-	if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {
-		return nil, err
+	var strategy BalanceStrategy
+	if strategy = c.config.Consumer.Group.Rebalance.Strategy; strategy != nil {
+		if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {
+			return nil, err
+		}
+	} else {
+		for _, strategy = range c.config.Consumer.Group.Rebalance.GroupStrategies {
+			if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return coordinator.JoinGroup(req)
+}
+
+// findStrategy returns the BalanceStrategy with the specified protocolName
+// from the slice provided.
+func (c *consumerGroup) findStrategy(name string, groupStrategies []BalanceStrategy) (BalanceStrategy, bool) {
+	for _, strategy := range groupStrategies {
+		if strategy.Name() == name {
+			return strategy, true
+		}
+	}
+	return nil, false
 }
 
 func (c *consumerGroup) syncGroupRequest(
@@ -432,13 +462,14 @@ func (c *consumerGroup) syncGroupRequest(
 	members map[string]ConsumerGroupMemberMetadata,
 	plan BalanceStrategyPlan,
 	generationID int32,
+	strategy BalanceStrategy,
 ) (*SyncGroupResponse, error) {
 	req := &SyncGroupRequest{
 		GroupId:      c.groupID,
 		MemberId:     c.memberID,
 		GenerationId: generationID,
 	}
-	strategy := c.config.Consumer.Group.Rebalance.Strategy
+
 	if c.config.Version.IsAtLeast(V2_3_0_0) {
 		req.Version = 3
 	}
@@ -481,7 +512,7 @@ func (c *consumerGroup) heartbeatRequest(coordinator *Broker, memberID string, g
 	return coordinator.Heartbeat(req)
 }
 
-func (c *consumerGroup) balance(members map[string]ConsumerGroupMemberMetadata) (BalanceStrategyPlan, error) {
+func (c *consumerGroup) balance(strategy BalanceStrategy, members map[string]ConsumerGroupMemberMetadata) (BalanceStrategyPlan, error) {
 	topics := make(map[string][]int32)
 	for _, meta := range members {
 		for _, topic := range meta.Topics {
@@ -497,7 +528,6 @@ func (c *consumerGroup) balance(members map[string]ConsumerGroupMemberMetadata) 
 		topics[topic] = partitions
 	}
 
-	strategy := c.config.Consumer.Group.Rebalance.Strategy
 	return strategy.Plan(members, topics)
 }
 

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -49,7 +49,7 @@ func TestConsumerGroupNewSessionDuringOffsetLoad(t *testing.T) {
 		"HeartbeatRequest": NewMockHeartbeatResponse(t),
 		"JoinGroupRequest": NewMockSequence(
 			NewMockJoinGroupResponse(t).SetError(ErrOffsetsLoadInProgress),
-			NewMockJoinGroupResponse(t),
+			NewMockJoinGroupResponse(t).SetGroupProtocol(RangeBalanceStrategyName),
 		),
 		"SyncGroupRequest": NewMockSequence(
 			NewMockSyncGroupResponse(t).SetError(ErrOffsetsLoadInProgress),

--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -70,11 +70,11 @@ func main() {
 
 	switch assignor {
 	case "sticky":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
+		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategySticky}
 	case "roundrobin":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategyRoundRobin}
 	case "range":
-		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategyRange}
 	default:
 		log.Panicf("Unrecognized consumer group partition assignor: %s", assignor)
 	}

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -59,7 +59,7 @@ func TestFuncConsumerGroupPartitioningStateful(t *testing.T) {
 
 	m1s := newTestStatefulStrategy(t)
 	config := defaultConfig("M1")
-	config.Consumer.Group.Rebalance.Strategy = m1s
+	config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{m1s}
 	config.Consumer.Group.Member.UserData = []byte(config.ClientID)
 
 	// start M1
@@ -72,7 +72,7 @@ func TestFuncConsumerGroupPartitioningStateful(t *testing.T) {
 
 	m2s := newTestStatefulStrategy(t)
 	config = defaultConfig("M2")
-	config.Consumer.Group.Rebalance.Strategy = m2s
+	config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{m2s}
 	config.Consumer.Group.Member.UserData = []byte(config.ClientID)
 
 	// start M2


### PR DESCRIPTION
As shown below, Kafka supports specifying multiple rebalance protocol from the very begining. ([source](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-PossibleErrorCodes:~:text=all%20client%20implementations.-,Join%20Group%20Request,-The%20join%20group))
```
v0 supported in 0.9.0.0 and greater
JoinGroupRequest => GroupId SessionTimeout MemberId ProtocolType GroupProtocols
  GroupId => string
  SessionTimeout => int32
  MemberId => string
  ProtocolType => string
  GroupProtocols => [ProtocolName ProtocolMetadata]
    ProtocolName => string
    ProtocolMetadata => bytes
 
v1 supported in 0.10.1.0 and greater
JoinGroupRequest => GroupId SessionTimeout MemberId ProtocolType GroupProtocols
  GroupId => string
  SessionTimeout => int32
  RebalanceTimeout => int32
  MemberId => string
  ProtocolType => string
  GroupProtocols => [ProtocolName ProtocolMetadata]
    ProtocolName => string
    ProtocolMetadata => bytes
```

However, Sarama only supports one group protocol right now, by specifying [`Consumer.Group.Rebalance.Strategy`](https://github.com/Shopify/sarama/blob/v1.36.0/config.go#L275-L276). **This prevents users from enjoying some benefits in Kafka.** For example, if users wanna change the default one `range` to a more advanced one like `sticky`, when the new consumers with `sticky` protocol try to join in the consumer group, they will be rejected by the coordinator with error `ErrInconsistentGroupProtocol(kafka server: The provider group protocol type is incompatible with the other members)` and thus cannot consume any messages. Only when all the instances are upgraded with `sticky` protocol can they resume consume message again.

In contrast, **the client supporting multiple group protocols enables rolling upgrades without downtime** -- The upgraded member includes both the new protocol and the protocol, and the coordinator will choose a single protocol which all members support. Once all members have upgraded, the coordinator will choose whichever protocol is listed first in the `GroupProtocols` array.

In this PR, I introduce a new config `Consumer.Group.Rebalance.GroupStrategies` and mark the old one `Consumer.Group.Rebalance.Strategy` deprecated. To make it **backward compatible**:
- The dafault value for `Consumer.Group.Rebalance.GroupStrategies` is `[]{BalanceStrategyRange}`
- `Consumer.Group.Rebalance.Strategy` takes precedence of `Consumer.Group.Rebalance.GroupStrategies`

Thus,
- if `Consumer.Group.Rebalance.Strategy` isn't explicitly configured previously, then the new default value `range` in `Consumer.Group.Rebalance.GroupStrategies` will be used.
- if `Consumer.Group.Rebalance.Strategy` is configured by users previously, `Consumer.Group.Rebalance.Strategy` is also chosen as the group protocol.

I believe it's a desirable feature in sarama, since other Go Kafka Libraries, like [segmentio/kafka-go](https://github.com/segmentio/kafka-go/blob/v0.4.35/consumergroup.go#L85-L90), already support it.
