### PR TITLE
fix: remove NewConsumerFromClient method call in newConsumerGroup method

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -126,14 +126,14 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_2_0")
 	}
 
-	c, err := newConsumer(client)
+	consumer, err := newConsumer(client)
 	if err != nil {
 		return nil, err
 	}
 
 	cg := &consumerGroup{
 		client:         client,
-		consumer:       c,
+		consumer:       consumer,
 		config:         config,
 		groupID:        groupID,
 		errors:         make(chan error, config.ChannelBufferSize),

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -126,14 +126,17 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_2_0")
 	}
 
-	consumer, err := NewConsumerFromClient(client)
-	if err != nil {
-		return nil, err
+	c := &consumer{
+		client:          client,
+		conf:            client.Config(),
+		children:        make(map[string]map[int32]*partitionConsumer),
+		brokerConsumers: make(map[*Broker]*brokerConsumer),
+		metricRegistry:  newCleanupRegistry(client.Config().MetricRegistry),
 	}
 
 	cg := &consumerGroup{
 		client:         client,
-		consumer:       consumer,
+		consumer:       c,
 		config:         config,
 		groupID:        groupID,
 		errors:         make(chan error, config.ChannelBufferSize),

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -126,12 +126,9 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_2_0")
 	}
 
-	c := &consumer{
-		client:          client,
-		conf:            client.Config(),
-		children:        make(map[string]map[int32]*partitionConsumer),
-		brokerConsumers: make(map[*Broker]*brokerConsumer),
-		metricRegistry:  newCleanupRegistry(client.Config().MetricRegistry),
+	c, err := newConsumer(client)
+	if err != nil {
+		return nil, err
 	}
 
 	cg := &consumerGroup{


### PR DESCRIPTION
fix the issue of consumergroup not closing properly when calling consumergroup.close()

currently, the NewConsumerGroup method calls the NewConsumerFromClient method which creates a nopclient, and thus this client cannot be closed properly

<img width="829" alt="Screenshot 2023-01-19 at 5 28 15 PM" src="https://user-images.githubusercontent.com/22215895/213422643-ef4ad891-50e2-4df9-8882-2b94f02e6d78.png">
<img width="885" alt="Screenshot 2023-01-19 at 5 24 18 PM" src="https://user-images.githubusercontent.com/22215895/213422676-333ec6d7-17f6-4e66-b6c7-7392a9d0c6f4.png">
<img width="552" alt="Screenshot 2023-01-19 at 5 24 35 PM" src="https://user-images.githubusercontent.com/22215895/213422702-dac6e1a0-30a6-4f08-903f-c7e9dfa9fa12.png">

