### PR TITLE
test: expand Java interop tests to cover all compression codecs

### DIFF
--- a/functional_java_interop_test.go
+++ b/functional_java_interop_test.go
@@ -51,7 +51,9 @@ func produceWithJava(t *testing.T, topic string, codec CompressionCodec, message
 		if err != nil {
 			stdin.Close()
 			waitErr := cmd.Wait()
-			require.NoError(t, waitErr, "Java producer failed")
+			if waitErr != nil {
+				err = fmt.Errorf("failed to write message: %w; Java producer failed: %w", err, waitErr)
+			}
 		}
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
- add gzip, lz4 and zstd to the existing snappy interop tests
- isolate each test's use of the shared topic
- support kafka <2.x (different cmdline options on console utilities)