### PR TITLE
fix: remove top-level renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
This was replaced with a proper config under `.github/renovate.json5`, but this placeholder needs to be removed for that one to take effect.