### PR TITLE
fix(consumer): default ResetInvalidOffsets to true

### DIFF
--- a/config.go
+++ b/config.go
@@ -508,7 +508,7 @@ func NewConfig() *Config {
 	c.Consumer.Group.Rebalance.Timeout = 60 * time.Second
 	c.Consumer.Group.Rebalance.Retry.Max = 4
 	c.Consumer.Group.Rebalance.Retry.Backoff = 2 * time.Second
-	c.Consumer.Group.ResetInvalidOffsets = false
+	c.Consumer.Group.ResetInvalidOffsets = true
 
 	c.ClientID = defaultClientID
 	c.ChannelBufferSize = 256


### PR DESCRIPTION
A number of people have reported issues with the change in default behaviour that was introduced in #2252 and the comment for this configuration value had suggested it would retain the behaviour of previous Sarama versions. This PR puts the default behaviour back to resetting to `c.Consumer.Offsets.Initial` when the server returns an out of range error on a Fetch.

Contributes-to: #2342