### PR TITLE
fix(zstd): default back to GOMAXPROCS concurrency

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -57,7 +57,7 @@ func getDecoder(params ZstdDecoderParams) *zstd.Decoder {
 	}
 	// It's possible to race and create multiple new readers.
 	// Only one will survive GC after use.
-	zstdDec, _ := zstd.NewReader(nil)
+	zstdDec, _ := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
 	zstdDecMap.Store(params, zstdDec)
 	return zstdDec
 }


### PR DESCRIPTION
After upgrading Sarama from 1.27.0 to 1.37.2, we noticed a significant performance regression in one of our services. This service runs on a very large (96 CPU) instance, and normally processes about 120K messages/sec. After the upgrade, it could only do about half that.

We traced the issue to [this change](https://github.com/klauspost/compress/pull/498) in klauspost/compress. Since Sarama uses the defaults when creating a new reader, concurrency is limited to 4.

By setting `WithDecoderConcurrency(0)`, concurrency is set to `GOMAXPROCS` (which in our app is set to `runtime.NumCPU()` == 96. When we deployed our service with this change, our performance issue disappeared.