### PR TITLE
chore: include kafka 3.3.1 in testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x]
     steps:
     - uses: actions/checkout@v3
     - name: Setup Go

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x]
-        kafka-version: [2.8.2, 3.0.2, 3.1.2, 3.2.3]
+        kafka-version: [2.8.2, 3.1.2, 3.2.3, 3.3.1]
     env:
       DEBUG: true
       GOFLAGS: -trimpath

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -15,12 +15,12 @@ RUN cd /etc/java/java-11-openjdk/*/conf/security \
   && echo 'networkaddress.cache.ttl=0' >> java.security \
   && echo 'networkaddress.cache.negative.ttl=0' >> java.security
 
-# https://github.com/apache/kafka/blob/0d518aaed158896ee9ee6949b8f38128d1d73634/tests/docker/Dockerfile#L65-L67
+# https://github.com/apache/kafka/blob/53eeaad946cd053e9eb1a762972d4efeacb8e4fc/tests/docker/Dockerfile#L65-L69
 ARG KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 RUN mkdir -p "/opt/kafka-2.8.2" && chmod a+rw /opt/kafka-2.8.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.8.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.8.2"
-RUN mkdir -p "/opt/kafka-3.0.2" && chmod a+rw /opt/kafka-3.0.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.0.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.0.2"
 RUN mkdir -p "/opt/kafka-3.1.2" && chmod a+rw /opt/kafka-3.1.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.2"
 RUN mkdir -p "/opt/kafka-3.2.3" && chmod a+rw /opt/kafka-3.2.3 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.2.3.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.2.3"
+RUN mkdir -p "/opt/kafka-3.3.1" && chmod a+rw /opt/kafka-3.3.1 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.3.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.3.1"
 
 COPY entrypoint.sh /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.2}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.3.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29091'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-1:9091,LISTENER_LOCAL://localhost:29091'
@@ -62,7 +62,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.2}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.3.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29092'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-2:9091,LISTENER_LOCAL://localhost:29092'
@@ -84,7 +84,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.2}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.3.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29093'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-3:9091,LISTENER_LOCAL://localhost:29093'
@@ -106,7 +106,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.2}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.3.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29094'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-4:9091,LISTENER_LOCAL://localhost:29094'
@@ -128,7 +128,7 @@ services:
       dockerfile: Dockerfile.kafka
     restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.1.2}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.3.1}
       KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
       KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29095'
       KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-5:9091,LISTENER_LOCAL://localhost:29095'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KAFKA_VERSION="${KAFKA_VERSION:-3.1.2}"
+KAFKA_VERSION="${KAFKA_VERSION:-3.3.1}"
 KAFKA_HOME="/opt/kafka-${KAFKA_VERSION}"
 
 if [ ! -d "${KAFKA_HOME}" ]; then

--- a/utils.go
+++ b/utils.go
@@ -191,6 +191,8 @@ var (
 	V3_2_1_0  = newKafkaVersion(3, 2, 1, 0)
 	V3_2_2_0  = newKafkaVersion(3, 2, 2, 0)
 	V3_2_3_0  = newKafkaVersion(3, 2, 3, 0)
+	V3_3_0_0  = newKafkaVersion(3, 3, 0, 0)
+	V3_3_1_0  = newKafkaVersion(3, 3, 1, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -244,9 +246,11 @@ var (
 		V3_2_1_0,
 		V3_2_2_0,
 		V3_2_3_0,
+		V3_3_0_0,
+		V3_3_1_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V3_2_3_0
+	MaxVersion     = V3_3_1_0
 	DefaultVersion = V1_0_0_0
 
 	// reduced set of versions to matrix test
@@ -256,17 +260,13 @@ var (
 		V1_0_2_0,
 		V1_1_1_0,
 		V2_0_1_0,
-		V2_1_1_0,
 		V2_2_2_0,
-		V2_3_1_0,
 		V2_4_1_0,
-		V2_5_1_0,
 		V2_6_2_0,
-		V2_7_1_0,
 		V2_8_2_0,
-		V3_0_2_0,
 		V3_1_2_0,
 		V3_2_3_0,
+		V3_3_1_0,
 	}
 )
 


### PR DESCRIPTION
- drop 3.0.x series from fvt runs
- add kafka version constants for 3.3.0 and 3.3.1
- default to 3.3.1 in docker-compose