### PR TITLE
fix(consumer): don't retry FindCoordinator forever

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -252,7 +252,10 @@ func (c *consumerGroup) retryNewSession(ctx context.Context, topics []string, ha
 	if refreshCoordinator {
 		err := c.client.RefreshCoordinator(c.groupID)
 		if err != nil {
-			return c.retryNewSession(ctx, topics, handler, retries, true)
+			if retries <= 0 {
+				return nil, err
+			}
+			return c.retryNewSession(ctx, topics, handler, retries-1, true)
 		}
 	}
 


### PR DESCRIPTION
If the consumer group hit an error finding the coordinator whilst setting up a session it would end up retrying forever because the retry count didn't get decremented and there was no exit of the loop. Fix that up and add a unittest to cover the scenario

Fixes #2426