### PR TITLE
fix: wrap KError into error returned by IncrementalAlterConfig

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -826,11 +826,12 @@ func (ca *clusterAdmin) IncrementalAlterConfig(resourceType ConfigResourceType, 
 
 	for _, rspResource := range rsp.Resources {
 		if rspResource.Name == name {
-			if rspResource.ErrorMsg != "" {
-				return errors.New(rspResource.ErrorMsg)
-			}
-			if rspResource.ErrorCode != 0 {
-				return KError(rspResource.ErrorCode)
+			if rspResource.ErrorCode != int16(ErrNoError) {
+				err = KError(rspResource.ErrorCode)
+				if rspResource.ErrorMsg != "" {
+					err = fmt.Errorf("%w: %s", err, rspResource.ErrorMsg)
+				}
+				return err
 			}
 		}
 	}

--- a/admin_test.go
+++ b/admin_test.go
@@ -1072,6 +1072,9 @@ func TestClusterAdminIncrementalAlterConfigWithErrorCode(t *testing.T) {
 	if err == nil {
 		t.Fatal(errors.New("ErrorCode present but no Error returned"))
 	}
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Fatal(errors.New("ErrorCode present but not wrapped into returned error"))
+	}
 }
 
 func TestClusterAdminIncrementalAlterBrokerConfig(t *testing.T) {

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -1029,8 +1029,8 @@ func (mr *MockIncrementalAlterConfigsResponseWithErrorCode) For(reqBody versione
 		res.Resources = append(res.Resources, &AlterConfigsResourceResponse{
 			Name:      r.Name,
 			Type:      r.Type,
-			ErrorCode: 83,
-			ErrorMsg:  "",
+			ErrorCode: int16(ErrInvalidConfig),
+			ErrorMsg:  "Invalid value xyz for configuration retention.ms: Not a number of type LONG",
 		})
 	}
 	return res


### PR DESCRIPTION
Allow use of errors.Is(...) to test against KError values when IncrementalAlterConfigs returns an error.