### PR TITLE
chore(ci): replace set-output command in GH Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     - name: Get Go environment
       id: go-env
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=modcache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Set up cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Get Go environment
       id: go-env
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=modcache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
     - name: Set up cache
       uses: actions/cache@v3

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Get Go environment
       id: go-env
       run: |
-        echo "::set-output name=cache::$(go env GOCACHE)"
-        echo "::set-output name=modcache::$(go env GOMODCACHE)"
+        echo "cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Set up cache
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/