### PR TITLE
fix(client): add nilguards to updateBroker

### DIFF
--- a/client.go
+++ b/client.go
@@ -685,9 +685,16 @@ func (client *client) randomizeSeedBrokers(addrs []string) {
 }
 
 func (client *client) updateBroker(brokers []*Broker) {
+	if client.brokers == nil {
+		return
+	}
+
 	currentBroker := make(map[int32]*Broker, len(brokers))
 
 	for _, broker := range brokers {
+		if broker == nil {
+			continue
+		}
 		currentBroker[broker.ID()] = broker
 		if client.brokers[broker.ID()] == nil { // add new broker
 			client.brokers[broker.ID()] = broker


### PR DESCRIPTION
This _should_ be a rare edge case as the updateBroker func is only called from updateMetadata which does already do an up-front `client.Close()` check under read-lock before then acquiring the write lock. However, there's potentially a small window of opportunity that if client.Close() was called whilst metadata refresh was in-flight and for whatever reason the updateMetadata goroutine gets pre-empted in-between the readlock release and the write lock acquire then the client could have been closed and so `client.brokers` will be nil.

I wouldn't have expected this to ever happen, but it was reported by a user in an older Sarama version in #3391 and there's no harm in adding the nilguard just in case.