### PR TITLE
fix: assign sequence when flushing retry buffers

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -751,6 +751,10 @@ func (pp *partitionProducer) flushRetryBuffers() {
 		}
 
 		for _, msg := range pp.retryState[pp.highWatermark].buf {
+			if pp.parent.conf.Producer.Idempotent && msg.retries == 0 && msg.flags == 0 && !msg.hasSequence {
+				msg.sequenceNumber, msg.producerEpoch = pp.parent.txnmgr.getAndIncrementSequenceNumber(msg.Topic, msg.Partition)
+				msg.hasSequence = true
+			}
 			pp.brokerProducer.input <- msg
 		}
 


### PR DESCRIPTION
As noted in #3354, messages buffered due to the highWatermark would inadvertently skip the usual sequence number assignment, manifesting as OutOfOrderSequenceException on the broker.

Wrote a functional test to trigger this behaviour and then used the same logic as found in  partitionProducer.dispatch() to prevent the problem occurring.