### PR TITLE
fix(admin): retry admin calls on network errors

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -1481,12 +1481,11 @@ func (ca *clusterAdmin) AlterClientQuotas(entity []QuotaEntityComponent, op Clie
 		ValidateOnly: validateOnly,
 	}
 
-	b, err := ca.Controller()
-	if err != nil {
-		return err
-	}
-
 	return ca.retryOnError(isRetriableControllerError, func() error {
+		b, err := ca.Controller()
+		if err != nil {
+			return err
+		}
 		_ = b.Open(ca.client.Config())
 
 		rsp, err := b.AlterClientQuotas(request)


### PR DESCRIPTION
Depends on #3406

Extends network retry/reconnect handling to more ClusterAdmin paths used in production.

Changes
- wrap ListTopics, config describe/alter, ACL CRUD, consumer-group listing/describe, SCRAM describe, and client quotas paths with retryOnError + Open/Close on network errors
- keep scope limited for reviewability; remaining admin paths (e.g., DeleteRecords, etc.) will be handled in a later PR

Notes
- should merge after #3406 is merged
