### PR TITLE
fix(metrics): fix race condition when calling Broker.Open() twice

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -175,7 +175,9 @@ func (b *Broker) Open(conf *Config) error {
 
 	b.lock.Lock()
 
-	b.metricRegistry = newCleanupRegistry(conf.MetricRegistry)
+	if b.metricRegistry == nil {
+		b.metricRegistry = newCleanupRegistry(conf.MetricRegistry)
+	}
 
 	go withRecover(func() {
 		defer func() {


### PR DESCRIPTION
On failure, `Broker.Open()` can be called several times while a producer is running. In #2409, it was assumed that AsyncProduce can only be called with an open broker, however, it should be read that a user should call it after opening the broker. The broker could be disconnected and in progress of being reconnected. This is not hard to fix as we already have a lock protecting the creation of the registry: just don't create a new metric registry when attempting to reopen the broker.

Fix #2320 (again)