### PR TITLE
fix: metadata_response valid version range

### DIFF
--- a/metadata_response.go
+++ b/metadata_response.go
@@ -448,7 +448,7 @@ func (r *MetadataResponse) headerVersion() int16 {
 }
 
 func (r *MetadataResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 10
 }
 
 func (r *MetadataResponse) requiredVersion() KafkaVersion {


### PR DESCRIPTION
Missed from 76ca69a5 which added more versions