### PR TITLE
#2443 Use version 4 of DescribeGroupsRequest only if kafka broker version is > 2.4.0.0

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -891,7 +891,7 @@ func (ca *clusterAdmin) DescribeConsumerGroups(groups []string) (result []*Group
 		describeReq := &DescribeGroupsRequest{
 			Groups: brokerGroups,
 		}
-		if ca.conf.Version.IsAtLeast(V2_3_0_0) {
+		if ca.conf.Version.IsAtLeast(V2_4_0_0) {
 			describeReq.Version = 4
 		}
 		response, err := broker.DescribeGroups(describeReq)

--- a/describe_groups_request.go
+++ b/describe_groups_request.go
@@ -44,8 +44,14 @@ func (r *DescribeGroupsRequest) headerVersion() int16 {
 
 func (r *DescribeGroupsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 1, 2, 3, 4:
+	case 1:
+		return V1_1_0_0
+	case 2:
+		return V2_0_0_0
+	case 3:
 		return V2_3_0_0
+	case 4:
+		return V2_4_0_0
 	}
 	return V0_9_0_0
 }

--- a/describe_groups_response.go
+++ b/describe_groups_response.go
@@ -65,8 +65,14 @@ func (r *DescribeGroupsResponse) headerVersion() int16 {
 
 func (r *DescribeGroupsResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 1, 2, 3, 4:
+	case 1:
+		return V1_1_0_0
+	case 2:
+		return V2_0_0_0
+	case 3:
 		return V2_3_0_0
+	case 4:
+		return V2_4_0_0
 	}
 	return V0_9_0_0
 }


### PR DESCRIPTION
Fixes issue #2443 