### PR TITLE
feat: always send ApiVersionsRequest and fallback to v0

### DIFF
--- a/client.go
+++ b/client.go
@@ -205,7 +205,7 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 		coordinators:            make(map[string]int32),
 		transactionCoordinators: make(map[string]int32),
 	}
-	var refresh = func(topics []string) error {
+	refresh := func(topics []string) error {
 		deadline := time.Time{}
 		if client.conf.Metadata.Timeout > 0 {
 			deadline = time.Now().Add(client.conf.Metadata.Timeout)
@@ -1002,7 +1002,7 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 		if err == nil {
 			// When talking to the startup phase of a broker, it is possible to receive an empty metadata set. We should remove that broker and try next broker (https://issues.apache.org/jira/browse/KAFKA-7924).
 			if len(response.Brokers) == 0 {
-				Logger.Println("client/metadata receiving empty brokers from the metadata response when requesting the broker #%d at %s", broker.ID(), broker.addr)
+				Logger.Printf("client/metadata receiving empty brokers from the metadata response when requesting the broker #%d at %s", broker.ID(), broker.addr)
 				_ = broker.Close()
 				client.deregisterBroker(broker)
 				continue

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,7 @@ import (
 // and the response versions our mocks use, we default to the minimum Kafka version in most tests
 func NewTestConfig() *Config {
 	config := NewConfig()
+	config.ApiVersionsRequest = false
 	config.Consumer.Retry.Backoff = 0
 	config.Producer.Retry.Backoff = 0
 	config.Version = MinVersion

--- a/functional_test.go
+++ b/functional_test.go
@@ -98,13 +98,13 @@ func NewFunctionalTestConfig() *Config {
 	config := NewConfig()
 	// config.Consumer.Retry.Backoff = 0
 	// config.Producer.Retry.Backoff = 0
-	config.Version = MinVersion
-	version, err := ParseKafkaVersion(os.Getenv("KAFKA_VERSION"))
-	if err != nil {
-		config.Version = DefaultVersion
-	} else {
-		config.Version = version
-	}
+
+	// Always use the maximum Sarama-supported API versions.
+	config.Version = MaxVersion
+	// Enable API versions negotiation with brokers. This will reduce the maximum
+	// API versions Sarama uses to never exceed the broker's supported versions.
+	config.ApiVersionsRequest = true
+
 	return config
 }
 
@@ -477,7 +477,6 @@ func ensureFullyReplicated(t testing.TB, timeout time.Duration, retry time.Durat
 	config.Metadata.Retry.Max = 5
 	config.Metadata.Retry.Backoff = 10 * time.Second
 	config.ClientID = "sarama-ensureFullyReplicated"
-	config.ApiVersionsRequest = false
 
 	var testTopicNames []string
 	for topic := range testTopicDetails {


### PR DESCRIPTION
We previously pinned to only sending if Version was set to v2.4.0.0, but we should always send the request regardless, but fallback to sending a v0 request (without client info) if the v3 request does not succeed

In functional tests we always use MaxVersion in config an ApiVersionsRequest enabled to negotiate versions.

In unittests we disable ApiVersionsRequest by default and pin Version. A number of these tests use step-by-step ordered protocol expectations and it isn't convenient to update them all to also include an ApiVersionsRequest roundtrip unnecessarily, so we disable it in plain unittests by default, keeping it as opt-in.