### PR TITLE
fix: improve KIP-511 behaviour on older Kafka clusters

### DIFF
--- a/api_versions_response.go
+++ b/api_versions_response.go
@@ -91,6 +91,13 @@ func (r *ApiVersionsResponse) decode(pd packetDecoder, version int16) (err error
 		return err
 	}
 
+	// KIP-511: if broker didn't understand the ApiVersionsRequest version then
+	// it replies with a V0 ApiVersionResponse where its supported
+	// ApiVersionsRequest version is available in ApiKeys
+	if r.ErrorCode == int16(ErrUnsupportedVersion) {
+		r.Version = 0
+	}
+
 	numApiKeys, err := pd.getArrayLength()
 	if err != nil {
 		return err


### PR DESCRIPTION
Rather than failing with "not enough bytes to read" when parsing the ApiVersionsResponse (and always sending a V0 as fallback), instead follow the KIP and expect a V0 ApiVersionsResponse to have been sent back with the supported ApiVersions apikey version included in it.