### PR TITLE
feat(proto): implement and use MetadataRequest v7

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -280,17 +280,7 @@ func (ca *clusterAdmin) DescribeTopics(topics []string) (metadata []*TopicMetada
 		return nil, err
 	}
 
-	request := &MetadataRequest{
-		Topics:                 topics,
-		AllowAutoTopicCreation: false,
-	}
-
-	if ca.conf.Version.IsAtLeast(V1_0_0_0) {
-		request.Version = 5
-	} else if ca.conf.Version.IsAtLeast(V0_11_0_0) {
-		request.Version = 4
-	}
-
+	request := NewMetadataRequest(ca.conf.Version, topics)
 	response, err := controller.GetMetadata(request)
 	if err != nil {
 		return nil, err
@@ -304,14 +294,7 @@ func (ca *clusterAdmin) DescribeCluster() (brokers []*Broker, controllerID int32
 		return nil, int32(0), err
 	}
 
-	request := &MetadataRequest{
-		Topics: []string{},
-	}
-
-	if ca.conf.Version.IsAtLeast(V0_10_0_0) {
-		request.Version = 1
-	}
-
+	request := NewMetadataRequest(ca.conf.Version, nil)
 	response, err := controller.GetMetadata(request)
 	if err != nil {
 		return nil, int32(0), err
@@ -352,7 +335,7 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 	}
 	_ = b.Open(ca.client.Config())
 
-	metadataReq := &MetadataRequest{}
+	metadataReq := NewMetadataRequest(ca.conf.Version, nil)
 	metadataResp, err := b.GetMetadata(metadataReq)
 	if err != nil {
 		return nil, err

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1711,7 +1711,7 @@ func TestTxnProduceBumpEpoch(t *testing.T) {
 	config.ApiVersionsRequest = false
 
 	metadataLeader := new(MetadataResponse)
-	metadataLeader.Version = 5
+	metadataLeader.Version = 7
 	metadataLeader.ControllerID = broker.brokerID
 	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
 	metadataLeader.AddTopic("test-topic", ErrNoError)

--- a/client.go
+++ b/client.go
@@ -989,13 +989,8 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 			DebugLogger.Printf("client/metadata fetching metadata for all topics from broker %s\n", broker.addr)
 		}
 
-		req := &MetadataRequest{Topics: topics, AllowAutoTopicCreation: allowAutoTopicCreation}
-		if client.conf.Version.IsAtLeast(V1_0_0_0) {
-			req.Version = 5
-		} else if client.conf.Version.IsAtLeast(V0_10_0_0) {
-			req.Version = 1
-		}
-
+		req := NewMetadataRequest(client.conf.Version, topics)
+		req.AllowAutoTopicCreation = allowAutoTopicCreation
 		t := atomic.LoadInt64(&client.updateMetaDataMs)
 		if !atomic.CompareAndSwapInt64(&client.updateMetaDataMs, t, time.Now().UnixNano()/int64(time.Millisecond)) {
 			return nil

--- a/metadata_request.go
+++ b/metadata_request.go
@@ -1,13 +1,30 @@
 package sarama
 
 type MetadataRequest struct {
-	Version                int16
-	Topics                 []string
+	// Version defines the protocol version to use for encode and decode
+	Version int16
+	// Topics contains the topics to fetch metadata for.
+	Topics []string
+	// AllowAutoTopicCreation contains a If this is true, the broker may auto-create topics that we requested which do not already exist, if it is configured to do so.
 	AllowAutoTopicCreation bool
 }
 
-func (r *MetadataRequest) encode(pe packetEncoder) error {
-	if r.Version < 0 || r.Version > 5 {
+func NewMetadataRequest(version KafkaVersion, topics []string) *MetadataRequest {
+	m := &MetadataRequest{Topics: topics}
+	if version.IsAtLeast(V2_1_0_0) {
+		m.Version = 7
+	} else if version.IsAtLeast(V2_0_0_0) {
+		m.Version = 6
+	} else if version.IsAtLeast(V1_0_0_0) {
+		m.Version = 5
+	} else if version.IsAtLeast(V0_10_0_0) {
+		m.Version = 1
+	}
+	return m
+}
+
+func (r *MetadataRequest) encode(pe packetEncoder) (err error) {
+	if r.Version < 0 || r.Version > 12 {
 		return PacketEncodingError{"invalid or unsupported MetadataRequest version field"}
 	}
 	if r.Version == 0 || len(r.Topics) > 0 {
@@ -25,13 +42,15 @@ func (r *MetadataRequest) encode(pe packetEncoder) error {
 	} else {
 		pe.putInt32(-1)
 	}
-	if r.Version > 3 {
+
+	if r.Version >= 4 {
 		pe.putBool(r.AllowAutoTopicCreation)
 	}
+
 	return nil
 }
 
-func (r *MetadataRequest) decode(pd packetDecoder, version int16) error {
+func (r *MetadataRequest) decode(pd packetDecoder, version int16) (err error) {
 	r.Version = version
 	size, err := pd.getInt32()
 	if err != nil {
@@ -47,13 +66,13 @@ func (r *MetadataRequest) decode(pd packetDecoder, version int16) error {
 			r.Topics[i] = topic
 		}
 	}
-	if r.Version > 3 {
-		autoCreation, err := pd.getBool()
-		if err != nil {
+
+	if r.Version >= 4 {
+		if r.AllowAutoTopicCreation, err = pd.getBool(); err != nil {
 			return err
 		}
-		r.AllowAutoTopicCreation = autoCreation
 	}
+
 	return nil
 }
 
@@ -79,6 +98,10 @@ func (r *MetadataRequest) requiredVersion() KafkaVersion {
 		return V0_11_0_0
 	case 5:
 		return V1_0_0_0
+	case 6:
+		return V2_0_0_0
+	case 7:
+		return V2_1_0_0
 	default:
 		return MinVersion
 	}

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -1,44 +1,57 @@
 package sarama
 
+// PartitionMetadata contains each partition in the topic.
 type PartitionMetadata struct {
-	Err             KError
-	ID              int32
-	Leader          int32
-	Replicas        []int32
-	Isr             []int32
+	// Version defines the protocol version to use for encode and decode
+	Version int16
+	// Err contains the partition error, or 0 if there was no error.
+	Err KError
+	// ID contains the partition index.
+	ID int32
+	// Leader contains the ID of the leader broker.
+	Leader int32
+	// LeaderEpoch contains the leader epoch of this partition.
+	LeaderEpoch int32
+	// Replicas contains the set of all nodes that host this partition.
+	Replicas []int32
+	// Isr contains the set of nodes that are in sync with the leader for this partition.
+	Isr []int32
+	// OfflineReplicas contains the set of offline replicas of this partition.
 	OfflineReplicas []int32
 }
 
-func (pm *PartitionMetadata) decode(pd packetDecoder, version int16) (err error) {
+func (p *PartitionMetadata) decode(pd packetDecoder, version int16) (err error) {
+	p.Version = version
 	tmp, err := pd.getInt16()
 	if err != nil {
 		return err
 	}
-	pm.Err = KError(tmp)
+	p.Err = KError(tmp)
 
-	pm.ID, err = pd.getInt32()
-	if err != nil {
+	if p.ID, err = pd.getInt32(); err != nil {
 		return err
 	}
 
-	pm.Leader, err = pd.getInt32()
-	if err != nil {
+	if p.Leader, err = pd.getInt32(); err != nil {
 		return err
 	}
 
-	pm.Replicas, err = pd.getInt32Array()
-	if err != nil {
+	if p.Version >= 7 {
+		if p.LeaderEpoch, err = pd.getInt32(); err != nil {
+			return err
+		}
+	}
+
+	if p.Replicas, err = pd.getInt32Array(); err != nil {
 		return err
 	}
 
-	pm.Isr, err = pd.getInt32Array()
-	if err != nil {
+	if p.Isr, err = pd.getInt32Array(); err != nil {
 		return err
 	}
 
-	if version >= 5 {
-		pm.OfflineReplicas, err = pd.getInt32Array()
-		if err != nil {
+	if p.Version >= 5 {
+		if p.OfflineReplicas, err = pd.getInt32Array(); err != nil {
 			return err
 		}
 	}
@@ -46,24 +59,28 @@ func (pm *PartitionMetadata) decode(pd packetDecoder, version int16) (err error)
 	return nil
 }
 
-func (pm *PartitionMetadata) encode(pe packetEncoder, version int16) (err error) {
-	pe.putInt16(int16(pm.Err))
-	pe.putInt32(pm.ID)
-	pe.putInt32(pm.Leader)
+func (p *PartitionMetadata) encode(pe packetEncoder, version int16) (err error) {
+	p.Version = version
+	pe.putInt16(int16(p.Err))
 
-	err = pe.putInt32Array(pm.Replicas)
-	if err != nil {
+	pe.putInt32(p.ID)
+
+	pe.putInt32(p.Leader)
+
+	if p.Version >= 7 {
+		pe.putInt32(p.LeaderEpoch)
+	}
+
+	if err := pe.putInt32Array(p.Replicas); err != nil {
 		return err
 	}
 
-	err = pe.putInt32Array(pm.Isr)
-	if err != nil {
+	if err := pe.putInt32Array(p.Isr); err != nil {
 		return err
 	}
 
-	if version >= 5 {
-		err = pe.putInt32Array(pm.OfflineReplicas)
-		if err != nil {
+	if p.Version >= 5 {
+		if err := pe.putInt32Array(p.OfflineReplicas); err != nil {
 			return err
 		}
 	}
@@ -71,68 +88,71 @@ func (pm *PartitionMetadata) encode(pe packetEncoder, version int16) (err error)
 	return nil
 }
 
+// TopicMetadata contains each topic in the response.
 type TopicMetadata struct {
-	Err        KError
-	Name       string
-	IsInternal bool // Only valid for Version >= 1
+	// Version defines the protocol version to use for encode and decode
+	Version int16
+	// Err contains the topic error, or 0 if there was no error.
+	Err KError
+	// Name contains the topic name.
+	Name string
+	// IsInternal contains a True if the topic is internal.
+	IsInternal bool
+	// Partitions contains each partition in the topic.
 	Partitions []*PartitionMetadata
 }
 
-func (tm *TopicMetadata) decode(pd packetDecoder, version int16) (err error) {
+func (t *TopicMetadata) decode(pd packetDecoder, version int16) (err error) {
+	t.Version = version
 	tmp, err := pd.getInt16()
 	if err != nil {
 		return err
 	}
-	tm.Err = KError(tmp)
+	t.Err = KError(tmp)
 
-	tm.Name, err = pd.getString()
-	if err != nil {
+	if t.Name, err = pd.getString(); err != nil {
 		return err
 	}
 
-	if version >= 1 {
-		tm.IsInternal, err = pd.getBool()
-		if err != nil {
+	if t.Version >= 1 {
+		if t.IsInternal, err = pd.getBool(); err != nil {
 			return err
 		}
 	}
 
-	n, err := pd.getArrayLength()
-	if err != nil {
+	if numPartitions, err := pd.getArrayLength(); err != nil {
 		return err
-	}
-	tm.Partitions = make([]*PartitionMetadata, n)
-	for i := 0; i < n; i++ {
-		tm.Partitions[i] = new(PartitionMetadata)
-		err = tm.Partitions[i].decode(pd, version)
-		if err != nil {
-			return err
+	} else {
+		t.Partitions = make([]*PartitionMetadata, numPartitions)
+		for i := 0; i < numPartitions; i++ {
+			block := &PartitionMetadata{}
+			if err := block.decode(pd, t.Version); err != nil {
+				return err
+			}
+			t.Partitions[i] = block
 		}
 	}
 
 	return nil
 }
 
-func (tm *TopicMetadata) encode(pe packetEncoder, version int16) (err error) {
-	pe.putInt16(int16(tm.Err))
+func (t *TopicMetadata) encode(pe packetEncoder, version int16) (err error) {
+	t.Version = version
+	pe.putInt16(int16(t.Err))
 
-	err = pe.putString(tm.Name)
-	if err != nil {
+	if err := pe.putString(t.Name); err != nil {
 		return err
 	}
 
-	if version >= 1 {
-		pe.putBool(tm.IsInternal)
+	if t.Version >= 1 {
+		pe.putBool(t.IsInternal)
 	}
 
-	err = pe.putArrayLength(len(tm.Partitions))
-	if err != nil {
+	if err := pe.putArrayLength(len(t.Partitions)); err != nil {
 		return err
 	}
-
-	for _, pm := range tm.Partitions {
-		err = pm.encode(pe, version)
-		if err != nil {
+	for _, block := range t.Partitions {
+		if err := block.encode(pe, t.Version); err != nil {
 			return err
 		}
 	}
@@ -141,20 +161,24 @@ func (tm *TopicMetadata) encode(pe packetEncoder, version int16) (err error) {
 }
 
 type MetadataResponse struct {
-	Version        int16
+	// Version defines the protocol version to use for encode and decode
+	Version int16
+	// ThrottleTimeMs contains the duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
 	ThrottleTimeMs int32
-	Brokers        []*Broker
-	ClusterID      *string
-	ControllerID   int32
-	Topics         []*TopicMetadata
+	// Brokers contains each broker in the response.
+	Brokers []*Broker
+	// ClusterID contains the cluster ID that responding broker belongs to.
+	ClusterID *string
+	// ControllerID contains the ID of the controller broker.
+	ControllerID int32
+	// Topics contains each topic in the response.
+	Topics []*TopicMetadata
 }
 
 func (r *MetadataResponse) decode(pd packetDecoder, version int16) (err error) {
 	r.Version = version
-
-	if version >= 3 {
-		r.ThrottleTimeMs, err = pd.getInt32()
-		if err != nil {
+	if r.Version >= 3 {
+		if r.ThrottleTimeMs, err = pd.getInt32(); err != nil {
 			return err
 		}
 	}
@@ -163,7 +187,6 @@ func (r *MetadataResponse) decode(pd packetDecoder, version int16) (err error) {
 	if err != nil {
 		return err
 	}
-
 	r.Brokers = make([]*Broker, n)
 	for i := 0; i < n; i++ {
 		r.Brokers[i] = new(Broker)
@@ -173,46 +196,40 @@ func (r *MetadataResponse) decode(pd packetDecoder, version int16) (err error) {
 		}
 	}
 
-	if version >= 2 {
-		r.ClusterID, err = pd.getNullableString()
-		if err != nil {
+	if r.Version >= 2 {
+		if r.ClusterID, err = pd.getNullableString(); err != nil {
 			return err
 		}
 	}
 
-	if version >= 1 {
-		r.ControllerID, err = pd.getInt32()
-		if err != nil {
+	if r.Version >= 1 {
+		if r.ControllerID, err = pd.getInt32(); err != nil {
 			return err
 		}
-	} else {
-		r.ControllerID = -1
 	}
 
-	n, err = pd.getArrayLength()
-	if err != nil {
+	if numTopics, err := pd.getArrayLength(); err != nil {
 		return err
-	}
-
-	r.Topics = make([]*TopicMetadata, n)
-	for i := 0; i < n; i++ {
-		r.Topics[i] = new(TopicMetadata)
-		err = r.Topics[i].decode(pd, version)
-		if err != nil {
-			return err
+	} else {
+		r.Topics = make([]*TopicMetadata, numTopics)
+		for i := 0; i < numTopics; i++ {
+			block := &TopicMetadata{}
+			if err := block.decode(pd, r.Version); err != nil {
+				return err
+			}
+			r.Topics[i] = block
 		}
 	}
 
 	return nil
 }
 
-func (r *MetadataResponse) encode(pe packetEncoder) error {
+func (r *MetadataResponse) encode(pe packetEncoder) (err error) {
 	if r.Version >= 3 {
 		pe.putInt32(r.ThrottleTimeMs)
 	}
 
-	err := pe.putArrayLength(len(r.Brokers))
-	if err != nil {
+	if err := pe.putArrayLength(len(r.Brokers)); err != nil {
 		return err
 	}
 	for _, broker := range r.Brokers {
@@ -223,8 +240,7 @@ func (r *MetadataResponse) encode(pe packetEncoder) error {
 	}
 
 	if r.Version >= 2 {
-		err := pe.putNullableString(r.ClusterID)
-		if err != nil {
+		if err := pe.putNullableString(r.ClusterID); err != nil {
 			return err
 		}
 	}
@@ -233,13 +249,11 @@ func (r *MetadataResponse) encode(pe packetEncoder) error {
 		pe.putInt32(r.ControllerID)
 	}
 
-	err = pe.putArrayLength(len(r.Topics))
-	if err != nil {
+	if err := pe.putArrayLength(len(r.Topics)); err != nil {
 		return err
 	}
-	for _, tm := range r.Topics {
-		err = tm.encode(pe, r.Version)
-		if err != nil {
+	for _, block := range r.Topics {
+		if err := block.encode(pe, r.Version); err != nil {
 			return err
 		}
 	}
@@ -269,6 +283,10 @@ func (r *MetadataResponse) requiredVersion() KafkaVersion {
 		return V0_11_0_0
 	case 5:
 		return V1_0_0_0
+	case 6:
+		return V2_0_0_0
+	case 7:
+		return V2_1_0_0
 	default:
 		return MinVersion
 	}
@@ -316,7 +334,6 @@ func (r *MetadataResponse) AddTopicPartition(topic string, partition, brokerID i
 	tmatch.Partitions = append(tmatch.Partitions, pmatch)
 
 foundPartition:
-
 	pmatch.Leader = brokerID
 	pmatch.Replicas = replicas
 	pmatch.Isr = isr

--- a/request.go
+++ b/request.go
@@ -125,7 +125,7 @@ func allocateBody(key, version int16) protocolBody {
 	case 2:
 		return &OffsetRequest{Version: version}
 	case 3:
-		return &MetadataRequest{}
+		return &MetadataRequest{Version: version}
 	case 8:
 		return &OffsetCommitRequest{Version: version}
 	case 9:


### PR DESCRIPTION
In order to receive the LeaderEpoch as part of the metadata response we need to be sending and receiving version 7 of the
MetadataRequest+Response protocol. Luckily the first flexible version wasn't until v8 so the changes to achieve this are minimal.

Contributes-to: #2365