### PR TITLE
fix: prevent data race in balance strategy

### DIFF
--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -73,7 +73,7 @@ func TestBalanceStrategyRange(t *testing.T) {
 		},
 	}
 
-	strategy := BalanceStrategyRange
+	strategy := NewBalanceStrategyRange()
 	if strategy.Name() != "range" {
 		t.Errorf("Unexpected stategy name\nexpected: range\nactual: %v", strategy.Name())
 	}
@@ -96,7 +96,7 @@ func TestBalanceStrategyRange(t *testing.T) {
 }
 
 func TestBalanceStrategyRangeAssignmentData(t *testing.T) {
-	strategy := BalanceStrategyRange
+	strategy := NewBalanceStrategyRange()
 
 	members := make(map[string]ConsumerGroupMemberMetadata, 2)
 	members["consumer1"] = ConsumerGroupMemberMetadata{
@@ -177,7 +177,7 @@ func TestBalanceStrategyRoundRobin(t *testing.T) {
 		},
 	}
 
-	strategy := BalanceStrategyRoundRobin
+	strategy := NewBalanceStrategyRoundRobin()
 	if strategy.Name() != "roundrobin" {
 		t.Errorf("Unexpected strategy name\nexpected: roundrobin\nactual: %v", strategy.Name())
 	}
@@ -284,7 +284,7 @@ func Test_deserializeTopicPartitionAssignment(t *testing.T) {
 }
 
 func TestBalanceStrategyRoundRobinAssignmentData(t *testing.T) {
-	strategy := BalanceStrategyRoundRobin
+	strategy := NewBalanceStrategyRoundRobin()
 
 	members := make(map[string]ConsumerGroupMemberMetadata, 2)
 	members["consumer1"] = ConsumerGroupMemberMetadata{
@@ -2091,6 +2091,23 @@ func Test_stickyBalanceStrategy_Plan_AssignmentData(t *testing.T) {
 	}
 	if !bytes.Equal(expected, actual) {
 		t.Error("Invalid assignment data returned from AssignmentData")
+	}
+}
+
+func Test_stickyBalanceStrategy_Plan_data_race(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		go func(bs BalanceStrategy) {
+			members := map[string]ConsumerGroupMemberMetadata{
+				"m1": {
+					Version: 3,
+					Topics:  []string{"topic"},
+				},
+			}
+			topics := map[string][]int32{
+				"topic": {0, 1, 2},
+			}
+			_, _ = bs.Plan(members, topics)
+		}(NewBalanceStrategySticky())
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -294,7 +294,7 @@ type Config struct {
 				Interval time.Duration
 			}
 			Rebalance struct {
-				// Strategy for allocating topic partitions to members (default BalanceStrategyRange)
+				// Strategy for allocating topic partitions to members.
 				// Deprecated: Strategy exists for historical compatibility
 				// and should not be used. Please use GroupStrategies.
 				Strategy BalanceStrategy
@@ -302,7 +302,7 @@ type Config struct {
 				// GroupStrategies is the priority-ordered list of client-side consumer group
 				// balancing strategies that will be offered to the coordinator. The first
 				// strategy that all group members support will be chosen by the leader.
-				// default: [BalanceStrategyRange]
+				// default: [ NewBalanceStrategyRange() ]
 				GroupStrategies []BalanceStrategy
 
 				// The maximum allowed time for each worker to join the group once a rebalance has begun.
@@ -539,7 +539,7 @@ func NewConfig() *Config {
 
 	c.Consumer.Group.Session.Timeout = 10 * time.Second
 	c.Consumer.Group.Heartbeat.Interval = 3 * time.Second
-	c.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{BalanceStrategyRange}
+	c.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{NewBalanceStrategyRange()}
 	c.Consumer.Group.Rebalance.Timeout = 60 * time.Second
 	c.Consumer.Group.Rebalance.Retry.Max = 4
 	c.Consumer.Group.Rebalance.Retry.Backoff = 2 * time.Second

--- a/config_test.go
+++ b/config_test.go
@@ -548,7 +548,7 @@ func TestGroupInstanceIdAndVersionValidation(t *testing.T) {
 
 func TestConsumerGroupStrategyCompatibility(t *testing.T) {
 	config := NewTestConfig()
-	config.Consumer.Group.Rebalance.Strategy = BalanceStrategySticky
+	config.Consumer.Group.Rebalance.Strategy = NewBalanceStrategySticky()
 	if err := config.Validate(); err != nil {
 		t.Error("Expected passing config validation, got ", err)
 	}

--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -70,11 +70,11 @@ func main() {
 
 	switch assignor {
 	case "sticky":
-		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategySticky}
+		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategySticky()}
 	case "roundrobin":
-		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategyRoundRobin}
+		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategyRoundRobin()}
 	case "range":
-		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.BalanceStrategyRange}
+		config.Consumer.Group.Rebalance.GroupStrategies = []sarama.BalanceStrategy{sarama.NewBalanceStrategyRange()}
 	default:
 		log.Panicf("Unrecognized consumer group partition assignor: %s", assignor)
 	}

--- a/examples/exactly_once/main.go
+++ b/examples/exactly_once/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	config.Consumer.IsolationLevel = sarama.ReadCommitted
 	config.Consumer.Offsets.AutoCommit.Enable = false
-	config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+	config.Consumer.Group.Rebalance.Strategy = sarama.NewBalanceStrategyRoundRobin()
 
 	if oldest {
 		config.Consumer.Offsets.Initial = sarama.OffsetOldest

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -552,7 +552,7 @@ func (m *testFuncConsumerGroupMember) loop(topics []string) {
 
 func newTestStatefulStrategy(t *testing.T) *testStatefulStrategy {
 	return &testStatefulStrategy{
-		BalanceStrategy: BalanceStrategyRange,
+		BalanceStrategy: NewBalanceStrategyRange(),
 		t:               t,
 	}
 }


### PR DESCRIPTION
For every `BalanceStrategy`, it may be shared across different consumer groups in one instance. Considering every built-in balance strategy has several fields in the struct as shown in the below snippet, data race issues may happen when several consumer group rebalances simultaneously.
```
type balanceStrategy struct {
	coreFn func(plan BalanceStrategyPlan, memberIDs []string, topic string, partitions []int32)
	name   string
}
type stickyBalanceStrategy struct {
	movements partitionMovements
}
```

Even worse, I think this issue could cause
- panic
- some topics/partitions are not subscribed by the corresponding consumers, because the corresponding fields in the struct may be modified by other consumer groups

To verify this issue, a unit test was written, which fails when -race detection is enabled. 
```
func Test_stickyBalanceStrategy_Plan_data_race(t *testing.T) {
	for i := 0; i < 1000; i++ {
		go func(bs BalanceStrategy) {
			members := map[string]ConsumerGroupMemberMetadata{
				"m1": {
					Version: 3,
					Topics:  []string{"topic"},
				},
			}
			topics := map[string][]int32{
				"topic": {0, 1, 2},
			}
			_, _ = bs.Plan(members, topics)
		}(BalanceStrategySticky)
	}
}
```

To avoid this problem, it may be best not to use a singleton for each and every of BalanceStrategy. Instead, newly-added functions like `NewBalanceStrategyRange() BalanceStrategy ` are recommended so that every time an exclusive variable is assigned to each consumer group.

Fixes #2422 