### PR TITLE
feat: add kafka 4.1.1 constants and use in FVT

### DIFF
--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [stable]
-        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0, 4.1.0]
+        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0, 4.1.1]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -43,7 +43,7 @@ jobs:
           scala-version: 2.13
         - kafka-version: 4.0.0
           scala-version: 2.13
-        - kafka-version: 4.1.0
+        - kafka-version: 4.1.1
           scala-version: 2.13
     uses: ./.github/workflows/fvt.yml
     with:

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [stable]
-        kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.9.1, 4.1.0]
+        kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.9.1, 4.1.1]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -30,7 +30,7 @@ jobs:
           scala-version: 2.13
         - kafka-version: 3.9.1
           scala-version: 2.13
-        - kafka-version: 4.0.0
+        - kafka-version: 4.1.1
           scala-version: 2.13
     uses: ./.github/workflows/fvt.yml
     with:

--- a/utils.go
+++ b/utils.go
@@ -217,6 +217,7 @@ var (
 	V3_9_1_0  = newKafkaVersion(3, 9, 1, 0)
 	V4_0_0_0  = newKafkaVersion(4, 0, 0, 0)
 	V4_1_0_0  = newKafkaVersion(4, 1, 0, 0)
+	V4_1_1_0  = newKafkaVersion(4, 1, 1, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -292,9 +293,10 @@ var (
 		V3_9_1_0,
 		V4_0_0_0,
 		V4_1_0_0,
+		V4_1_1_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V4_1_0_0
+	MaxVersion     = V4_1_1_0
 	DefaultVersion = V2_1_0_0
 
 	// reduced set of protocol versions to matrix test


### PR DESCRIPTION
https://kafka.apache.org/community/downloads/#411

https://kafka.apache.org/blog/2025/11/12/apache-kafka-4.1.1-release-announcement/