### PR TITLE
fix: set version from IBM/sarama, not main app

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,6 +1,7 @@
 package sarama
 
 import (
+	"reflect"
 	"runtime/debug"
 	"sync"
 )
@@ -12,9 +13,18 @@ var (
 
 func version() string {
 	vOnce.Do(func() {
+		// Determine our package name without hardcoding a string
+		type getPackageName struct{}
+		thisPackagePath := reflect.TypeFor[getPackageName]().PkgPath()
+
 		bi, ok := debug.ReadBuildInfo()
 		if ok {
-			v = bi.Main.Version
+			for _, dep := range bi.Deps {
+				if dep.Path == thisPackagePath {
+					v = dep.Version
+					break
+				}
+			}
 		}
 		if v == "" || v == "(devel)" {
 			// if we can't read a go module version then they're using a git


### PR DESCRIPTION
We are experiencing connection errors with a hosted Kafka vendor who is inspecting ClientSoftwareVersion. Currently this version is "v0.34.1" -- our application's version, but Sarama is on v1.46.3 which is what the vendor expects to see.

This behavior matches franz-go as well:
https://github.com/twmb/franz-go/blob/v1.20.6/pkg/kgo/config.go#L480