### PR TITLE
fix: use newConsumer method in newConsumerGroup method

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -126,7 +126,7 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_2_0")
 	}
 
-	consumer, err := NewConsumerFromClient(client)
+	consumer, err := newConsumer(client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix the issue of consumergroup not closing properly when calling consumergroup.close()

currently, the NewConsumerGroup method calls the NewConsumerFromClient method which creates a nopclient, and thus this client cannot be closed properly

<img width="829" alt="Screenshot 2023-01-19 at 5 28 15 PM" src="https://user-images.githubusercontent.com/22215895/213422643-ef4ad891-50e2-4df9-8882-2b94f02e6d78.png">
<img width="885" alt="Screenshot 2023-01-19 at 5 24 18 PM" src="https://user-images.githubusercontent.com/22215895/213422676-333ec6d7-17f6-4e66-b6c7-7392a9d0c6f4.png">
<img width="552" alt="Screenshot 2023-01-19 at 5 24 35 PM" src="https://user-images.githubusercontent.com/22215895/213422702-dac6e1a0-30a6-4f08-903f-c7e9dfa9fa12.png">

Replaces https://github.com/Shopify/sarama/pull/2423