### PR TITLE
fix: sync response header version to clamped request header

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -130,7 +130,7 @@ type SCRAMClient interface {
 type responsePromise struct {
 	requestTime   time.Time
 	correlationID int32
-	headerVersion int16
+	response      protocolBody
 	handler       func([]byte, error)
 	packets       chan []byte
 	errors        chan error
@@ -455,7 +455,7 @@ func (b *Broker) AsyncProduce(request *ProduceRequest, cb ProduceCallback) error
 		// Create ProduceResponse early to provide the header version
 		res := new(ProduceResponse)
 		promise = &responsePromise{
-			headerVersion: res.headerVersion(),
+			response: res,
 			// Packets will be converted to a ProduceResponse in the responseReceiver goroutine
 			handler: func(packets []byte, err error) {
 				if err != nil {
@@ -970,26 +970,28 @@ func (b *Broker) write(buf []byte) (n int, err error) {
 }
 
 // b.lock must be held by caller
-func (b *Broker) send(rb protocolBody, promiseResponse bool, responseHeaderVersion int16) (*responsePromise, error) {
+//
+// a non-nil res results in a response promise being created
+func (b *Broker) send(req, res protocolBody) (*responsePromise, error) {
 	var promise *responsePromise
-	if promiseResponse {
+	if res != nil {
 		// Packets or error will be sent to the following channels
 		// once the response is received
-		promise = makeResponsePromise(responseHeaderVersion)
+		promise = makeResponsePromise(res)
 	}
 
-	if err := b.sendWithPromise(rb, promise); err != nil {
+	if err := b.sendWithPromise(req, promise); err != nil {
 		return nil, err
 	}
 
 	return promise, nil
 }
 
-func makeResponsePromise(responseHeaderVersion int16) *responsePromise {
+func makeResponsePromise(res protocolBody) *responsePromise {
 	promise := &responsePromise{
-		headerVersion: responseHeaderVersion,
-		packets:       make(chan []byte),
-		errors:        make(chan error),
+		response: res,
+		packets:  make(chan []byte),
+		errors:   make(chan error),
 	}
 	return promise
 }
@@ -1018,6 +1020,11 @@ func (b *Broker) sendInternal(rb protocolBody, promise *responsePromise) error {
 	// try restricting API version to ranges advertised by the broker
 	if err := restrictApiVersion(rb, b.brokerAPIVersions); err != nil {
 		return err
+	}
+
+	// response versions must always match their corresponding request's
+	if promise != nil && promise.response != nil {
+		promise.response.setVersion(rb.version())
 	}
 
 	if !b.conf.Version.IsAtLeast(rb.requiredVersion()) {
@@ -1061,12 +1068,8 @@ func (b *Broker) sendInternal(rb protocolBody, promise *responsePromise) error {
 func (b *Broker) sendAndReceive(req protocolBody, res protocolBody) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	responseHeaderVersion := int16(-1)
-	if res != nil {
-		responseHeaderVersion = res.headerVersion()
-	}
 
-	promise, err := b.send(req, res != nil, responseHeaderVersion)
+	promise, err := b.send(req, res)
 	if err != nil {
 		return err
 	}
@@ -1184,41 +1187,41 @@ func (b *Broker) encode(pe packetEncoder, version int16) (err error) {
 func (b *Broker) responseReceiver() {
 	var dead error
 
-	for response := range b.responses {
+	for promise := range b.responses {
 		if dead != nil {
 			// This was previously incremented in send() and
 			// we are not calling updateIncomingCommunicationMetrics()
 			b.addRequestInFlightMetrics(-1)
-			response.handle(nil, dead)
+			promise.handle(nil, dead)
 			continue
 		}
 
-		headerLength := getHeaderLength(response.headerVersion)
+		headerLength := getHeaderLength(promise.response.headerVersion())
 		header := make([]byte, headerLength)
 
 		bytesReadHeader, err := b.readFull(header)
-		requestLatency := time.Since(response.requestTime)
+		requestLatency := time.Since(promise.requestTime)
 		if err != nil {
 			b.updateIncomingCommunicationMetrics(bytesReadHeader, requestLatency)
 			dead = err
-			response.handle(nil, err)
+			promise.handle(nil, err)
 			continue
 		}
 
 		decodedHeader := responseHeader{}
-		err = versionedDecode(header, &decodedHeader, response.headerVersion, b.metricRegistry)
+		err = versionedDecode(header, &decodedHeader, promise.response.headerVersion(), b.metricRegistry)
 		if err != nil {
 			b.updateIncomingCommunicationMetrics(bytesReadHeader, requestLatency)
 			dead = err
-			response.handle(nil, err)
+			promise.handle(nil, err)
 			continue
 		}
-		if decodedHeader.correlationID != response.correlationID {
+		if decodedHeader.correlationID != promise.correlationID {
 			b.updateIncomingCommunicationMetrics(bytesReadHeader, requestLatency)
 			// TODO if decoded ID < cur ID, discard until we catch up
 			// TODO if decoded ID > cur ID, save it so when cur ID catches up we have a response
-			dead = PacketDecodingError{fmt.Sprintf("correlation ID didn't match, wanted %d, got %d", response.correlationID, decodedHeader.correlationID)}
-			response.handle(nil, dead)
+			dead = PacketDecodingError{fmt.Sprintf("correlation ID didn't match, wanted %d, got %d", promise.correlationID, decodedHeader.correlationID)}
+			promise.handle(nil, dead)
 			continue
 		}
 
@@ -1227,11 +1230,11 @@ func (b *Broker) responseReceiver() {
 		b.updateIncomingCommunicationMetrics(bytesReadHeader+bytesReadBody, requestLatency)
 		if err != nil {
 			dead = err
-			response.handle(nil, err)
+			promise.handle(nil, err)
 			continue
 		}
 
-		response.handle(buf, nil)
+		promise.handle(buf, nil)
 	}
 	close(b.done)
 }
@@ -1322,7 +1325,7 @@ func (b *Broker) authenticateViaSASLv1() error {
 	if b.conf.Net.SASL.Handshake {
 		handshakeRequest := &SaslHandshakeRequest{Mechanism: string(b.conf.Net.SASL.Mechanism), Version: b.conf.Net.SASL.Version}
 		handshakeResponse := new(SaslHandshakeResponse)
-		prom := makeResponsePromise(handshakeResponse.version())
+		prom := makeResponsePromise(handshakeResponse)
 
 		handshakeErr := b.sendInternal(handshakeRequest, prom)
 		if handshakeErr != nil {
@@ -1343,7 +1346,7 @@ func (b *Broker) authenticateViaSASLv1() error {
 	authSendReceiver := func(authBytes []byte) (*SaslAuthenticateResponse, error) {
 		authenticateRequest := b.createSaslAuthenticateRequest(authBytes)
 		authenticateResponse := new(SaslAuthenticateResponse)
-		prom := makeResponsePromise(authenticateResponse.version())
+		prom := makeResponsePromise(authenticateResponse)
 		authErr := b.sendInternal(authenticateRequest, prom)
 		if authErr != nil {
 			Logger.Printf("Error while performing SASL Auth %s\n", b.addr)

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -289,11 +289,12 @@ func (om *offsetManager) flushToBroker() {
 
 func sendOffsetCommit(coordinator *Broker, req *OffsetCommitRequest) (*OffsetCommitResponse, *responsePromise, error) {
 	resp := new(OffsetCommitResponse)
-	responseHeaderVersion := resp.headerVersion()
-	promise, err := coordinator.send(req, true, responseHeaderVersion)
+
+	promise, err := coordinator.send(req, resp)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return resp, promise, nil
 }
 


### PR DESCRIPTION
Smallish refactor changing the internal structure of `responsePromise`: instead of storing a (potentially stale) response header version, it now stores a pointer to the response's `protocolBody` (if any).

This allows `sendInternal` to easily update the response's `Version` after version negotiation. (request and response versions must match; _header versions_ instead don't map 1-1, meaning we can't rely on the request's header version for decoding responses).

Fixes the issue from [this comment](https://github.com/IBM/sarama/pull/3209#issuecomment-3078126116).