### PR TITLE
chore(ci): extract tool versions and add renovate customManagers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ permissions:
 env:
   # Use the Go toolchain installed by setup-go
   GOTOOLCHAIN: local
+  # renovate: datasource=github-releases depName=golangci/golangci-lint
+  GOLANGCI_LINT_VERSION: v2.5.0
+  # renovate: datasource=github-releases depName=dominikh/go-tools
+  STATICCHECK_VERSION: v0.6.0
+  # renovate: datasource=github-releases depName=mfridman/tparse
+  TPARSE_VERSION: v0.18.0
 
 jobs:
   lint:
@@ -46,9 +52,8 @@ jobs:
       shell: bash
       env:
         BUILDTAGS: "functional"
-        VERSION: "v0.6.0"
       run: |
-        go install "honnef.co/go/tools/cmd/staticcheck@${VERSION}"
+        go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
         echo "::add-matcher::./.github/actions/staticcheck-matchers.json"
         $(go env GOPATH)/bin/staticcheck -tags "${BUILDTAGS}" ./...
     - name: golangci-lint
@@ -56,7 +61,7 @@ jobs:
         GOFLAGS: -tags=functional
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.4.0
+        version: ${{ env.GOLANGCI_LINT_VERSION }}
   test:
     name: Unit Testing with Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest
@@ -80,8 +85,7 @@ jobs:
     - name: Report Test Results
       if: always()
       run: |
-        # renovate: datasource=github-releases depName=mfridman/tparse
-        go run github.com/mfridman/tparse@v0.18.0 -all -format markdown -file _test/unittests.json | tee -a $GITHUB_STEP_SUMMARY
+        go run github.com/mfridman/tparse@${TPARSE_VERSION} -all -format markdown -file _test/unittests.json | tee -a $GITHUB_STEP_SUMMARY
     - name: Report Per Func Test Coverage
       if: always()
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ GOBIN    := $(shell pwd)/bin
 GOBUILD  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG)
 
 GOTESTSUM         := $(GOBIN)/gotestsum
+# renovate: datasource=github-releases depName=gotestyourself/gotestsum
 GOTESTSUM_VERSION := v1.13.0
 $(GOTESTSUM):
 	GOBIN=$(GOBIN) go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
 TESTSTAT         := $(GOBIN)/teststat
+# renovate: datasource=github-releases depName=vearutop/teststat
 TESTSTAT_VERSION := v0.1.26
 $(TESTSTAT):
 	GOBIN=$(GOBIN) go install github.com/vearutop/teststat@$(TESTSTAT_VERSION)


### PR DESCRIPTION
Allow renovate to keep these version numbers up-to-date