### PR TITLE
Added support for Kerberos authentication with a credentials cache.

### DIFF
--- a/config.go
+++ b/config.go
@@ -650,19 +650,26 @@ func (c *Config) Validate() error {
 				return ConfigurationError("Net.SASL.GSSAPI.ServiceName must not be empty when GSS-API mechanism is used")
 			}
 
-			if c.Net.SASL.GSSAPI.AuthType == KRB5_USER_AUTH {
+			switch c.Net.SASL.GSSAPI.AuthType {
+			case KRB5_USER_AUTH:
 				if c.Net.SASL.GSSAPI.Password == "" {
 					return ConfigurationError("Net.SASL.GSSAPI.Password must not be empty when GSS-API " +
 						"mechanism is used and Net.SASL.GSSAPI.AuthType = KRB5_USER_AUTH")
 				}
-			} else if c.Net.SASL.GSSAPI.AuthType == KRB5_KEYTAB_AUTH {
+			case KRB5_KEYTAB_AUTH:
 				if c.Net.SASL.GSSAPI.KeyTabPath == "" {
 					return ConfigurationError("Net.SASL.GSSAPI.KeyTabPath must not be empty when GSS-API mechanism is used" +
-						" and  Net.SASL.GSSAPI.AuthType = KRB5_KEYTAB_AUTH")
+						" and Net.SASL.GSSAPI.AuthType = KRB5_KEYTAB_AUTH")
 				}
-			} else {
-				return ConfigurationError("Net.SASL.GSSAPI.AuthType is invalid. Possible values are KRB5_USER_AUTH and KRB5_KEYTAB_AUTH")
+			case KRB5_CCACHE_AUTH:
+				if c.Net.SASL.GSSAPI.CCachePath == "" {
+					return ConfigurationError("Net.SASL.GSSAPI.CCachePath must not be empty when GSS-API mechanism is used" +
+						" and Net.SASL.GSSAPI.AuthType = KRB5_CCACHE_AUTH")
+				}
+			default:
+				return ConfigurationError("Net.SASL.GSSAPI.AuthType is invalid. Possible values are KRB5_USER_AUTH, KRB5_KEYTAB_AUTH, and KRB5_CCACHE_AUTH")
 			}
+
 			if c.Net.SASL.GSSAPI.KerberosConfigPath == "" {
 				return ConfigurationError("Net.SASL.GSSAPI.KerberosConfigPath must not be empty when GSS-API mechanism is used")
 			}

--- a/config_test.go
+++ b/config_test.go
@@ -162,7 +162,7 @@ func TestNetConfigValidates(t *testing.T) {
 				cfg.Net.SASL.GSSAPI.KerberosConfigPath = "/etc/krb5.conf"
 			},
 			"Net.SASL.GSSAPI.KeyTabPath must not be empty when GSS-API mechanism is used" +
-				" and  Net.SASL.GSSAPI.AuthType = KRB5_KEYTAB_AUTH",
+				" and Net.SASL.GSSAPI.AuthType = KRB5_KEYTAB_AUTH",
 		},
 		{
 			"SASL.Mechanism GSSAPI (Kerberos) - Missing username",
@@ -201,7 +201,7 @@ func TestNetConfigValidates(t *testing.T) {
 				cfg.Net.SASL.GSSAPI.Realm = "kafka"
 				cfg.Net.SASL.GSSAPI.KerberosConfigPath = "/etc/krb5.conf"
 			},
-			"Net.SASL.GSSAPI.AuthType is invalid. Possible values are KRB5_USER_AUTH and KRB5_KEYTAB_AUTH",
+			"Net.SASL.GSSAPI.AuthType is invalid. Possible values are KRB5_USER_AUTH, KRB5_KEYTAB_AUTH, and KRB5_CCACHE_AUTH",
 		},
 		{
 			"SASL.Mechanism GSSAPI (Kerberos) - Missing KerberosConfigPath",
@@ -228,6 +228,18 @@ func TestNetConfigValidates(t *testing.T) {
 				cfg.Net.SASL.GSSAPI.KerberosConfigPath = "/etc/krb5.conf"
 			},
 			"Net.SASL.GSSAPI.Realm must not be empty when GSS-API mechanism is used",
+		},
+		{
+			"SASL.Mechanism GSSAPI (Kerberos) - Using Credentials Cache, Missing CCachePath field",
+			func(cfg *Config) {
+				cfg.Net.SASL.Enable = true
+				cfg.Net.SASL.GSSAPI.ServiceName = "kafka"
+				cfg.Net.SASL.Mechanism = SASLTypeGSSAPI
+				cfg.Net.SASL.GSSAPI.AuthType = KRB5_CCACHE_AUTH
+				cfg.Net.SASL.GSSAPI.KerberosConfigPath = "/etc/krb5.conf"
+			},
+			"Net.SASL.GSSAPI.CCachePath must not be empty when GSS-API mechanism is used" +
+				" and Net.SASL.GSSAPI.AuthType = KRB5_CCACHE_AUTH",
 		},
 	}
 

--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -23,6 +23,7 @@ const (
 	GSS_API_GENERIC_TAG = 0x60
 	KRB5_USER_AUTH      = 1
 	KRB5_KEYTAB_AUTH    = 2
+	KRB5_CCACHE_AUTH    = 3
 	GSS_API_INITIAL     = 1
 	GSS_API_VERIFY      = 2
 	GSS_API_FINISH      = 3
@@ -31,6 +32,7 @@ const (
 type GSSAPIConfig struct {
 	AuthType           int
 	KeyTabPath         string
+	CCachePath         string
 	KerberosConfigPath string
 	ServiceName        string
 	Username           string

--- a/kerberos_client_test.go
+++ b/kerberos_client_test.go
@@ -127,6 +127,26 @@ func TestCreateWithKeyTab(t *testing.T) {
 	}
 }
 
+func TestCreateWithCredentialsCache(t *testing.T) {
+	kerberosConfig, err := krbcfg.NewFromString(krb5cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expect to try to create a client with a credentials cache and fails with "o such file or directory" error
+	expectedErr := errors.New("open nonexist.ccache: no such file or directory")
+	clientConfig := NewTestConfig()
+	clientConfig.Net.SASL.Mechanism = SASLTypeGSSAPI
+	clientConfig.Net.SASL.Enable = true
+	clientConfig.Net.SASL.GSSAPI.ServiceName = "kafka"
+	clientConfig.Net.SASL.GSSAPI.AuthType = KRB5_CCACHE_AUTH
+	clientConfig.Net.SASL.GSSAPI.CCachePath = "nonexist.ccache"
+	clientConfig.Net.SASL.GSSAPI.KerberosConfigPath = "/etc/krb5.conf"
+	_, err = createClient(&clientConfig.Net.SASL.GSSAPI, kerberosConfig)
+	if err.Error() != expectedErr.Error() {
+		t.Errorf("Expected error:%s, got:%s.", err, expectedErr)
+	}
+}
+
 func TestCreateWithDisablePAFXFAST(t *testing.T) {
 	kerberosConfig, err := krbcfg.NewFromString(krb5cfg)
 	if err != nil {


### PR DESCRIPTION
Implemented the support for Kerberos authentication using a credentials cache, as described in #2421. 
This adds a KRB5_CCACHE_AUTH value for GSSAPIConfig.AuthType.